### PR TITLE
init cli improvements: check the current version of RNmacOS, other display tweaks

### DIFF
--- a/change/react-native-macos-init-2020-05-18-19-18-39-init-cli-improvements.json
+++ b/change/react-native-macos-init-2020-05-18-19-18-39-init-cli-improvements.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "check the currently installed version of RNmacOS + CLI display tweaks",
+  "packageName": "react-native-macos-init",
+  "email": "gosimek@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-18T17:18:39.367Z"
+}

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -297,11 +297,11 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
     if (reactNativeMacOSResolvedVersion !== reactNativeMacOSVersion) {
       console.log(`${reactNativeMacOSVersion ? 'Upgrading to' : 'Installing'} ${pkgLatest}…`);
 
-      const verbose = argv.verbose;
+      const { verbose } = argv;
       const pkgmgr = isProjectUsingYarn(process.cwd())
         ? `yarn add${verbose ? '' : ' -s'}`
         : `npm install --save${verbose ? '' : ' --silent'}`;
-      const execOptions = argv.verbose ? { stdio: 'inherit' as 'inherit' } : {};
+      const execOptions = verbose ? { stdio: 'inherit' as 'inherit' } : {};
       execSync(`${pkgmgr} "${MACOSPKG}@${version}"`, execOptions);
 
       console.log(`${pkgLatest} ${chalk.green('successfully installed!')}`);

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -75,7 +75,7 @@ function getReactNativeAppName() {
     }
   }
   if (!name) {
-    printError('Please specify name in package.json or app.json');
+    printError('Please specify name in package.json or app.json.');
   }
   return name;
 }
