### PR TITLE
feat(react-native-macos-init): add pod folder to gitignore

### DIFF
--- a/local-cli/generator-macos/index.js
+++ b/local-cli/generator-macos/index.js
@@ -52,6 +52,7 @@ function copyProjectTemplateAndReplace(
 
   [
     { from: path.join(srcRootPath, macOSDir, 'Podfile'), to: path.join(macOSDir, 'Podfile') },
+    { from: path.join(srcRootPath, macOSDir, '_gitignore'), to: path.join(macOSDir, '.gitignore') },
     { from: path.join(srcRootPath, srcDirPath(oldProjectName, 'iOS')), to: srcDirPath(newProjectName, 'iOS') },
     { from: path.join(srcRootPath, srcDirPath(oldProjectName, 'macOS')), to: srcDirPath(newProjectName, 'macOS') },
     { from: path.join(srcRootPath, pbxprojPath(oldProjectName)), to: pbxprojPath(newProjectName) },

--- a/local-cli/generator-macos/templates/macos/_gitignore
+++ b/local-cli/generator-macos/templates/macos/_gitignore
@@ -1,0 +1,2 @@
+# CocoaPods
+Pods/

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -4,8 +4,7 @@
  *
  * @format
  */
-import * as path from 'path';
-import * as util from 'util';
+
 import * as yargs from 'yargs';
 import * as fs from 'fs';
 import * as semver from 'semver';
@@ -16,9 +15,6 @@ import * as findUp from 'find-up';
 import * as chalk from 'chalk';
 // @ts-ignore
 import * as Registry from 'npm-registry';
-
-const readFile = util.promisify(fs.readFile);
-const writeFile = util.promisify(fs.writeFile);
 
 const npmConfReg = execSync('npm config get registry')
   .toString()
@@ -44,7 +40,6 @@ const argv = yargs.version(false).options({
   },
 }).argv;
 
-const MACOS_POD = '/macos/Pods/';
 const EXITCODE_NO_MATCHING_RNMACOS = 2;
 const EXITCODE_UNSUPPORTED_VERION_RN = 3;
 const EXITCODE_USER_CANCEL = 4;
@@ -208,26 +203,6 @@ async function getLatestMatchingReactNativeMacOSVersion(
   }
 }
 
-async function updateGitIgnore(cwd: string) {
-  try {
-    const gitIgnorePath = path.join(cwd, '.gitignore');
-
-    const gitIgnore = await readFile(gitIgnorePath)
-      .then(buf => buf.toString())
-      .catch(() => null);
-
-    if (!gitIgnore || !gitIgnore.split('\n').includes(MACOS_POD)) {
-      await writeFile(
-        gitIgnorePath,
-        gitIgnore ? `${gitIgnore}\n${MACOS_POD}` : MACOS_POD,
-      );
-      console.log(chalk.green(`updated .gitignore for macos projects`));
-    }
-  } catch (error) {
-    // ignore non-critical error
-  }
-}
-
 /**
  * Check if project is using Yarn (has `yarn.lock` in the tree)
  */
@@ -314,9 +289,6 @@ You can either downgrade your version of ${chalk.green(
     console.log(
       chalk.green(`react-native-macos@${version} successfully installed.`),
     );
-
-    // update Gitignore
-    updateGitIgnore(process.cwd());
 
     const generateMacOS = require(reactNativeMacOSGeneratePath());
     generateMacOS(process.cwd(), name, {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

running `react-native-macos-init` in a react native project automatically runs pod install for macos, resulting a large diff.

I thought it would be nice if `react-native-macos-init` automatically adds `/macos/Pods` to `.gitignore` so the user does not need to worry about it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[macOS] [Added] - [init] Add macos Pod folder to .gitignore

## Test Plan
Tested running the cli locally to see that `/macos/Pods` was added to `.gitignore`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/369)