### PR TITLE
Include building and publishing with Android NDKr21 into PR and publi…

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -22,10 +22,6 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - template: templates/apple-droid-node-patching.yml
-        parameters:
-          apply_office_patches: true
-
       - task: UseNode@1
         inputs:
           version: '10.x'
@@ -34,6 +30,10 @@ jobs:
       - task: NuGetToolInstaller@1
         inputs:
           versionSpec: '>=4.6.4'
+
+      - template: templates/apple-droid-node-patching.yml
+        parameters:
+          apply_office_patches: true
 
       - task: CmdLine@2
         displayName: npm install
@@ -156,3 +156,77 @@ jobs:
           #checkStyleRunAnalysis: false # Optional
           #findBugsRunAnalysis: false # Optional
           #pmdRunAnalysis: false # Optional
+  
+
+  - job: AndroidRNPR_ndkr21
+    displayName: Android React Native PR on NDK r21
+    pool:
+      vmImage: ubuntu-18.04
+    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+    steps:
+      - checkout: self # self represents the repo where the initial Pipelines YAML file was found
+        clean: true # whether to fetch clean each time
+        # fetchDepth: 2 # the depth of commits to ask Git to fetch
+        lfs: false # whether to download Git-LFS files
+        submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+        persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+      
+      # Install NuGet
+      - task: CmdLine@2
+        inputs:
+          script: mkdir $(System.DefaultWorkingDirectory)/nuget-bin/ && curl -o $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+        continueOnError: true
+
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
+
+      - template: templates/apple-droid-node-patching.yml
+        parameters:
+          apply_office_patches: true
+
+      # This is currently required as the command task (strangely) always runs elevated .. 
+      # which makes all the files touched by the above patching step unreadable by following non-command tasks without sudo. 
+      # This makes all the files readable.
+      - task: CmdLine@2
+        displayName: chmod
+        inputs:
+          script: chmod -R +r .
+
+      - task: CmdLine@2
+        displayName: npm install
+        inputs:
+          script: npm install
+
+      - task: CmdLine@2
+        displayName: nuget restore
+        inputs:
+          script: mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe restore $(System.DefaultWorkingDirectory)/ReactAndroid/packages.config -PackagesDirectory  $(System.DefaultWorkingDirectory)/ReactAndroid/packages/ -Verbosity Detailed -NonInteractive
+        continueOnError: true
+
+      - task: CmdLine@2
+        displayName: Setup Build Dependencies
+        inputs:
+          script: chmod +x .ado/setup_droid_deps.sh && .ado/setup_droid_deps.sh
+
+      - task: CmdLine@2
+        displayName: gradlew installArchives
+        inputs:
+          script: REACT_NATIVE_DEPENDENCIES=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
+        continueOnError: true
+
+      - template: templates\prep-android-nuget.yml
+
+      # Very similar to the default pack task .. but appends 'ndk21' to the nuget pack version
+      - task: CmdLine@2
+        displayName: 'Verify NuGet can be packed'
+        inputs:
+          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(System.DefaultWorkingDirectory) -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
+        continueOnError: true
+
+      - task: CmdLine@2
+        displayName: gradlew clean
+        inputs:
+          script: ./gradlew clean
+        continueOnError: true

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -277,14 +277,16 @@ jobs:
       - template: templates\prep-android-nuget.yml
 
       # Very similar to the default pack task .. but appends 'ndk21' to the nuget pack version
+      # Note: We are keeping the output directory different from default ask to avoid potential race condition in case the checkout is reused.
       - task: CmdLine@2
         displayName: 'NuGet pack'
         inputs:
-          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)\final -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
+          script: OUTPUT_DIR=$(Build.StagingDirectory)\final-ndk21;NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $OUTPUT_DIR -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
         continueOnError: true
 
+      # Note: PathtoPublish should match $OUTPUT_DIR in the nuget pack task. 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish final artifacts'
         inputs:
-          PathtoPublish: '$(Build.StagingDirectory)\final'
+          PathtoPublish: '$(Build.StagingDirectory)\final-ndk21'
           ArtifactName: 'ReactNative-Final'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -283,7 +283,7 @@ jobs:
           script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)\final -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
         continueOnError: true
 
-     - task: PublishBuildArtifacts@1
+      - task: PublishBuildArtifacts@1
         displayName: 'Publish final artifacts'
         inputs:
           PathtoPublish: '$(Build.StagingDirectory)\final'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -100,10 +100,6 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - template: templates/apple-droid-node-patching.yml
-        parameters:
-          apply_office_patches: true
-
       # Install NuGet v4.6.4+
       - task: NuGetToolInstaller@1
         inputs:
@@ -113,6 +109,10 @@ jobs:
         displayName: npm install
         inputs:
           script: npm install
+
+      - template: templates/apple-droid-node-patching.yml
+        parameters:
+          apply_office_patches: true
 
       - task: CmdLine@2
         displayName: Bump package version
@@ -211,6 +211,79 @@ jobs:
           githubApiToken: $(githubApiToken)
 
       - task: PublishBuildArtifacts@1
