### PR TITLE
install and link macOS Pods automatically on init

### DIFF
--- a/local-cli/generate-macos.js
+++ b/local-cli/generate-macos.js
@@ -6,7 +6,7 @@ const {
   copyProjectTemplateAndReplace,
   installDependencies,
   installPods,
-  printFinishMessage
+  printFinishMessage,
 } = require('./generator-macos');
 
 /**

--- a/local-cli/generate-macos.js
+++ b/local-cli/generate-macos.js
@@ -5,7 +5,9 @@ const path = require('path');
 const {
   copyProjectTemplateAndReplace,
   installDependencies,
- } = require('./generator-macos');
+  installPods,
+  printFinishMessage
+} = require('./generator-macos');
 
 /**
  * Simple utility for running the macOS generator.
@@ -27,6 +29,10 @@ function generateMacOS (projectDir, name, options) {
     name,
     { overwrite: options.overwrite }
   );
+
+  installPods(options);
+
+  printFinishMessage(name);
 }
 
 module.exports = generateMacOS;

--- a/local-cli/generator-macos/index.js
+++ b/local-cli/generator-macos/index.js
@@ -66,16 +66,6 @@ function copyProjectTemplateAndReplace(
   [
     { from: path.join(srcRootPath, 'metro.config.macos.js'), to: 'metro.config.macos.js' },
   ].forEach((mapping) => copyAndReplaceWithChangedCallback(mapping.from, destPath, mapping.to, templateVars, options.overwrite));
-
-  console.log(`
-  ${chalk.blue(`Run instructions for ${chalk.bold('macOS')}`)}:
-    • cd macos && pod install && cd ..
-    • npx react-native run-macos
-    ${chalk.dim('- or -')}
-    • Open ${xcworkspacePath(newProjectName)} in Xcode or run "xed -b ${macOSDir}"
-    • yarn start:macos
-    • Hit the Run button
-`);
 }
 
 /**
@@ -153,7 +143,26 @@ function installDependencies(options) {
   childProcess.execSync(isYarn ? 'yarn' : 'npm i', execOptions);
 }
 
+function installPods(options) {
+  const cwd = path.join(process.cwd(), macOSDir);
+  const quietFlag = options && options.verbose ? '' : '--quiet';
+  childProcess.execSync(`npx pod-install --non-interactive ${quietFlag}`, { stdio: 'inherit', cwd });
+}
+
+function printFinishMessage(newProjectName) {
+  console.log(`
+  ${chalk.blue(`Run instructions for ${chalk.bold('macOS')}`)}:
+    • npx react-native run-macos
+    ${chalk.dim('- or -')}
+    • Open ${xcworkspacePath(newProjectName)} in Xcode or run "xed -b ${macOSDir}"
+    • yarn start:macos
+    • Hit the Run button
+`);
+}
+
 module.exports = {
   copyProjectTemplateAndReplace,
   installDependencies,
+  installPods,
+  printFinishMessage
 };

--- a/local-cli/generator-macos/index.js
+++ b/local-cli/generator-macos/index.js
@@ -164,5 +164,5 @@ module.exports = {
   copyProjectTemplateAndReplace,
   installDependencies,
   installPods,
-  printFinishMessage
+  printFinishMessage,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [X] I am making a fix / change for the macOS implementation of react-native

## Summary

Fixes #306, #362

This PR adds automatic `pod` installation (but utilizing `pod-install` package from the Expo) to the `react-native-macos-init` NPX script. 

Unfortunately due to `react-native-config.js` content duplication issue `pod` installation will only work correctly when `react-native-macos-init` was executed in the project without `react-native-config.js` file.

Because of the issue above and not 100% clean testing procedures I suggest that this PR should be reviewed on the few machines before the merge.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[macOS] [Added] - automatically install and link Pods on macOS init

## Test Plan

I have tested those changes locally by linking working copy of the `react-native-macos-init` package in the test macOS app.

## Preview

Expected end of the successful output:

<img width="1035" alt="Screenshot 2020-05-15 at 21 07 22" src="https://user-images.githubusercontent.com/719641/82087287-195c0580-96f0-11ea-8f34-02367d922d44.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/366)