### PR TITLE
fix default Text color in DarkMode

### DIFF
--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -95,27 +95,27 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
         alignment = NSTextAlignmentRight;
       }
     }
-
+    
     paragraphStyle.alignment = alignment;
     isParagraphStyleUsed = YES;
   }
-
+  
   if (_baseWritingDirection != NSWritingDirectionNatural) {
     paragraphStyle.baseWritingDirection = _baseWritingDirection;
     isParagraphStyleUsed = YES;
   }
-
+  
   if (!isnan(_lineHeight)) {
     CGFloat lineHeight = _lineHeight * self.effectiveFontSizeMultiplier;
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
     isParagraphStyleUsed = YES;
   }
-
+  
   if (isParagraphStyleUsed) {
     return [paragraphStyle copy];
   }
-
+  
   return nil;
 }
 
@@ -133,13 +133,13 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   // Colors
   RCTUIColor *effectiveForegroundColor = self.effectiveForegroundColor; // TODO(OSS Candidate ISS#2710739)
 
-#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
+#if !TARGET_OS_OSX // [TODO(macOS ISS#2323203)
   if (_foregroundColor || !isnan(_opacity)) {
     attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
   }
 #else
   attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
-#endif // TODO(macOS ISS#2323203)
+#endif // ]TODO(macOS ISS#2323203)
 
   if (_backgroundColor || !isnan(_opacity)) {
     attributes[NSBackgroundColorAttributeName] = self.effectiveBackgroundColor;

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -133,13 +133,9 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   // Colors
   RCTUIColor *effectiveForegroundColor = self.effectiveForegroundColor; // TODO(OSS Candidate ISS#2710739)
 
-#if !TARGET_OS_OSX // [TODO(macOS ISS#2323203)
   if (_foregroundColor || !isnan(_opacity)) {
     attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
   }
-#else
-  attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
-#endif // ]TODO(macOS ISS#2323203)
 
   if (_backgroundColor || !isnan(_opacity)) {
     attributes[NSBackgroundColorAttributeName] = self.effectiveBackgroundColor;
@@ -229,7 +225,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
 
 - (RCTUIColor *)effectiveForegroundColor // TODO(OSS Candidate ISS#2710739)
 {
-  RCTUIColor *effectiveForegroundColor = _foregroundColor ?: [RCTUIColor labelColor]; // TODO(OSS Candidate ISS#2710739)
+  RCTUIColor *effectiveForegroundColor = _foregroundColor ?: [RCTUIColor blackColor]; // TODO(OSS Candidate ISS#2710739)
 
   if (!isnan(_opacity)) {
     effectiveForegroundColor = [effectiveForegroundColor colorWithAlphaComponent:CGColorGetAlpha(effectiveForegroundColor.CGColor) * _opacity];

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -95,27 +95,27 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
         alignment = NSTextAlignmentRight;
       }
     }
-    
+
     paragraphStyle.alignment = alignment;
     isParagraphStyleUsed = YES;
   }
-  
+
   if (_baseWritingDirection != NSWritingDirectionNatural) {
     paragraphStyle.baseWritingDirection = _baseWritingDirection;
     isParagraphStyleUsed = YES;
   }
-  
+
   if (!isnan(_lineHeight)) {
     CGFloat lineHeight = _lineHeight * self.effectiveFontSizeMultiplier;
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
     isParagraphStyleUsed = YES;
   }
-  
+
   if (isParagraphStyleUsed) {
     return [paragraphStyle copy];
   }
-  
+
   return nil;
 }
 
@@ -133,9 +133,13 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   // Colors
   RCTUIColor *effectiveForegroundColor = self.effectiveForegroundColor; // TODO(OSS Candidate ISS#2710739)
 
+#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
   if (_foregroundColor || !isnan(_opacity)) {
     attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
   }
+#else
+  attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
+#endif // TODO(macOS ISS#2323203)
 
   if (_backgroundColor || !isnan(_opacity)) {
     attributes[NSBackgroundColorAttributeName] = self.effectiveBackgroundColor;
@@ -225,7 +229,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
 
 - (RCTUIColor *)effectiveForegroundColor // TODO(OSS Candidate ISS#2710739)
 {
-  RCTUIColor *effectiveForegroundColor = _foregroundColor ?: [RCTUIColor blackColor]; // TODO(OSS Candidate ISS#2710739)
+  RCTUIColor *effectiveForegroundColor = _foregroundColor ?: [RCTUIColor labelColor]; // TODO(OSS Candidate ISS#2710739)
 
   if (!isnan(_opacity)) {
     effectiveForegroundColor = [effectiveForegroundColor colorWithAlphaComponent:CGColorGetAlpha(effectiveForegroundColor.CGColor) * _opacity];

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -16,6 +16,7 @@ const ReactNativeViewAttributes = require('../Components/View/ReactNativeViewAtt
 const TextAncestor = require('./TextAncestor');
 const Touchable = require('../Components/Touchable/Touchable');
 const UIManager = require('../ReactNative/UIManager');
+const Platform = require('../Utilities/Platform');
 
 const createReactNativeComponentClass = require('../Renderer/shims/createReactNativeComponentClass');
 const nullthrows = require('nullthrows');
@@ -139,6 +140,12 @@ class TouchableText extends React.Component<Props, State> {
       props = {
         ...props,
         selectionColor: processColor(props.selectionColor),
+      };
+    }
+    if (Platform.OS === 'macos' && !props?.style?.color) {
+      props = {
+        ...props,
+        style: [props.style, {color: {semantic: 'labelColor'}}],
       };
     }
     if (__DEV__) {

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -142,7 +142,10 @@ class TouchableText extends React.Component<Props, State> {
         selectionColor: processColor(props.selectionColor),
       };
     }
-    if (Platform.OS === 'macos' && !props?.style?.color) {
+    if (
+      Platform.OS === 'macos' &&
+      (!props.style || (props.style && !props.style.color))
+    ) {
       props = {
         ...props,
         style: [props.style, {color: {semantic: 'labelColor'}}],

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -148,7 +148,7 @@ class TouchableText extends React.Component<Props, State> {
     ) {
       props = {
         ...props,
-        style: [props.style, {color: {semantic: 'labelColor'}}],
+        style: [{color: {semantic: 'labelColor'}}, props.style],
       };
     }
     if (__DEV__) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This small change fixes the default Text color in DarkMode. To ensure that correct color is always applied I had to remove the check which was an optimisation for other platforms and I have wrapped the whole block with `TARGET_OS_OSX`. I'm not sure if it's a correct approach, feel free to correct me.

Also it seems that my IDE has made a whitespace cleanup on commit. I hope this is not a problem.

This change also introduced a few display issues in RNTester. I'm working on the separate PR which will fix those issues.

## Changelog

[macOS] [Fixed] - Text: fix default color in Dark Mode

## Test Plan

All the changes has been tested in the RNTester build from local working copy.

## Preview

![May-20-2020 14-37-31](https://user-images.githubusercontent.com/719641/82449083-f55f4200-9aaa-11ea-9aef-af344a2de439.gif)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/402)