### PR TITLE
Sync most changes in ReactCommon/jsi/JSCRuntime.cpp from upstream facebook/react-native.

### DIFF
--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -1348,9 +1348,9 @@
 		3DFE0D1B1DF8575800459392 /* YGMacros.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 130A77041DF767AF001F9587 /* YGMacros.h */; };
 		3DFE0D1C1DF8575800459392 /* Yoga.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 130A77081DF767AF001F9587 /* Yoga.h */; };
 		3EDCA8A51D3591E700450C31 /* RCTErrorInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EDCA8A41D3591E700450C31 /* RCTErrorInfo.m */; };
-		4F56C93822167A4800DB9F3F /* jsi/jsilib.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsi/jsilib.h */; };
-		4F56C93922167A4D00DB9F3F /* jsi/jsilib.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsi/jsilib.h */; };
-		4F56C93A2216A3B700DB9F3F /* jsi/jsilib.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsi/jsilib.h */; };
+		4F56C93822167A4800DB9F3F /* jsilib.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsilib.h */; };
+		4F56C93922167A4D00DB9F3F /* jsilib.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsilib.h */; };
+		4F56C93A2216A3B700DB9F3F /* jsilib.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsilib.h */; };
 		5335D5411FE81A4700883D58 /* RCTShadowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5335D5401FE81A4700883D58 /* RCTShadowView.m */; };
 		53438962203905BB008E0CB3 /* YGLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5343895E203905B6008E0CB3 /* YGLayout.cpp */; };
 		53438963203905BC008E0CB3 /* YGLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5343895E203905B6008E0CB3 /* YGLayout.cpp */; };
@@ -1576,7 +1576,7 @@
 		8507BBC021EDACC200AEAFCA /* JSCExecutorFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 8507BBBD21EDACC200AEAFCA /* JSCExecutorFactory.h */; };
 		8507BBC121EDACC200AEAFCA /* JSCExecutorFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 8507BBBD21EDACC200AEAFCA /* JSCExecutorFactory.h */; };
 		916F9C2D1F743F57002E5920 /* RCTModalManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 91076A871F743AB00081B4FA /* RCTModalManager.m */; };
-		99942CF922F34AB4009FAB58 /* jsi/jsilib.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsi/jsilib.h */; };
+		99942CF922F34AB4009FAB58 /* jsilib.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsilib.h */; };
 		9F0D8908224160F20053729F /* Assume.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D8907224160F10053729F /* Assume.cpp */; };
 		9F0D8909224160F20053729F /* Assume.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D8907224160F10053729F /* Assume.cpp */; };
 		9F0D890A224160F20053729F /* Assume.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D8907224160F10053729F /* Assume.cpp */; };
@@ -2660,7 +2660,7 @@
 				ED296FC7214C9B4B00B7C4FE /* instrumentation.h in Copy Headers */,
 				ED296FC6214C9B4400B7C4FE /* JSIDynamic.h in Copy Headers */,
 				ED296FC5214C9B3E00B7C4FE /* jsi-inl.h in Copy Headers */,
-				4F56C93A2216A3B700DB9F3F /* jsi/jsilib.h in Copy Headers */,
+				4F56C93A2216A3B700DB9F3F /* jsilib.h in Copy Headers */,
 			);
 			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2688,7 +2688,7 @@
 				EDEBC71D214B40F900DD5AC8 /* JSIDynamic.h in Copy Headers */,
 				EDEBC71E214B40F900DD5AC8 /* JSCRuntime.h in Copy Headers */,
 				EDEBC71F214B40F900DD5AC8 /* jsi.h in Copy Headers */,
-				4F56C93922167A4D00DB9F3F /* jsi/jsilib.h in Copy Headers */,
+				4F56C93922167A4D00DB9F3F /* jsilib.h in Copy Headers */,
 			);
 			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2974,7 +2974,7 @@
 		3EDCA8A21D3591E700450C31 /* RCTErrorCustomizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTErrorCustomizer.h; sourceTree = "<group>"; };
 		3EDCA8A31D3591E700450C31 /* RCTErrorInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTErrorInfo.h; sourceTree = "<group>"; };
 		3EDCA8A41D3591E700450C31 /* RCTErrorInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTErrorInfo.m; sourceTree = "<group>"; };
-		4F56C93722167A4800DB9F3F /* jsi/jsilib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jsi/jsilib.h; sourceTree = "<group>"; };
+		4F56C93722167A4800DB9F3F /* jsilib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = jsilib.h; path = jsi/jsilib.h; sourceTree = "<group>"; };
 		5335D5401FE81A4700883D58 /* RCTShadowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTShadowView.m; sourceTree = "<group>"; };
 		5343895E203905B6008E0CB3 /* YGLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = YGLayout.cpp; sourceTree = "<group>"; };
 		5343895F203905B6008E0CB3 /* YGLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YGLayout.h; sourceTree = "<group>"; };
@@ -4027,7 +4027,7 @@
 				EDEBC6DF214B3F6800DD5AC8 /* BUCK */,
 				EDEBC6E0214B3F6800DD5AC8 /* instrumentation.h */,
 				EDEBC6E1214B3F6800DD5AC8 /* jsi.h */,
-				4F56C93722167A4800DB9F3F /* jsi/jsilib.h */,
+				4F56C93722167A4800DB9F3F /* jsilib.h */,
 			);
 			path = jsi;
 			sourceTree = "<group>";
@@ -4801,7 +4801,7 @@
 				9FD21D67224303D900E7F88E /* JSIDynamic.h in Headers */,
 				9FD21D68224303D900E7F88E /* jsi-inl.h in Headers */,
 				9FD21D69224303D900E7F88E /* instrumentation.h in Headers */,
-				99942CF922F34AB4009FAB58 /* jsi/jsilib.h in Headers */,
+				99942CF922F34AB4009FAB58 /* jsilib.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4871,7 +4871,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EDEBC6E9214B3F6800DD5AC8 /* jsi.h in Headers */,
-				4F56C93822167A4800DB9F3F /* jsi/jsilib.h in Headers */,
+				4F56C93822167A4800DB9F3F /* jsilib.h in Headers */,
 				EDEBC6E7214B3F6800DD5AC8 /* JSCRuntime.h in Headers */,
 				EDEBC6E5214B3F6800DD5AC8 /* JSIDynamic.h in Headers */,
 				EDEBC6E2214B3F6800DD5AC8 /* jsi-inl.h in Headers */,

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -1540,6 +1540,7 @@
 		66CD94B61F1045E700CB3C7C /* RCTMaskedViewManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 66CD94AF1F1045E700CB3C7C /* RCTMaskedViewManager.h */; };
 		66CD94B71F1045E700CB3C7C /* RCTMaskedViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 66CD94B01F1045E700CB3C7C /* RCTMaskedViewManager.m */; };
 		68EFE4EE1CF6EB3900A1DE13 /* RCTBundleURLProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 68EFE4ED1CF6EB3900A1DE13 /* RCTBundleURLProvider.m */; };
+		81EE589324521A2900C9D359 /* jsilib.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 4F56C93722167A4800DB9F3F /* jsilib.h */; };
 		830A229E1A66C68A008503DA /* RCTRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 830A229D1A66C68A008503DA /* RCTRootView.m */; };
 		83281384217EB70900574D55 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		83281385217EB71200574D55 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -2611,6 +2612,7 @@
 				9FD21D6D224303D900E7F88E /* JSIDynamic.h in Copy Headers */,
 				9FD21D6E224303D900E7F88E /* JSCRuntime.h in Copy Headers */,
 				9FD21D6F224303D900E7F88E /* jsi.h in Copy Headers */,
