### PR TITLE
RNTester: fix TesterBlock description color in DarkMode

### DIFF
--- a/RNTester/js/components/RNTesterBlock.js
+++ b/RNTester/js/components/RNTesterBlock.js
@@ -103,6 +103,15 @@ const styles = StyleSheet.create({
   },
   descriptionText: {
     fontSize: 14,
+    ...Platform.select({
+      macos: {
+        color: {semantic: 'secondaryLabelColor'},
+      },
+      ios: {
+        color: {semantic: 'secondaryLabelColor'},
+      },
+      default: undefined,
+    }),
   },
   children: {
     margin: 10,


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
This small PR makes the descriptions of the TesterBlock component in the RNTesters readable on macOS in the DarkMode.

I have check the content of this file in the RN core package, but it seems that there is a different  DarkMode implementation based on the ThemeContext.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Changed] - RNTester: ensure that description is readable in DarkMode too

## Test Plan

Locally run of RNTester app.

## Preview
### Before

<img width="691" alt="Screenshot 2020-05-19 at 19 33 41" src="https://user-images.githubusercontent.com/719641/82360404-9a294300-9a09-11ea-91ce-ed4c9a484353.png">

### After
<img width="691" alt="Screenshot 2020-05-19 at 19 33 19" src="https://user-images.githubusercontent.com/719641/82360387-93023500-9a09-11ea-8eac-219eed625f38.png">

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/378)