### PR TITLE
CI: remove 'Install pods' step since Pods are installed by init

### DIFF
--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -92,12 +92,6 @@ steps:
       workingDirectory: $(Agent.BuildDirectory)/testcli
 
   - task: CmdLine@2
-    displayName: Install pods
-    inputs:
-      script: pod install
-      workingDirectory: $(Agent.BuildDirectory)/testcli/macos
-
-  - task: CmdLine@2
     displayName: Run macos
     inputs:
       script: npx react-native run-macos


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native
- [X] None of the above

## Summary

Since Pods are automatically installed during the `react-native-macos-init` (#366) the manual installation became redundant, so the CI step 'Install pods' can be removed.

## Changelog

[Internal] [Removed] - CI: remove 'Install pods' step from `react-native-macos-init` template

## Test Plan

Run the CI!


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/375)