### PR TITLE
fix Picker text color in DarkMode, tweak text size

### DIFF
--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -24,11 +24,11 @@
 {
   if ((self = [super initWithFrame:frame])) {
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
-    _font = [UIFont systemFontOfSize:21]; // TODO: selected title default should be 23.5
     _color = [RCTUIColor blackColor]; // TODO(OSS Candidate ISS#2710739)
+    _font = [UIFont systemFontOfSize:21]; // TODO: selected title default should be 23.5
 #else // [TODO(macOS ISS#2323203)
-    _font = [UIFont systemFontOfSize:13];
-    _color = [RCTUIColor labelColor];
+    _color = [NSColor labelColor];
+    _font = [NSFont systemFontOfSize:[NSFont systemFontSize]];
 #endif // ]TODO(macOS ISS#2323203)
     _selectedIndex = NSNotFound;
     _textAlign = NSTextAlignmentCenter;

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -23,16 +23,17 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if ((self = [super initWithFrame:frame])) {
-    _color = [RCTUIColor blackColor]; // TODO(OSS Candidate ISS#2710739)
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
     _font = [UIFont systemFontOfSize:21]; // TODO: selected title default should be 23.5
+    _color = [RCTUIColor blackColor]; // TODO(OSS Candidate ISS#2710739)
 #else // [TODO(macOS ISS#2323203)
-    _font = [UIFont systemFontOfSize:11];
+    _font = [UIFont systemFontOfSize:13];
+    _color = [RCTUIColor labelColor];
 #endif // ]TODO(macOS ISS#2323203)
     _selectedIndex = NSNotFound;
     _textAlign = NSTextAlignmentCenter;
     self.delegate = self;
-    
+
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
     self.controlSize = NSControlSizeRegular;
     self.editable = NO;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This small PR fixes the default Picker text and items color in DarkMode and changes the text size to match default styling on macOS.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[macOS] [Fixed] - Picker: fix default text color in DarkMode, adjust default text size

## Test Plan

All the changes has been tested in the RNTester build from local working copy.

## Preview
### Before
<img width="132" alt="Screenshot 2020-05-20 at 14 04 22" src="https://user-images.githubusercontent.com/719641/82444403-7adef400-9aa3-11ea-8a45-9469e33aaae6.png">

### After
<img width="132" alt="Screenshot 2020-05-20 at 14 02 44" src="https://user-images.githubusercontent.com/719641/82444418-816d6b80-9aa3-11ea-84cf-155e3677eb5f.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/401)