### PR TITLE
local-cli: quiet npx messages before pod-install

### DIFF
--- a/local-cli/generator-macos/index.js
+++ b/local-cli/generator-macos/index.js
@@ -143,12 +143,18 @@ function installDependencies(options) {
   childProcess.execSync(isYarn ? 'yarn' : 'npm i', execOptions);
 }
 
+/**
+ * @param {{ verbose?: boolean }=} options
+ */
 function installPods(options) {
   const cwd = path.join(process.cwd(), macOSDir);
   const quietFlag = options && options.verbose ? '' : '--quiet';
-  childProcess.execSync(`npx pod-install --non-interactive ${quietFlag}`, { stdio: 'inherit', cwd });
+  childProcess.execSync(`npx ${quietFlag} pod-install --non-interactive ${quietFlag}`, { stdio: 'inherit', cwd });
 }
 
+/**
+ * @param {string} newProjectName
+ */
 function printFinishMessage(newProjectName) {
   console.log(`
   ${chalk.blue(`Run instructions for ${chalk.bold('macOS')}`)}:


### PR DESCRIPTION
#### Please select one of the following
- [X] I am making a fix / change for the macOS implementation of react-native

## Summary

Refs #366 

This small PR adds `--quiet` flag also for the `npx` [itself](https://www.npmjs.com/package/npx#description) to get rid of the installation message in non verbose run. 

This changeset also includes missing `@param` annotations for the extracted and added methods in the referenced PR.

## Changelog

[Internal] [Changed] - `react-native-macos-init`: pass `verbose` flag also to `npx`

## Test Plan

I have tested those changes locally by linking working copy of the `react-native-macos` package in the test macOS app.

## Preview
### Before
<img width="733" alt="Screenshot 2020-05-17 at 17 06 44" src="https://user-images.githubusercontent.com/719641/82152348-d40b1580-9860-11ea-86a4-dcb0354a8ff6.png">

### After
<img width="722" alt="Screenshot 2020-05-18 at 21 32 36" src="https://user-images.githubusercontent.com/719641/82252328-1c086600-994f-11ea-9a8d-58fb48febbb0.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/373)