### PR TITLE
0.60-stable publish fixes

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -6,6 +6,7 @@ trigger: none # will disable CI builds entirely
 pr:
 - master
 - 0.59-stable
+- 0.60-stable
 
 jobs:
   - job: AndroidRNPR

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -9,6 +9,7 @@ trigger: none # will disable CI builds entirely
 pr:
 - master
 - 0.59-stable
+- 0.60-stable
 
 jobs:
   - job: JavaScriptRNPR

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -5,6 +5,7 @@ trigger:
   batch: true
   branches:
     include:
+      - 0.60-stable
       - master
       - fabric
   paths:
@@ -48,43 +49,6 @@ jobs:
         inputs:
           command: 'publish'
           publishEndpoint: 'npmjs'
-
-  - job: RNMacOSInitNpmJSPublish
-    displayName: react-native-macos-init Publish to npmjs.org
-    pool:
-      vmImage: vs2017-win2016
-    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
-    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-    steps:
-      - checkout: self # self represents the repo where the initial Pipelines YAML file was found
-        clean: true # whether to fetch clean each time
-        # fetchDepth: 2 # the depth of commits to ask Git to fetch
-        lfs: false # whether to download Git-LFS files
-        submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
-        persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
-
-      - template: templates/configure-git.yml
-
-      - task: CmdLine@2
-        displayName: yarn install
-        inputs:
-          script: |
-            cd packages/react-native-macos-init
-            yarn install
-
-      - task: CmdLine@2
-        displayName: yarn build
-        inputs:
-          script: |
-            cd packages/react-native-macos-init
-            yarn build
-
-      - task: CmdLine@2
-        displayName: "Publish react-native-macos-init to npmjs.org"
-        inputs:
-          script: |
-            cd packages/react-native-macos-init
-            npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --access public
 
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office

--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/microsoft/react-native-macos",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "scripts": {
     "change": "beachball change",
     "check": "beachball check",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Prepping the build logic of the 0.60-stable branch to allow future hotfixes.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/360)