@@ -215,7 +215,7 @@ async function getLatestMatchingReactNativeMacOSVersion(
     return version;
   } catch (err) {
     printError(
-      `No version of ${MACOSPKG}@${versionSemVer} found!`,
+      `No version of ${printPkg(MACOSPKG, versionSemVer)} found!`,
     );
     process.exit(EXITCODE_NO_MATCHING_RNMACOS);
     return "";
@@ -237,7 +237,7 @@ function printPkg(name: string, version?: string) {
 }
 
 /**
- * Prints decorated version of console.error the CLI
+ * Prints decorated version of console.error to the CLI
  */
 function printError(message: string, ...optionalParams: any[]) {
   return console.error(chalk.red(chalk.bold(message)), ...optionalParams);

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -61,7 +61,7 @@ function getReactNativeAppName() {
   const cwd = process.cwd();
   const pkgJsonPath = findUp.sync('package.json', {cwd});
   if (!pkgJsonPath) {
-    console.error(
+    printError(
       `Unable to find package.json. This should be run from within an existing ${RNPKG} app.`,
     );
     process.exit(EXITCODE_NO_PACKAGE_JSON);
@@ -75,7 +75,7 @@ function getReactNativeAppName() {
     }
   }
   if (!name) {
-    console.error('Please specify name in package.json or app.json');
+    printError('Please specify name in package.json or app.json');
   }
   return name;
 }
@@ -95,7 +95,7 @@ function getPackageVersion(
     }
   } catch (error) {
     if (exitOnError) {
-      console.error(
+      printError(
         `Must be run from a project that already depends on ${packageName}, and has ${packageName} installed.`,
       );
       process.exit(EXITCODE_NO_REACTNATIVE_FOUND);
@@ -112,7 +112,7 @@ function getReactNativeMacOSVersion() {
 }
 
 function errorOutOnUnsupportedVersionOfReactNative(rnVersion: string) {
-  console.error(`Unsupported version of ${RNPKG}: ${chalk.cyan(
+  printError(`Unsupported version of ${RNPKG}: ${chalk.cyan(
     rnVersion,
   )}
 ${MACOSPKG} supports ${RNPKG} versions ${chalk.cyan('>=0.60')}`);
@@ -214,7 +214,7 @@ async function getLatestMatchingReactNativeMacOSVersion(
     );
     return version;
   } catch (err) {
-    console.error(
+    printError(
       `No version of ${MACOSPKG}@${versionSemVer} found!`,
     );
     process.exit(EXITCODE_NO_MATCHING_RNMACOS);
@@ -234,6 +234,13 @@ function isProjectUsingYarn(cwd: string) {
  */
 function printPkg(name: string, version?: string) {
   return `${chalk.yellow(name)}${version ? `${chalk.grey('@')}${chalk.cyan(version)}` : ''}`;
+}
+
+/**
+ * Prints decorated version of console.error the CLI
+ */
+function printError(message: string, ...optionalParams: any[]) {
+  return console.error(chalk.red(chalk.bold(message)), ...optionalParams);
 }
 
 (async () => {
@@ -315,8 +322,7 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
       verbose: argv.verbose,
     });
   } catch (error) {
-    console.error(chalk.red(error.message));
-    console.error(error);
+    printError(error.message, error);
     process.exit(EXITCODE_UNKNOWN_ERROR);
   }
 })();

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -240,14 +240,15 @@ function printPkg(name: string, version?: string) {
  * Prints decorated version of console.error to the CLI
  */
 function printError(message: string, ...optionalParams: any[]) {
-  return console.error(chalk.red(chalk.bold(message)), ...optionalParams);
+  console.error(chalk.red(chalk.bold(message)), ...optionalParams);
 }
 
 (async () => {
   try {
-    const name = getReactNativeAppName();
+    const { overwrite, verbose } = argv;
     let version = argv.version;
 
+    const name = getReactNativeAppName();
     const reactNativeVersion = getReactNativeVersion();
     const reactNativeMacOSVersion = getReactNativeMacOSVersion();
     const reactNativeMacOSLatestVersion = await getLatestMatchingReactNativeMacOSVersion('latest');
@@ -304,7 +305,6 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
     if (reactNativeMacOSResolvedVersion !== reactNativeMacOSVersion) {
       console.log(`${reactNativeMacOSVersion ? 'Upgrading to' : 'Installing'} ${pkgLatest}…`);
 
-      const { verbose } = argv;
       const pkgmgr = isProjectUsingYarn(process.cwd())
         ? `yarn add${verbose ? '' : ' -s'}`
         : `npm install --save${verbose ? '' : ' --silent'}`;
@@ -318,8 +318,8 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
 
     const generateMacOS = require(reactNativeMacOSGeneratePath());
     generateMacOS(process.cwd(), name, {
-      overwrite: argv.overwrite,
-      verbose: argv.verbose,
+      overwrite,
+      verbose,
     });
   } catch (error) {
     printError(error.message, error);


### PR DESCRIPTION
#### Please select one of the following
- [x] I am making a fix / change for the macOS implementation of react-native

## Summary

This PR introduces the following changes to the `react-native-macos-init` script:
* check the currently installed version of `react-native-macos`, skip installation if it is latest available version
* refactor `getReactNativeVersion` to the `getPackageVersion` (more generalised)
* utilize `verbose` flag in `react-native-macos` installation exec
* store package names in the constants
* update and simplify display aspect of the script (`printPkg` method for pretty-printing packages and other tweaks), update colors (this can be easily changed now): 
  * package name changed from the green to the yellow
  * `prerelease` warning uses yellow background instead yellow text
* `printError` function which prints decorated error messages (red + bold)
* punctuation marks in CLI messages, ellipsis instead of three dots (my code OCD 😉)

Since the changes above has not been request (and some of them apply only for those who are upgrading) I can understand if there will be a lot of review feedback and request for the changes but I'm happy to work further on those improvements and bring this PR to the more meaningful state. 

In the future PRs I want to adjust the display and processes inside `local-cli` too, for example changed file prompts (leave or replace). 

In a long term it will be nice if `react-native-macos-init` can also handle or at least help with the upgrading existing  project which already is using the RN macOS to the latest version.

## Changelog

[Internal] [Added] - [init] Check the currently installed version of `react-native-macos`, skip installation if it is latest
[Internal] [Changed] - [init] Utilize `verbose` flag in `react-native-macos` installation exec

## Test Plan

I have tested those changes locally by linking working copy of the `react-native-macos-init` package in the test macOS app.

## Preview

Successful init:
<img width="776" alt="Screenshot 2020-05-17 at 17 03 38" src="https://user-images.githubusercontent.com/719641/82152291-6bbc3400-9860-11ea-8bf2-9dc2b4eccec8.png">

Successful init (skip installation):
<img width="733" alt="Screenshot 2020-05-17 at 17 06 44" src="https://user-images.githubusercontent.com/719641/82152348-d40b1580-9860-11ea-86a4-dcb0354a8ff6.png">

Decorated errors:
<img width="504" alt="Screenshot 2020-05-17 at 16 40 34" src="https://user-images.githubusercontent.com/719641/82151740-598cc680-985d-11ea-8147-41a31c113eb0.png">
<img width="504" alt="Screenshot 2020-05-17 at 16 50 08" src="https://user-images.githubusercontent.com/719641/82152003-dec4ab00-985e-11ea-9bee-5f3456bbdbaa.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/370)