+        displayName: 'Publish final artifacts'
+        inputs:
+          PathtoPublish: '$(Build.StagingDirectory)\final'
+          ArtifactName: 'ReactNative-Final'
+
+  - job: RNGithubOfficePublish_ndkr21
+    displayName: React-Native GitHub Publish to Office with Android NDK r21
+    pool:
+      vmImage: ubuntu-18.04
+    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+    steps:
+      - checkout: self # self represents the repo where the initial Pipelines YAML file was found
+        clean: true # whether to fetch clean each time
+        # fetchDepth: 2 # the depth of commits to ask Git to fetch
+        lfs: false # whether to download Git-LFS files
+        submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+        persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+      
+      # Install NuGet
+      - task: CmdLine@2
+        inputs:
+          script: mkdir $(System.DefaultWorkingDirectory)/nuget-bin/ && curl -o $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+        continueOnError: true
+
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
+
+      - template: templates/apple-droid-node-patching.yml
+        parameters:
+          apply_office_patches: true
+
+      # This is currently required as the command task (strangely) always runs elevated .. 
+      # which makes all the files touched by the above patching step unreadable by following non-command tasks without sudo. 
+      # This makes all the files readable.
+      - task: CmdLine@2
+        displayName: chmod
+        inputs:
+          script: chmod -R +r .
+
+      - task: CmdLine@2
+        displayName: npm install
+        inputs:
+          script: npm install
+
+      - task: CmdLine@2
+        displayName: nuget restore
+        inputs:
+          script: mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe restore $(System.DefaultWorkingDirectory)/ReactAndroid/packages.config -PackagesDirectory  $(System.DefaultWorkingDirectory)/ReactAndroid/packages/ -Verbosity Detailed -NonInteractive
+        continueOnError: true
+
+      - task: CmdLine@2
+        displayName: Setup Build Dependencies
+        inputs:
+          script: chmod +x .ado/setup_droid_deps.sh && .ado/setup_droid_deps.sh
+
+      - task: CmdLine@2
+        displayName: gradlew installArchives
+        inputs:
+          script: REACT_NATIVE_DEPENDENCIES=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
+        continueOnError: true
+
+      - template: templates\prep-android-nuget.yml
+
+      # Very similar to the default pack task .. but appends 'ndk21' to the nuget pack version
+      - task: CmdLine@2
+        displayName: 'NuGet pack'
+        inputs:
+          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)\final -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
+        continueOnError: true
+
+     - task: PublishBuildArtifacts@1
         displayName: 'Publish final artifacts'
         inputs:
           PathtoPublish: '$(Build.StagingDirectory)\final'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -281,7 +281,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'NuGet pack'
         inputs:
-          script: OUTPUT_DIR=$(Build.StagingDirectory)\final-ndk21;NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $OUTPUT_DIR -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
+          script: OUTPUT_DIR=$(Build.StagingDirectory)/final-ndk21;NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $OUTPUT_DIR -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
         continueOnError: true
 
       # Note: PathtoPublish should match $OUTPUT_DIR in the nuget pack task. 

--- a/.ado/setup_droid_deps.sh
+++ b/.ado/setup_droid_deps.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+BUILD_DEPS_DIR=build_deps
+
+rm -rf $BUILD_DEPS_DIR
+mkdir $BUILD_DEPS_DIR
+
+ln -s "$PWD/ReactAndroid/packages/boost.1.68.0.0/lib/native/include/boost" "$BUILD_DEPS_DIR/boost"
+ln -s "$PWD/double-conversion/double-conversion" "$BUILD_DEPS_DIR/double-conversion"
+ln -s "$PWD/Folly/" "$BUILD_DEPS_DIR/Folly"
+ln -s "$PWD/glog/" "$BUILD_DEPS_DIR/glog"

--- a/android-patches/patches-droid-office-grouped/BuildAndThirdPartyFixes/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches-droid-office-grouped/BuildAndThirdPartyFixes/ReactAndroid/ReactAndroid.nuspec
@@ -115,7 +115,7 @@
 +    <file src="..\ReactCommon\cxxreact\**\*.h" target="inc\cxxreact"/>
 +    <file src="..\ReactCommon\jsi\**\*.h" target="inc\jsi"/>
 +    <file src="..\ReactCommon\yoga\yoga\**\*.h" target="inc\Yoga"/>
-+    <file src="..\folly\**\*.*" target="inc" />
++    <file src="..\Folly\**\*.*" target="inc" />
 +    <file src="..\glog\src\glog\*.h" target="inc\glog" />
 +    <file src="..\jsc\jsc-headers\*.h" target="inc\jsc"/>
 +  </files>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

Devmain is being switched to using Android NDK r21. This change adds PR valiation for building using NDK r21 and publish job using NDK r21.

#### Focus areas to test
No change in product code. Ensure PR jobs succeeds.. and ensure that a nuget package built with NDK r21 is published whose version is appended with '-ndk21'


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/321)