+				81EE589324521A2900C9D359 /* jsilib.h in Copy Headers */,
 			);
 			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -1,12 +1,15 @@
-//  Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the MIT license found in the
- // LICENSE file in the root directory of this source tree.
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "JSCRuntime.h"
 
 #include <JavaScriptCore/JavaScript.h>
 #include <jsi/jsilib.h>
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <cstdlib>
@@ -25,8 +28,8 @@ class ArgsConverter;
 class JSCRuntime;
 
 struct Lock {
-  void lock(const jsc::JSCRuntime&) const {}
-  void unlock(const jsc::JSCRuntime&) const {}
+  void lock(const jsc::JSCRuntime &) const {}
+  void unlock(const jsc::JSCRuntime &) const {}
 };
 
 class JSCRuntime : public jsi::Runtime {
@@ -42,18 +45,18 @@ class JSCRuntime : public jsi::Runtime {
       std::string sourceURL) override;
 
   jsi::Value evaluatePreparedJavaScript(
-    const std::shared_ptr<const jsi::PreparedJavaScript>& js) override;
+      const std::shared_ptr<const jsi::PreparedJavaScript> &js) override;
 
   jsi::Value evaluateJavaScript(
       const std::shared_ptr<const jsi::Buffer> &buffer,
-      const std::string& sourceURL) override;
+      const std::string &sourceURL) override;
   jsi::Object global() override;
 
   std::string description() override;
 
   bool isInspectable() override;
 
-  void setDescription(const std::string& desc);
+  void setDescription(const std::string &desc);
 
   // Please don't use the following two functions, only exposed for
   // integration efforts.
