### PR TITLE
set autorecalculatesKeyView to YES in the init template

### DIFF
--- a/local-cli/generator-macos/templates/macos/HelloWorld-macOS/Base.lproj/Main.storyboard
+++ b/local-cli/generator-macos/templates/macos/HelloWorld-macOS/Base.lproj/Main.storyboard
@@ -683,7 +683,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="HelloWorld" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="HelloWorld" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fixes #376 

This small PR changes value of `autorecalculatesKeyView` inside the `init` template from `NO` to `YES` as requested in referenced issue (similar way to RNTester).

## Changelog

[Internal] [Changed] - set correct `autorecalculatesKeyView` property in the init template storyboard

## Test Plan

The `Main.storyboard` in the test project generated form the local, working copy of RNmacOS had a correct value of `autorecalculatesKeyView`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/377)