### PR TITLE
Reverting the BUCK files.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/module/annotations/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/module/annotations/BUCK
@@ -3,6 +3,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_tar
 rn_android_library(
     name = "annotations",
     srcs = glob(["**/*.java"]),
+    required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/module/processing/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/module/processing/BUCK
@@ -2,6 +2,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_tar
 
 rn_java_annotation_processor(
     name = "processing",
+    does_not_affect_abi = True,
     processor_class = "com.facebook.react.module.processing.ReactModuleSpecProcessor",
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/BUCK
@@ -3,6 +3,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_libra
 rn_android_library(
     name = "annotations",
     srcs = glob(["*.java"]),
+    required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/jni/first-party/yogajni/BUCK
+++ b/ReactAndroid/src/main/jni/first-party/yogajni/BUCK
@@ -12,7 +12,6 @@ oss_cxx_library(
         "-Werror",
         "-O3",
         "-std=c++11",
-        '-DANDROIDPLAT',
     ],
     soname = "libyoga.$(ext)",
     visibility = ["PUBLIC"],


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

Reverting the BUCK files to their version from Facebook/rn tag v0.60.0

#### Focus areas to test

NA


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/168)