@@ -65,29 +68,32 @@ class JSCRuntime : public jsi::Runtime {
   jsi::Value createValue(JSValueRef value) const;
 
   // Value->JSValueRef (similar to above)
-  JSValueRef valueRef(const jsi::Value& value);
+  JSValueRef valueRef(const jsi::Value &value);
 
  protected:
   friend class detail::ArgsConverter;
   class JSCSymbolValue final : public PointerValue {
 #ifndef NDEBUG
-    JSCSymbolValue(JSGlobalContextRef ctx,
-                   const std::atomic<bool>& ctxInvalid,
-                   JSValueRef sym, std::atomic<intptr_t>& counter);
+    JSCSymbolValue(
+        JSGlobalContextRef ctx,
+        const std::atomic<bool> &ctxInvalid,
+        JSValueRef sym,
+        std::atomic<intptr_t> &counter);
 #else
-    JSCSymbolValue(JSGlobalContextRef ctx,
-                   const std::atomic<bool>& ctxInvalid,
-                   JSValueRef sym);
+    JSCSymbolValue(
+        JSGlobalContextRef ctx,
+        const std::atomic<bool> &ctxInvalid,
+        JSValueRef sym);
 #endif
     void invalidate() override;
 
     JSGlobalContextRef ctx_;
-    const std::atomic<bool>& ctxInvalid_;
+    const std::atomic<bool> &ctxInvalid_;
     // There is no C type in the JSC API to represent Symbol, so this stored
     // a JSValueRef which contains the Symbol.
     JSValueRef sym_;
 #ifndef NDEBUG
-    std::atomic<intptr_t>& counter_;
+    std::atomic<intptr_t> &counter_;
 #endif
    protected:
     friend class JSCRuntime;
@@ -95,7 +101,7 @@ class JSCRuntime : public jsi::Runtime {
 
   class JSCStringValue final : public PointerValue {
 #ifndef NDEBUG
-    JSCStringValue(JSStringRef str, std::atomic<intptr_t>& counter);
+    JSCStringValue(JSStringRef str, std::atomic<intptr_t> &counter);
 #else
     JSCStringValue(JSStringRef str);
 #endif
@@ -103,7 +109,7 @@ class JSCRuntime : public jsi::Runtime {
 
     JSStringRef str_;
 #ifndef NDEBUG
-    std::atomic<intptr_t>& counter_;
+    std::atomic<intptr_t> &counter_;
 #endif
    protected:
     friend class JSCRuntime;
@@ -112,111 +118,111 @@ class JSCRuntime : public jsi::Runtime {
   class JSCObjectValue final : public PointerValue {
     JSCObjectValue(
         JSGlobalContextRef ctx,
-        const std::atomic<bool>& ctxInvalid,
+        const std::atomic<bool> &ctxInvalid,
         JSObjectRef obj
 #ifndef NDEBUG
         ,
-        std::atomic<intptr_t>& counter
+        std::atomic<intptr_t> &counter
 #endif
-                   );
+    );
 
     void invalidate() override;
 
     JSGlobalContextRef ctx_;
-    const std::atomic<bool>& ctxInvalid_;
+    const std::atomic<bool> &ctxInvalid_;
     JSObjectRef obj_;
 #ifndef NDEBUG
-    std::atomic<intptr_t>& counter_;
+    std::atomic<intptr_t> &counter_;
 #endif
    protected:
     friend class JSCRuntime;
   };
 
-  PointerValue* cloneSymbol(const Runtime::PointerValue* pv) override;
-  PointerValue* cloneString(const Runtime::PointerValue* pv) override;
-  PointerValue* cloneObject(const Runtime::PointerValue* pv) override;
-  PointerValue* clonePropNameID(const Runtime::PointerValue* pv) override;
+  PointerValue *cloneSymbol(const Runtime::PointerValue *pv) override;
+  PointerValue *cloneString(const Runtime::PointerValue *pv) override;
+  PointerValue *cloneObject(const Runtime::PointerValue *pv) override;
+  PointerValue *clonePropNameID(const Runtime::PointerValue *pv) override;
 
-  jsi::PropNameID createPropNameIDFromAscii(const char* str, size_t length)
+  jsi::PropNameID createPropNameIDFromAscii(const char *str, size_t length)
       override;
-  jsi::PropNameID createPropNameIDFromUtf8(const uint8_t* utf8, size_t length)
+  jsi::PropNameID createPropNameIDFromUtf8(const uint8_t *utf8, size_t length)
       override;
-  jsi::PropNameID createPropNameIDFromString(const jsi::String& str) override;
-  std::string utf8(const jsi::PropNameID&) override;
-  bool compare(const jsi::PropNameID&, const jsi::PropNameID&) override;
+  jsi::PropNameID createPropNameIDFromString(const jsi::String &str) override;
+  std::string utf8(const jsi::PropNameID &) override;
+  bool compare(const jsi::PropNameID &, const jsi::PropNameID &) override;
 
-  std::string symbolToString(const jsi::Symbol&) override;
+  std::string symbolToString(const jsi::Symbol &) override;
 
-  jsi::String createStringFromAscii(const char* str, size_t length) override;
-  jsi::String createStringFromUtf8(const uint8_t* utf8, size_t length) override;
-  std::string utf8(const jsi::String&) override;
+  jsi::String createStringFromAscii(const char *str, size_t length) override;
+  jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
+  std::string utf8(const jsi::String &) override;
 
   jsi::Object createObject() override;
   jsi::Object createObject(std::shared_ptr<jsi::HostObject> ho) override;
   virtual std::shared_ptr<jsi::HostObject> getHostObject(
-      const jsi::Object&) override;
-  jsi::HostFunctionType& getHostFunction(const jsi::Function&) override;
+      const jsi::Object &) override;
+  jsi::HostFunctionType &getHostFunction(const jsi::Function &) override;
 
-  jsi::Value getProperty(const jsi::Object&, const jsi::String& name) override;
-  jsi::Value getProperty(const jsi::Object&, const jsi::PropNameID& name)
+  jsi::Value getProperty(const jsi::Object &, const jsi::String &name) override;
+  jsi::Value getProperty(const jsi::Object &, const jsi::PropNameID &name)
       override;
-  bool hasProperty(const jsi::Object&, const jsi::String& name) override;
-  bool hasProperty(const jsi::Object&, const jsi::PropNameID& name) override;
+  bool hasProperty(const jsi::Object &, const jsi::String &name) override;
+  bool hasProperty(const jsi::Object &, const jsi::PropNameID &name) override;
   void setPropertyValue(
-      jsi::Object&,
-      const jsi::String& name,
-      const jsi::Value& value) override;
+      jsi::Object &,
+      const jsi::String &name,
+      const jsi::Value &value) override;
   void setPropertyValue(
-      jsi::Object&,
-      const jsi::PropNameID& name,
-      const jsi::Value& value) override;
-  bool isArray(const jsi::Object&) const override;
-  bool isArrayBuffer(const jsi::Object&) const override;
-  bool isFunction(const jsi::Object&) const override;
-  bool isHostObject(const jsi::Object&) const override;
-  bool isHostFunction(const jsi::Function&) const override;
-  jsi::Array getPropertyNames(const jsi::Object&) override;
+      jsi::Object &,
+      const jsi::PropNameID &name,
+      const jsi::Value &value) override;
+  bool isArray(const jsi::Object &) const override;
+  bool isArrayBuffer(const jsi::Object &) const override;
+  bool isFunction(const jsi::Object &) const override;
+  bool isHostObject(const jsi::Object &) const override;
+  bool isHostFunction(const jsi::Function &) const override;
+  jsi::Array getPropertyNames(const jsi::Object &) override;
 
   // TODO: revisit this implementation
-  jsi::WeakObject createWeakObject(const jsi::Object&) override;
-  jsi::Value lockWeakObject(const jsi::WeakObject&) override;
+  jsi::WeakObject createWeakObject(const jsi::Object &) override;
+  jsi::Value lockWeakObject(const jsi::WeakObject &) override;
 
   jsi::Array createArray(size_t length) override;
-  size_t size(const jsi::Array&) override;
-  size_t size(const jsi::ArrayBuffer&) override;
-  uint8_t* data(const jsi::ArrayBuffer&) override;
-  jsi::Value getValueAtIndex(const jsi::Array&, size_t i) override;
-  void setValueAtIndexImpl(jsi::Array&, size_t i, const jsi::Value& value)
+  size_t size(const jsi::Array &) override;
+  size_t size(const jsi::ArrayBuffer &) override;
+  uint8_t *data(const jsi::ArrayBuffer &) override;
+  jsi::Value getValueAtIndex(const jsi::Array &, size_t i) override;
+  void setValueAtIndexImpl(jsi::Array &, size_t i, const jsi::Value &value)
       override;
 
   jsi::Function createFunctionFromHostFunction(
-      const jsi::PropNameID& name,
+      const jsi::PropNameID &name,
       unsigned int paramCount,
       jsi::HostFunctionType func) override;
   jsi::Value call(
-      const jsi::Function&,
-      const jsi::Value& jsThis,
-      const jsi::Value* args,
+      const jsi::Function &,
+      const jsi::Value &jsThis,
+      const jsi::Value *args,
       size_t count) override;
   jsi::Value callAsConstructor(
-      const jsi::Function&,
-      const jsi::Value* args,
+      const jsi::Function &,
+      const jsi::Value *args,
       size_t count) override;
 
-  bool strictEquals(const jsi::Symbol& a, const jsi::Symbol& b) const override;
-  bool strictEquals(const jsi::String& a, const jsi::String& b) const override;
-  bool strictEquals(const jsi::Object& a, const jsi::Object& b) const override;
-  bool instanceOf(const jsi::Object& o, const jsi::Function& f) override;
+  bool strictEquals(const jsi::Symbol &a, const jsi::Symbol &b) const override;
+  bool strictEquals(const jsi::String &a, const jsi::String &b) const override;
+  bool strictEquals(const jsi::Object &a, const jsi::Object &b) const override;
+  bool instanceOf(const jsi::Object &o, const jsi::Function &f) override;
 
  private:
   // Basically convenience casts
-  static JSValueRef symbolRef(const jsi::Symbol& str);
-  static JSStringRef stringRef(const jsi::String& str);
-  static JSStringRef stringRef(const jsi::PropNameID& sym);
-  static JSObjectRef objectRef(const jsi::Object& obj);
+  static JSValueRef symbolRef(const jsi::Symbol &str);
+  static JSStringRef stringRef(const jsi::String &str);
+  static JSStringRef stringRef(const jsi::PropNameID &sym);
+  static JSObjectRef objectRef(const jsi::Object &obj);
 
 #ifdef RN_FABRIC_ENABLED
-  static JSObjectRef objectRef(const jsi::WeakObject& obj);
+  static JSObjectRef objectRef(const jsi::WeakObject &obj);
 #endif
 
   // Factory methods for creating String/Object
@@ -226,14 +232,14 @@ class JSCRuntime : public jsi::Runtime {
   jsi::Object createObject(JSObjectRef objectRef) const;
 
   // Used by factory methods and clone methods
-  jsi::Runtime::PointerValue* makeSymbolValue(JSValueRef sym) const;
-  jsi::Runtime::PointerValue* makeStringValue(JSStringRef str) const;
-  jsi::Runtime::PointerValue* makeObjectValue(JSObjectRef obj) const;
+  jsi::Runtime::PointerValue *makeSymbolValue(JSValueRef sym) const;
+  jsi::Runtime::PointerValue *makeStringValue(JSStringRef str) const;
+  jsi::Runtime::PointerValue *makeObjectValue(JSObjectRef obj) const;
 
   void checkException(JSValueRef exc);
   void checkException(JSValueRef res, JSValueRef exc);
-  void checkException(JSValueRef exc, const char* msg);
-  void checkException(JSValueRef res, JSValueRef exc, const char* msg);
+  void checkException(JSValueRef exc, const char *msg);
+  void checkException(JSValueRef res, JSValueRef exc, const char *msg);
 
   JSGlobalContextRef ctx_;
   std::atomic<bool> ctxInvalid_;
@@ -319,7 +325,7 @@ JSStringRef getIsArrayString() {
 
 // std::string utility
 namespace {
-std::string to_string(void* value) {
+std::string to_string(void *value) {
   std::ostringstream ss;
   ss << value;
   return ss.str();
@@ -367,9 +373,9 @@ std::shared_ptr<const jsi::PreparedJavaScript> JSCRuntime::prepareJavaScript(
 }
 
 jsi::Value JSCRuntime::evaluatePreparedJavaScript(
-  const std::shared_ptr<const jsi::PreparedJavaScript>& js) {
+    const std::shared_ptr<const jsi::PreparedJavaScript> &js) {
   assert(
-      dynamic_cast<const jsi::SourceJavaScriptPreparation*>(js.get()) &&
+      dynamic_cast<const jsi::SourceJavaScriptPreparation *>(js.get()) &&
       "preparedJavaScript must be a SourceJavaScriptPreparation");
   auto sourceJs =
       std::static_pointer_cast<const jsi::SourceJavaScriptPreparation>(js);
@@ -378,9 +384,9 @@ jsi::Value JSCRuntime::evaluatePreparedJavaScript(
 
 jsi::Value JSCRuntime::evaluateJavaScript(
     const std::shared_ptr<const jsi::Buffer> &buffer,
-    const std::string& sourceURL) {
+    const std::string &sourceURL) {
   std::string tmp(
-      reinterpret_cast<const char*>(buffer->data()), buffer->size());
+      reinterpret_cast<const char *>(buffer->data()), buffer->size());
   JSStringRef sourceRef = JSStringCreateWithUTF8CString(tmp.c_str());
   JSStringRef sourceURLRef = nullptr;
   if (!sourceURL.empty()) {
@@ -425,11 +431,11 @@ bool smellsLikeES6Symbol(JSGlobalContextRef ctx, JSValueRef ref) {
 
 JSCRuntime::JSCSymbolValue::JSCSymbolValue(
     JSGlobalContextRef ctx,
-    const std::atomic<bool>& ctxInvalid,
+    const std::atomic<bool> &ctxInvalid,
     JSValueRef sym
 #ifndef NDEBUG
     ,
-    std::atomic<intptr_t>& counter
+    std::atomic<intptr_t> &counter
 #endif
     )
     : ctx_(ctx),
@@ -461,7 +467,7 @@ void JSCRuntime::JSCSymbolValue::invalidate() {
 #ifndef NDEBUG
 JSCRuntime::JSCStringValue::JSCStringValue(
     JSStringRef str,
-    std::atomic<intptr_t>& counter)
+    std::atomic<intptr_t> &counter)
     : str_(JSStringRetain(str)), counter_(counter) {
   // Since std::atomic returns a copy instead of a reference when calling
   // operator+= we must do this explicitly in the constructor
@@ -469,8 +475,7 @@ JSCRuntime::JSCStringValue::JSCStringValue(
 }
 #else
 JSCRuntime::JSCStringValue::JSCStringValue(JSStringRef str)
-    : str_(JSStringRetain(str)) {
-}
+    : str_(JSStringRetain(str)) {}
 #endif
 
 void JSCRuntime::JSCStringValue::invalidate() {
@@ -487,11 +492,11 @@ void JSCRuntime::JSCStringValue::invalidate() {
 
 JSCRuntime::JSCObjectValue::JSCObjectValue(
     JSGlobalContextRef ctx,
-    const std::atomic<bool>& ctxInvalid,
+    const std::atomic<bool> &ctxInvalid,
     JSObjectRef obj
 #ifndef NDEBUG
     ,
-    std::atomic<intptr_t>& counter
+    std::atomic<intptr_t> &counter
 #endif
     )
     : ctx_(ctx),
@@ -540,47 +545,47 @@ void JSCRuntime::JSCObjectValue::invalidate() {
   delete this;
 }
 
-jsi::Runtime::PointerValue* JSCRuntime::cloneSymbol(
-    const jsi::Runtime::PointerValue* pv) {
+jsi::Runtime::PointerValue *JSCRuntime::cloneSymbol(
+    const jsi::Runtime::PointerValue *pv) {
   if (!pv) {
     return nullptr;
   }
-  const JSCSymbolValue* symbol = static_cast<const JSCSymbolValue*>(pv);
+  const JSCSymbolValue *symbol = static_cast<const JSCSymbolValue *>(pv);
   return makeSymbolValue(symbol->sym_);
 }
 
-jsi::Runtime::PointerValue* JSCRuntime::cloneString(
-    const jsi::Runtime::PointerValue* pv) {
+jsi::Runtime::PointerValue *JSCRuntime::cloneString(
+    const jsi::Runtime::PointerValue *pv) {
   if (!pv) {
     return nullptr;
   }
-  const JSCStringValue* string = static_cast<const JSCStringValue*>(pv);
+  const JSCStringValue *string = static_cast<const JSCStringValue *>(pv);
   return makeStringValue(string->str_);
 }
 
-jsi::Runtime::PointerValue* JSCRuntime::cloneObject(
-    const jsi::Runtime::PointerValue* pv) {
+jsi::Runtime::PointerValue *JSCRuntime::cloneObject(
+    const jsi::Runtime::PointerValue *pv) {
   if (!pv) {
     return nullptr;
   }
-  const JSCObjectValue* object = static_cast<const JSCObjectValue*>(pv);
+  const JSCObjectValue *object = static_cast<const JSCObjectValue *>(pv);
   assert(
       object->ctx_ == ctx_ &&
       "Don't try to clone an object backed by a different Runtime");
   return makeObjectValue(object->obj_);
 }
 
-jsi::Runtime::PointerValue* JSCRuntime::clonePropNameID(
-    const jsi::Runtime::PointerValue* pv) {
+jsi::Runtime::PointerValue *JSCRuntime::clonePropNameID(
+    const jsi::Runtime::PointerValue *pv) {
   if (!pv) {
     return nullptr;
   }
-  const JSCStringValue* string = static_cast<const JSCStringValue*>(pv);
+  const JSCStringValue *string = static_cast<const JSCStringValue *>(pv);
   return makeStringValue(string->str_);
 }
 
 jsi::PropNameID JSCRuntime::createPropNameIDFromAscii(
-    const char* str,
+    const char *str,
     size_t length) {
   // For system JSC this must is identical to a string
   std::string tmp(str, length);
@@ -591,38 +596,36 @@ jsi::PropNameID JSCRuntime::createPropNameIDFromAscii(
 }
 
 jsi::PropNameID JSCRuntime::createPropNameIDFromUtf8(
-    const uint8_t* utf8,
+    const uint8_t *utf8,
     size_t length) {
-  std::string tmp(reinterpret_cast<const char*>(utf8), length);
+  std::string tmp(reinterpret_cast<const char *>(utf8), length);
   JSStringRef strRef = JSStringCreateWithUTF8CString(tmp.c_str());
   auto res = createPropNameID(strRef);
   JSStringRelease(strRef);
   return res;
 }
 
-jsi::PropNameID JSCRuntime::createPropNameIDFromString(const jsi::String& str) {
+jsi::PropNameID JSCRuntime::createPropNameIDFromString(const jsi::String &str) {
   return createPropNameID(stringRef(str));
 }
 
-std::string JSCRuntime::utf8(const jsi::PropNameID& sym) {
+std::string JSCRuntime::utf8(const jsi::PropNameID &sym) {
   return JSStringToSTLString(stringRef(sym));
 }
 
-bool JSCRuntime::compare(const jsi::PropNameID& a, const jsi::PropNameID& b) {
+bool JSCRuntime::compare(const jsi::PropNameID &a, const jsi::PropNameID &b) {
   return JSStringIsEqual(stringRef(a), stringRef(b));
 }
 
-std::string JSCRuntime::symbolToString(const jsi::Symbol& sym) {
-  return jsi::Value(*this, sym)
-    .toString(*this)
-    .utf8(*this);
+std::string JSCRuntime::symbolToString(const jsi::Symbol &sym) {
+  return jsi::Value(*this, sym).toString(*this).utf8(*this);
 }
 
-jsi::String JSCRuntime::createStringFromAscii(const char* str, size_t length) {
+jsi::String JSCRuntime::createStringFromAscii(const char *str, size_t length) {
   // Yes we end up double casting for semantic reasons (UTF8 contains ASCII,
   // not the other way around)
   return this->createStringFromUtf8(
-      reinterpret_cast<const uint8_t*>(str), length);
+      reinterpret_cast<const uint8_t *>(str), length);
 }
 
 jsi::String JSCRuntime::createStringFromUtf8(
@@ -633,7 +636,7 @@ jsi::String JSCRuntime::createStringFromUtf8(
   return createString(stringRef);
 }
 
-std::string JSCRuntime::utf8(const jsi::String& str) {
+std::string JSCRuntime::utf8(const jsi::String &str) {
   return JSStringToSTLString(stringRef(str));
 }
 
@@ -645,11 +648,11 @@ jsi::Object JSCRuntime::createObject() {
 namespace detail {
 struct HostObjectProxyBase {
   HostObjectProxyBase(
-      JSCRuntime& rt,
-      const std::shared_ptr<jsi::HostObject>& sho)
+      JSCRuntime &rt,
+      const std::shared_ptr<jsi::HostObject> &sho)
       : runtime(rt), hostObject(sho) {}
 
-  JSCRuntime& runtime;
+  JSCRuntime &runtime;
   std::shared_ptr<jsi::HostObject> hostObject;
 };
 } // namespace detail
@@ -665,25 +668,25 @@ jsi::Object JSCRuntime::createObject(std::shared_ptr<jsi::HostObject> ho) {
         JSContextRef ctx,
         JSObjectRef object,
         JSStringRef propName,
-        JSValueRef* exception) {
-      auto proxy = static_cast<HostObjectProxy*>(JSObjectGetPrivate(object));
-      auto& rt = proxy->runtime;
+        JSValueRef *exception) {
+      auto proxy = static_cast<HostObjectProxy *>(JSObjectGetPrivate(object));
+      auto &rt = proxy->runtime;
       jsi::PropNameID sym = rt.createPropNameID(propName);
       jsi::Value ret;
       try {
         ret = proxy->hostObject->get(rt, sym);
-      } catch (const jsi::JSError& error) {
+      } catch (const jsi::JSError &error) {
         *exception = rt.valueRef(error.value());
         return JSValueMakeUndefined(ctx);
-      } catch (const std::exception& ex) {
+      } catch (const std::exception &ex) {
         auto excValue =
             rt.global()
                 .getPropertyAsFunction(rt, "Error")
                 .call(
                     rt,
-                    std::string("Exception in HostObject::get(propName:")
-                      + JSStringToSTLString(propName)
-                      + std::string("): ") + ex.what());
+                    std::string("Exception in HostObject::get(propName:") +
+                        JSStringToSTLString(propName) + std::string("): ") +
+                        ex.what());
         *exception = rt.valueRef(excValue);
         return JSValueMakeUndefined(ctx);
       } catch (...) {
@@ -692,41 +695,41 @@ jsi::Object JSCRuntime::createObject(std::shared_ptr<jsi::HostObject> ho) {
                 .getPropertyAsFunction(rt, "Error")
                 .call(
                     rt,
-                    std::string("Exception in HostObject::get(propName:")
-                      + JSStringToSTLString(propName)
-                      + std::string("): <unknown>"));
+                    std::string("Exception in HostObject::get(propName:") +
+                        JSStringToSTLString(propName) +
+                        std::string("): <unknown>"));
         *exception = rt.valueRef(excValue);
         return JSValueMakeUndefined(ctx);
       }
       return rt.valueRef(ret);
     }
 
-    #define JSC_UNUSED(x) (void) (x);
+#define JSC_UNUSED(x) (void)(x);
 
     static bool setProperty(
         JSContextRef ctx,
         JSObjectRef object,
         JSStringRef propName,
         JSValueRef value,
-        JSValueRef* exception) {
+        JSValueRef *exception) {
       JSC_UNUSED(ctx);
-      auto proxy = static_cast<HostObjectProxy*>(JSObjectGetPrivate(object));
-      auto& rt = proxy->runtime;
+      auto proxy = static_cast<HostObjectProxy *>(JSObjectGetPrivate(object));
+      auto &rt = proxy->runtime;
       jsi::PropNameID sym = rt.createPropNameID(propName);
       try {
         proxy->hostObject->set(rt, sym, rt.createValue(value));
-      } catch (const jsi::JSError& error) {
+      } catch (const jsi::JSError &error) {
         *exception = rt.valueRef(error.value());
         return false;
-      } catch (const std::exception& ex) {
+      } catch (const std::exception &ex) {
         auto excValue =
             rt.global()
                 .getPropertyAsFunction(rt, "Error")
                 .call(
                     rt,
-                    std::string("Exception in HostObject::set(propName:")
-                      + JSStringToSTLString(propName)
-                      + std::string("): ") + ex.what());
+                    std::string("Exception in HostObject::set(propName:") +
+                        JSStringToSTLString(propName) + std::string("): ") +
+                        ex.what());
         *exception = rt.valueRef(excValue);
         return false;
       } catch (...) {
@@ -735,9 +738,9 @@ jsi::Object JSCRuntime::createObject(std::shared_ptr<jsi::HostObject> ho) {
                 .getPropertyAsFunction(rt, "Error")
                 .call(
                     rt,
-                      std::string("Exception in HostObject::set(propName:")
-                      + JSStringToSTLString(propName)
-                      + std::string("): <unknown>"));
+                    std::string("Exception in HostObject::set(propName:") +
+                        JSStringToSTLString(propName) +
+                        std::string("): <unknown>"));
         *exception = rt.valueRef(excValue);
         return false;
       }
@@ -752,18 +755,18 @@ jsi::Object JSCRuntime::createObject(std::shared_ptr<jsi::HostObject> ho) {
         JSObjectRef object,
         JSPropertyNameAccumulatorRef propertyNames) noexcept {
       JSC_UNUSED(ctx);
-      auto proxy = static_cast<HostObjectProxy*>(JSObjectGetPrivate(object));
-      auto& rt = proxy->runtime;
+      auto proxy = static_cast<HostObjectProxy *>(JSObjectGetPrivate(object));
+      auto &rt = proxy->runtime;
       auto names = proxy->hostObject->getPropertyNames(rt);
-      for (auto& name : names) {
+      for (auto &name : names) {
         JSPropertyNameAccumulatorAddName(propertyNames, stringRef(name));
       }
     }
 
-    #undef JSC_UNUSED
+#undef JSC_UNUSED
 
     static void finalize(JSObjectRef obj) {
-      auto hostObject = static_cast<HostObjectProxy*>(JSObjectGetPrivate(obj));
+      auto hostObject = static_cast<HostObjectProxy *>(JSObjectGetPrivate(obj));
       JSObjectSetPrivate(obj, nullptr);
       delete hostObject;
     }
@@ -788,19 +791,19 @@ jsi::Object JSCRuntime::createObject(std::shared_ptr<jsi::HostObject> ho) {
 }
 
 std::shared_ptr<jsi::HostObject> JSCRuntime::getHostObject(
-    const jsi::Object& obj) {
+    const jsi::Object &obj) {
   // We are guaranteed at this point to have isHostObject(obj) == true
   // so the private data should be HostObjectMetadata
   JSObjectRef object = objectRef(obj);
   auto metadata =
-      static_cast<detail::HostObjectProxyBase*>(JSObjectGetPrivate(object));
+      static_cast<detail::HostObjectProxyBase *>(JSObjectGetPrivate(object));
   assert(metadata);
   return metadata->hostObject;
 }
 
 jsi::Value JSCRuntime::getProperty(
-    const jsi::Object& obj,
-    const jsi::String& name) {
+    const jsi::Object &obj,
+    const jsi::String &name) {
   JSObjectRef objRef = objectRef(obj);
   JSValueRef exc = nullptr;
   JSValueRef res = JSObjectGetProperty(ctx_, objRef, stringRef(name), &exc);
@@ -809,8 +812,8 @@ jsi::Value JSCRuntime::getProperty(
 }
 
 jsi::Value JSCRuntime::getProperty(
-    const jsi::Object& obj,
-    const jsi::PropNameID& name) {
+    const jsi::Object &obj,
+    const jsi::PropNameID &name) {
   JSObjectRef objRef = objectRef(obj);
   JSValueRef exc = nullptr;
   JSValueRef res = JSObjectGetProperty(ctx_, objRef, stringRef(name), &exc);
@@ -818,22 +821,22 @@ jsi::Value JSCRuntime::getProperty(
   return createValue(res);
 }
 
-bool JSCRuntime::hasProperty(const jsi::Object& obj, const jsi::String& name) {
+bool JSCRuntime::hasProperty(const jsi::Object &obj, const jsi::String &name) {
   JSObjectRef objRef = objectRef(obj);
   return JSObjectHasProperty(ctx_, objRef, stringRef(name));
 }
 
 bool JSCRuntime::hasProperty(
-    const jsi::Object& obj,
-    const jsi::PropNameID& name) {
+    const jsi::Object &obj,
+    const jsi::PropNameID &name) {
   JSObjectRef objRef = objectRef(obj);
   return JSObjectHasProperty(ctx_, objRef, stringRef(name));
 }
 
 void JSCRuntime::setPropertyValue(
-    jsi::Object& object,
-    const jsi::PropNameID& name,
-    const jsi::Value& value) {
+    jsi::Object &object,
+    const jsi::PropNameID &name,
+    const jsi::Value &value) {
   JSValueRef exc = nullptr;
   JSObjectSetProperty(
       ctx_,
@@ -846,9 +849,9 @@ void JSCRuntime::setPropertyValue(
 }
 
 void JSCRuntime::setPropertyValue(
-    jsi::Object& object,
-    const jsi::String& name,
-    const jsi::Value& value) {
+    jsi::Object &object,
+    const jsi::String &name,
+    const jsi::Value &value) {
   JSValueRef exc = nullptr;
   JSObjectSetProperty(
       ctx_,
@@ -860,7 +863,7 @@ void JSCRuntime::setPropertyValue(
   checkException(exc);
 }
 
-bool JSCRuntime::isArray(const jsi::Object& obj) const {
+bool JSCRuntime::isArray(const jsi::Object &obj) const {
 #if !defined(_JSC_FAST_IS_ARRAY)
   JSObjectRef global = JSContextGetGlobalObject(ctx_);
   JSStringRef arrayString = getArrayString();
@@ -886,37 +889,37 @@ bool JSCRuntime::isArray(const jsi::Object& obj) const {
 #endif
 }
 
-bool JSCRuntime::isArrayBuffer(const jsi::Object& /*obj*/) const {
+bool JSCRuntime::isArrayBuffer(const jsi::Object & /*obj*/) const {
   // TODO: T23270523 - This would fail on builds that use our custom JSC
   // auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj),
   // nullptr);  return typedArrayType == kJSTypedArrayTypeArrayBuffer;
   throw std::runtime_error("Unsupported");
 }
 
-uint8_t* JSCRuntime::data(const jsi::ArrayBuffer& /*obj*/) {
+uint8_t *JSCRuntime::data(const jsi::ArrayBuffer & /*obj*/) {
   // TODO: T23270523 - This would fail on builds that use our custom JSC
   // return static_cast<uint8_t*>(
   //    JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
   throw std::runtime_error("Unsupported");
 }
 
-size_t JSCRuntime::size(const jsi::ArrayBuffer& /*obj*/) {
+size_t JSCRuntime::size(const jsi::ArrayBuffer & /*obj*/) {
   // TODO: T23270523 - This would fail on builds that use our custom JSC
   // return JSObjectGetArrayBufferByteLength(ctx_, objectRef(obj), nullptr);
   throw std::runtime_error("Unsupported");
 }
 
-bool JSCRuntime::isFunction(const jsi::Object& obj) const {
+bool JSCRuntime::isFunction(const jsi::Object &obj) const {
   return JSObjectIsFunction(ctx_, objectRef(obj));
 }
 
-bool JSCRuntime::isHostObject(const jsi::Object& obj) const {
+bool JSCRuntime::isHostObject(const jsi::Object &obj) const {
   auto cls = hostObjectClass;
   return cls != nullptr && JSValueIsObjectOfClass(ctx_, objectRef(obj), cls);
 }
 
 // Very expensive
-jsi::Array JSCRuntime::getPropertyNames(const jsi::Object& obj) {
+jsi::Array JSCRuntime::getPropertyNames(const jsi::Object &obj) {
   JSPropertyNameArrayRef names =
       JSObjectCopyPropertyNames(ctx_, objectRef(obj));
   size_t len = JSPropertyNameArrayGetCount(names);
@@ -930,7 +933,7 @@ jsi::Array JSCRuntime::getPropertyNames(const jsi::Object& obj) {
   return result;
 }
 
-jsi::WeakObject JSCRuntime::createWeakObject(const jsi::Object& obj) {
+jsi::WeakObject JSCRuntime::createWeakObject(const jsi::Object &obj) {
 #ifdef RN_FABRIC_ENABLED
   // TODO: revisit this implementation
   JSObjectRef objRef = objectRef(obj);
@@ -940,7 +943,7 @@ jsi::WeakObject JSCRuntime::createWeakObject(const jsi::Object& obj) {
 #endif
 }
 
-jsi::Value JSCRuntime::lockWeakObject(const jsi::WeakObject& obj) {
+jsi::Value JSCRuntime::lockWeakObject(const jsi::WeakObject &obj) {
 #ifdef RN_FABRIC_ENABLED
   // TODO: revisit this implementation
   JSObjectRef objRef = objectRef(obj);
@@ -965,12 +968,12 @@ jsi::Array JSCRuntime::createArray(size_t length) {
   return createObject(obj).getArray(*this);
 }
 
-size_t JSCRuntime::size(const jsi::Array& arr) {
+size_t JSCRuntime::size(const jsi::Array &arr) {
   return static_cast<size_t>(
       getProperty(arr, createPropNameID(getLengthString())).getNumber());
 }
 
-jsi::Value JSCRuntime::getValueAtIndex(const jsi::Array& arr, size_t i) {
+jsi::Value JSCRuntime::getValueAtIndex(const jsi::Array &arr, size_t i) {
   JSValueRef exc = nullptr;
   auto res = JSObjectGetPropertyAtIndex(ctx_, objectRef(arr), (int)i, &exc);
   checkException(exc);
@@ -978,11 +981,12 @@ jsi::Value JSCRuntime::getValueAtIndex(const jsi::Array& arr, size_t i) {
 }
 
 void JSCRuntime::setValueAtIndexImpl(
-    jsi::Array& arr,
+    jsi::Array &arr,
     size_t i,
-    const jsi::Value& value) {
+    const jsi::Value &value) {
   JSValueRef exc = nullptr;
-  JSObjectSetPropertyAtIndex(ctx_, objectRef(arr), (int)i, valueRef(value), &exc);
+  JSObjectSetPropertyAtIndex(
+      ctx_, objectRef(arr), (int)i, valueRef(value), &exc);
   checkException(exc);
 }
 
@@ -995,7 +999,7 @@ class HostFunctionProxy {
   HostFunctionProxy(jsi::HostFunctionType hostFunction)
       : hostFunction_(hostFunction) {}
 
-  jsi::HostFunctionType& getHostFunction() {
+  jsi::HostFunctionType &getHostFunction() {
     return hostFunction_;
   }
 
@@ -1005,7 +1009,7 @@ class HostFunctionProxy {
 } // namespace
 
 jsi::Function JSCRuntime::createFunctionFromHostFunction(
-    const jsi::PropNameID& name,
+    const jsi::PropNameID &name,
     unsigned int paramCount,
     jsi::HostFunctionType func) {
   class HostFunctionMetadata : public HostFunctionProxy {
@@ -1014,8 +1018,8 @@ jsi::Function JSCRuntime::createFunctionFromHostFunction(
       // We need to set up the prototype chain properly here. In theory we
       // could set func.prototype.prototype = Function.prototype to get the
       // same result. Not sure which approach is better.
-      HostFunctionMetadata* metadata =
-          static_cast<HostFunctionMetadata*>(JSObjectGetPrivate(object));
+      HostFunctionMetadata *metadata =
+          static_cast<HostFunctionMetadata *>(JSObjectGetPrivate(object));
 
       JSValueRef exc = nullptr;
       JSObjectSetProperty(
@@ -1063,7 +1067,7 @@ jsi::Function JSCRuntime::createFunctionFromHostFunction(
       JSObjectSetPrototype(ctx, object, funcProto);
     }
 
-    static JSValueRef makeError(JSCRuntime& rt, const std::string& desc) {
+    static JSValueRef makeError(JSCRuntime &rt, const std::string &desc) {
       jsi::Value value =
           rt.global().getPropertyAsFunction(rt, "Error").call(rt, desc);
       return rt.valueRef(value);
@@ -1075,14 +1079,14 @@ jsi::Function JSCRuntime::createFunctionFromHostFunction(
         JSObjectRef thisObject,
         size_t argumentCount,
         const JSValueRef arguments[],
-        JSValueRef* exception) {
-      HostFunctionMetadata* metadata =
-          static_cast<HostFunctionMetadata*>(JSObjectGetPrivate(function));
-      JSCRuntime& rt = *(metadata->runtime);
+        JSValueRef *exception) {
+      HostFunctionMetadata *metadata =
+          static_cast<HostFunctionMetadata *>(JSObjectGetPrivate(function));
+      JSCRuntime &rt = *(metadata->runtime);
       const unsigned maxStackArgCount = 8;
       jsi::Value stackArgs[maxStackArgCount];
       std::unique_ptr<jsi::Value[]> heapArgs;
-      jsi::Value* args;
+      jsi::Value *args;
       if (argumentCount > maxStackArgCount) {
         heapArgs = std::make_unique<jsi::Value[]>(argumentCount);
         for (size_t i = 0; i < argumentCount; i++) {
@@ -1100,10 +1104,10 @@ jsi::Function JSCRuntime::createFunctionFromHostFunction(
       try {
         res = rt.valueRef(
             metadata->hostFunction_(rt, thisVal, args, argumentCount));
-      } catch (const jsi::JSError& error) {
+      } catch (const jsi::JSError &error) {
         *exception = rt.valueRef(error.value());
         res = JSValueMakeUndefined(ctx);
-      } catch (const std::exception& ex) {
+      } catch (const std::exception &ex) {
         std::string exceptionString("Exception in HostFunction: ");
         exceptionString += ex.what();
         *exception = makeError(rt, exceptionString);
@@ -1117,14 +1121,14 @@ jsi::Function JSCRuntime::createFunctionFromHostFunction(
     }
 
     static void finalize(JSObjectRef object) {
-      HostFunctionMetadata* metadata =
-          static_cast<HostFunctionMetadata*>(JSObjectGetPrivate(object));
+      HostFunctionMetadata *metadata =
+          static_cast<HostFunctionMetadata *>(JSObjectGetPrivate(object));
       JSObjectSetPrivate(object, nullptr);
       delete metadata;
     }
 
     HostFunctionMetadata(
-        JSCRuntime* rt,
+        JSCRuntime *rt,
         jsi::HostFunctionType hf,
         unsigned ac,
         JSStringRef n)
@@ -1133,7 +1137,7 @@ jsi::Function JSCRuntime::createFunctionFromHostFunction(
           argCount(ac),
           name(JSStringRetain(n)) {}
 
-    JSCRuntime* runtime;
+    JSCRuntime *runtime;
     unsigned argCount;
     JSStringRef name;
   };
@@ -1160,8 +1164,8 @@ namespace detail {
 
 class ArgsConverter {
  public:
-  ArgsConverter(JSCRuntime& rt, const jsi::Value* args, size_t count) {
-    JSValueRef* destination = inline_;
+  ArgsConverter(JSCRuntime &rt, const jsi::Value *args, size_t count) {
+    JSValueRef *destination = inline_;
     if (count > maxStackArgs) {
       outOfLine_ = std::make_unique<JSValueRef[]>(count);
       destination = outOfLine_.get();
@@ -1172,7 +1176,7 @@ class ArgsConverter {
     }
   }
 
-  operator JSValueRef*() {
+  operator JSValueRef *() {
     return outOfLine_ ? outOfLine_.get() : inline_;
   }
 
@@ -1183,22 +1187,22 @@ class ArgsConverter {
 };
 } // namespace detail
 
-bool JSCRuntime::isHostFunction(const jsi::Function& obj) const {
+bool JSCRuntime::isHostFunction(const jsi::Function &obj) const {
   auto cls = hostFunctionClass;
   return cls != nullptr && JSValueIsObjectOfClass(ctx_, objectRef(obj), cls);
 }
 
-jsi::HostFunctionType& JSCRuntime::getHostFunction(const jsi::Function& obj) {
+jsi::HostFunctionType &JSCRuntime::getHostFunction(const jsi::Function &obj) {
   // We know that isHostFunction(obj) is true here, so its safe to proceed
   auto proxy =
-      static_cast<HostFunctionProxy*>(JSObjectGetPrivate(objectRef(obj)));
+      static_cast<HostFunctionProxy *>(JSObjectGetPrivate(objectRef(obj)));
   return proxy->getHostFunction();
 }
 
 jsi::Value JSCRuntime::call(
-    const jsi::Function& f,
-    const jsi::Value& jsThis,
-    const jsi::Value* args,
+    const jsi::Function &f,
+    const jsi::Value &jsThis,
+    const jsi::Value *args,
     size_t count) {
   JSValueRef exc = nullptr;
   auto res = JSObjectCallAsFunction(
@@ -1213,8 +1217,8 @@ jsi::Value JSCRuntime::call(
 }
 
 jsi::Value JSCRuntime::callAsConstructor(
-    const jsi::Function& f,
-    const jsi::Value* args,
+    const jsi::Function &f,
+    const jsi::Value *args,
     size_t count) {
   JSValueRef exc = nullptr;
   auto res = JSObjectCallAsConstructor(
@@ -1227,25 +1231,25 @@ jsi::Value JSCRuntime::callAsConstructor(
   return createValue(res);
 }
 
-bool JSCRuntime::strictEquals(const jsi::Symbol& a, const jsi::Symbol& b)
+bool JSCRuntime::strictEquals(const jsi::Symbol &a, const jsi::Symbol &b)
     const {
   JSValueRef exc = nullptr;
   bool ret = JSValueIsEqual(ctx_, symbolRef(a), symbolRef(b), &exc);
-  const_cast<JSCRuntime*>(this)->checkException(exc);
+  const_cast<JSCRuntime *>(this)->checkException(exc);
   return ret;
 }
 
-bool JSCRuntime::strictEquals(const jsi::String& a, const jsi::String& b)
+bool JSCRuntime::strictEquals(const jsi::String &a, const jsi::String &b)
     const {
   return JSStringIsEqual(stringRef(a), stringRef(b));
 }
 
-bool JSCRuntime::strictEquals(const jsi::Object& a, const jsi::Object& b)
+bool JSCRuntime::strictEquals(const jsi::Object &a, const jsi::Object &b)
     const {
   return objectRef(a) == objectRef(b);
 }
 
-bool JSCRuntime::instanceOf(const jsi::Object& o, const jsi::Function& f) {
+bool JSCRuntime::instanceOf(const jsi::Object &o, const jsi::Function &f) {
   JSValueRef exc = nullptr;
   bool res =
       JSValueIsInstanceOfConstructor(ctx_, objectRef(o), objectRef(f), &exc);
@@ -1253,7 +1257,7 @@ bool JSCRuntime::instanceOf(const jsi::Object& o, const jsi::Function& f) {
   return res;
 }
 
-jsi::Runtime::PointerValue* JSCRuntime::makeSymbolValue(
+jsi::Runtime::PointerValue *JSCRuntime::makeSymbolValue(
     JSValueRef symbolRef) const {
 #ifndef NDEBUG
   return new JSCSymbolValue(ctx_, ctxInvalid_, symbolRef, symbolCounter_);
@@ -1269,7 +1273,7 @@ JSStringRef getEmptyString() {
 }
 } // namespace
 
-jsi::Runtime::PointerValue* JSCRuntime::makeStringValue(
+jsi::Runtime::PointerValue *JSCRuntime::makeStringValue(
     JSStringRef stringRef) const {
   if (!stringRef) {
     stringRef = getEmptyString();
@@ -1293,7 +1297,7 @@ jsi::PropNameID JSCRuntime::createPropNameID(JSStringRef str) {
   return make<jsi::PropNameID>(makeStringValue(str));
 }
 
-jsi::Runtime::PointerValue* JSCRuntime::makeObjectValue(
+jsi::Runtime::PointerValue *JSCRuntime::makeObjectValue(
     JSObjectRef objectRef) const {
   if (!objectRef) {
     objectRef = JSObjectMake(ctx_, nullptr, nullptr);
@@ -1334,7 +1338,7 @@ jsi::Value JSCRuntime::createValue(JSValueRef value) const {
   }
 }
 
-JSValueRef JSCRuntime::valueRef(const jsi::Value& value) {
+JSValueRef JSCRuntime::valueRef(const jsi::Value &value) {
   // I would rather switch on value.kind_
   if (value.isUndefined()) {
     return JSValueMakeUndefined(ctx_);
@@ -1356,26 +1360,26 @@ JSValueRef JSCRuntime::valueRef(const jsi::Value& value) {
   }
 }
 
-JSValueRef JSCRuntime::symbolRef(const jsi::Symbol& sym) {
-  return static_cast<const JSCSymbolValue*>(getPointerValue(sym))->sym_;
+JSValueRef JSCRuntime::symbolRef(const jsi::Symbol &sym) {
+  return static_cast<const JSCSymbolValue *>(getPointerValue(sym))->sym_;
 }
 
-JSStringRef JSCRuntime::stringRef(const jsi::String& str) {
-  return static_cast<const JSCStringValue*>(getPointerValue(str))->str_;
+JSStringRef JSCRuntime::stringRef(const jsi::String &str) {
+  return static_cast<const JSCStringValue *>(getPointerValue(str))->str_;
 }
 
-JSStringRef JSCRuntime::stringRef(const jsi::PropNameID& sym) {
-  return static_cast<const JSCStringValue*>(getPointerValue(sym))->str_;
+JSStringRef JSCRuntime::stringRef(const jsi::PropNameID &sym) {
+  return static_cast<const JSCStringValue *>(getPointerValue(sym))->str_;
 }
 
-JSObjectRef JSCRuntime::objectRef(const jsi::Object& obj) {
-  return static_cast<const JSCObjectValue*>(getPointerValue(obj))->obj_;
+JSObjectRef JSCRuntime::objectRef(const jsi::Object &obj) {
+  return static_cast<const JSCObjectValue *>(getPointerValue(obj))->obj_;
 }
 
 #ifdef RN_FABRIC_ENABLED
-JSObjectRef JSCRuntime::objectRef(const jsi::WeakObject& obj) {
+JSObjectRef JSCRuntime::objectRef(const jsi::WeakObject &obj) {
   // TODO: revisit this implementation
-  return static_cast<const JSCObjectValue*>(getPointerValue(obj))->obj_;
+  return static_cast<const JSCObjectValue *>(getPointerValue(obj))->obj_;
 }
 #endif
 
@@ -1391,7 +1395,7 @@ void JSCRuntime::checkException(JSValueRef res, JSValueRef exc) {
   }
 }
 
-void JSCRuntime::checkException(JSValueRef exc, const char* msg) {
+void JSCRuntime::checkException(JSValueRef exc, const char *msg) {
   if (JSC_UNLIKELY(exc)) {
     throw jsi::JSError(std::string(msg), *this, createValue(exc));
   }
@@ -1400,7 +1404,7 @@ void JSCRuntime::checkException(JSValueRef exc, const char* msg) {
 void JSCRuntime::checkException(
     JSValueRef res,
     JSValueRef exc,
-    const char* msg) {
+    const char *msg) {
   if (JSC_UNLIKELY(!res)) {
     throw jsi::JSError(std::string(msg), *this, createValue(exc));
   }

--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -6,10 +6,10 @@
 #include "JSCRuntime.h"
 
 #include <JavaScriptCore/JavaScript.h>
+#include <jsi/jsilib.h>
 #include <atomic>
 #include <condition_variable>
 #include <cstdlib>
-#include "jsi/jsilib.h"
 #include <mutex>
 #include <queue>
 #include <sstream>


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
This syncs most changes from upstream facebook/react-native around 1 file specifically - ReactCommon/jsi/JSCRuntime.cpp.

There is 1 critical change here that we need internally at FB - usage of angle brackets for include, instead of quotes for `jsi/jsilib.h`, as with some build setups it starts tracking the header from file system, instead of from other places where the dependency is provided.

The rest is just some formatting changes that I synced over, which should help resolve differences and merge cleanly in the future.

## Test Plan

Formatting and header include changes only, any issue should be caught by CI.

## Changelog

[General][Changed] Update ReactCommon/jsi/JSCRuntime.cpp from upstream facebook/react-native.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/320)