### PR TITLE
fix RNTester display issues after adjusting default Text color

### DIFF
--- a/RNTester/js/components/ListExampleShared.js
+++ b/RNTester/js/components/ListExampleShared.js
@@ -286,7 +286,7 @@ const styles = StyleSheet.create({
     backgroundColor: Platform.select({
       macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
       default: 'rgb(239, 239, 244)',
-    })
+    }),
   },
   listEmpty: {
     alignItems: 'center',
@@ -315,7 +315,7 @@ const styles = StyleSheet.create({
     backgroundColor: Platform.select({
       macos: {semantic: 'textBackgroundColor'}, // TODO(macOS ISS#2323203)
       default: 'white',
-    })
+    }),
   },
   selectedRow: {
     // [TODO(macOS ISS#2323203)

--- a/RNTester/js/components/ListExampleShared.js
+++ b/RNTester/js/components/ListExampleShared.js
@@ -283,7 +283,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   headerFooterContainer: {
-    backgroundColor: 'rgb(239, 239, 244)',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: 'rgb(239, 239, 244)',
+    })
   },
   listEmpty: {
     alignItems: 'center',
@@ -309,7 +312,10 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     padding: 10,
-    backgroundColor: 'white',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'textBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: 'white',
+    })
   },
   selectedRow: {
     // [TODO(macOS ISS#2323203)
@@ -353,7 +359,10 @@ const styles = StyleSheet.create({
   }),
   stacked: {
     alignItems: 'center',
-    backgroundColor: 'white',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'textBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: 'white',
+    }),
     padding: 10,
   },
   thumb: {

--- a/RNTester/js/components/RNTesterTitle.js
+++ b/RNTester/js/components/RNTesterTitle.js
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
     padding: 10,
     backgroundColor: Platform.select({
       macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
-      default: '#fff',
+      default: 'white',
     }),
   },
   text: {

--- a/RNTester/js/components/RNTesterTitle.js
+++ b/RNTester/js/components/RNTesterTitle.js
@@ -33,7 +33,10 @@ const styles = StyleSheet.create({
     marginBottom: 0,
     height: 45,
     padding: 10,
-    backgroundColor: 'white',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#fff',
+    }),
   },
   text: {
     fontSize: 19,

--- a/RNTester/js/components/RNTesterTitle.js
+++ b/RNTester/js/components/RNTesterTitle.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 
-const {StyleSheet, Text, View} = require('react-native');
+const {Platform, StyleSheet, Text, View} = require('react-native');
 
 class RNTesterTitle extends React.Component<$FlowFixMeProps> {
   render(): React.Node {

--- a/RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -61,7 +61,10 @@ const styles = StyleSheet.create({
     padding: 8,
   },
   gray: {
-    backgroundColor: '#cccccc',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'underPageBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#ccc',
+    }),
   },
   horizontal: {
     flexDirection: 'row',

--- a/RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
   gray: {
     backgroundColor: Platform.select({
       macos: {semantic: 'underPageBackgroundColor'}, // TODO(macOS ISS#2323203)
-      default: '#ccc',
+      default: '#cccccc',
     }),
   },
   horizontal: {

--- a/RNTester/js/examples/Alert/AlertExample.js
+++ b/RNTester/js/examples/Alert/AlertExample.js
@@ -12,6 +12,7 @@
 const React = require('react');
 const {
   Alert,
+  Platform,
   StyleSheet,
   Text,
   TouchableHighlight,

--- a/RNTester/js/examples/Alert/AlertExample.js
+++ b/RNTester/js/examples/Alert/AlertExample.js
@@ -150,7 +150,7 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: Platform.select({
       macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
-      default: '#eee',
+      default: '#eeeeee',
     }),
     padding: 10,
   },

--- a/RNTester/js/examples/Alert/AlertExample.js
+++ b/RNTester/js/examples/Alert/AlertExample.js
@@ -147,7 +147,10 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
   button: {
-    backgroundColor: '#eeeeee',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#eee',
+    }),
     padding: 10,
   },
 });

--- a/RNTester/js/examples/Alert/AlertIOSExample.js
+++ b/RNTester/js/examples/Alert/AlertIOSExample.js
@@ -143,7 +143,7 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: Platform.select({
       macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
-      default: '#eee',
+      default: '#eeeeee',
     }),
     padding: 10,
   },

--- a/RNTester/js/examples/Alert/AlertIOSExample.js
+++ b/RNTester/js/examples/Alert/AlertIOSExample.js
@@ -140,7 +140,10 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
   button: {
-    backgroundColor: '#eeeeee',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#eee',
+    }),
     padding: 10,
   },
   promptValue: {

--- a/RNTester/js/examples/Alert/AlertIOSExample.js
+++ b/RNTester/js/examples/Alert/AlertIOSExample.js
@@ -14,6 +14,7 @@ const React = require('react');
 
 const {SimpleAlertExampleBlock} = require('./AlertExample');
 const {
+  Platform,
   StyleSheet,
   View,
   Text,

--- a/RNTester/js/examples/Alert/AlertMacOSExample.js
+++ b/RNTester/js/examples/Alert/AlertMacOSExample.js
@@ -258,7 +258,7 @@ var styles = StyleSheet.create({
     marginBottom: 5,
   },
   button: {
-    backgroundColor: '#eeeeee',
+    backgroundColor: {semantic: 'controlBackgroundColor'},
     padding: 10,
   },
 });

--- a/RNTester/js/examples/DatePicker/DatePickerMacOSExample.js
+++ b/RNTester/js/examples/DatePicker/DatePickerMacOSExample.js
@@ -170,7 +170,7 @@ var styles = StyleSheet.create({
   },
   headingContainer: {
     padding: 4,
-    backgroundColor: '#f6f7f8',
+    backgroundColor: {semantic: 'controlBackgroundColor'},
   },
   heading: {
     fontWeight: '500',

--- a/RNTester/js/examples/FlatList/FlatListExample.js
+++ b/RNTester/js/examples/FlatList/FlatListExample.js
@@ -29,7 +29,7 @@ const {
   pressItem,
   renderSmallSwitchOption,
 } = require('../../components/ListExampleShared');
-const {Alert, Animated, StyleSheet, View} = require('react-native');
+const {Alert, Animated, Platform, StyleSheet, View} = require('react-native');
 
 import type {Item} from '../../components/ListExampleShared';
 

--- a/RNTester/js/examples/FlatList/FlatListExample.js
+++ b/RNTester/js/examples/FlatList/FlatListExample.js
@@ -239,7 +239,10 @@ class FlatListExample extends React.PureComponent<Props, State> {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: 'rgb(239, 239, 244)',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'windowBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: 'rgb(239, 239, 244)',
+    }),
     flex: 1,
   },
   list: {

--- a/RNTester/js/examples/ScrollView/ScrollViewExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewExample.js
@@ -316,7 +316,10 @@ const Button = ({label, onPress}) => (
 
 const styles = StyleSheet.create({
   scrollView: {
-    backgroundColor: '#eeeeee',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'windowBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#eee',
+    }),
     height: 300,
   },
   horizontalScrollView: {
@@ -341,7 +344,10 @@ const styles = StyleSheet.create({
   item: {
     margin: 5,
     padding: 5,
-    backgroundColor: '#cccccc',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'windowBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#ccc',
+    }),
     borderRadius: 3,
     minWidth: 96,
   },

--- a/RNTester/js/examples/ScrollView/ScrollViewExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewExample.js
@@ -318,7 +318,7 @@ const styles = StyleSheet.create({
   scrollView: {
     backgroundColor: Platform.select({
       macos: {semantic: 'windowBackgroundColor'}, // TODO(macOS ISS#2323203)
-      default: '#eee',
+      default: '#eeeeee',
     }),
     height: 300,
   },
@@ -346,7 +346,7 @@ const styles = StyleSheet.create({
     padding: 5,
     backgroundColor: Platform.select({
       macos: {semantic: 'windowBackgroundColor'}, // TODO(macOS ISS#2323203)
-      default: '#ccc',
+      default: '#cccccc',
     }),
     borderRadius: 3,
     minWidth: 96,

--- a/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -13,6 +13,7 @@
 const React = require('react');
 
 const {
+  Platform,
   ScrollView,
   StyleSheet,
   Text,

--- a/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -78,7 +78,10 @@ const styles = StyleSheet.create({
     margin: 10,
   },
   itemWrapper: {
-    backgroundColor: '#dddddd',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'windowBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#ddd',
+    }),
     alignItems: 'center',
     borderRadius: 5,
     borderWidth: 5,

--- a/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
   itemWrapper: {
     backgroundColor: Platform.select({
       macos: {semantic: 'windowBackgroundColor'}, // TODO(macOS ISS#2323203)
-      default: '#ddd',
+      default: '#dddddd',
     }),
     alignItems: 'center',
     borderRadius: 5,

--- a/RNTester/js/examples/Touchable/TouchableExample.js
+++ b/RNTester/js/examples/Touchable/TouchableExample.js
@@ -540,7 +540,10 @@ const styles = StyleSheet.create({
     margin: 10,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: '#f0f0f0',
-    backgroundColor: '#f9f9f9',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#f9f9f9',
+    }),
   },
   eventLogBox: {
     padding: 10,
@@ -548,14 +551,20 @@ const styles = StyleSheet.create({
     height: 120,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: '#f0f0f0',
-    backgroundColor: '#f9f9f9',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#f9f9f9',
+    }),
   },
   forceTouchBox: {
     padding: 10,
     margin: 10,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: '#f0f0f0',
-    backgroundColor: '#f9f9f9',
+    backgroundColor: Platform.select({
+      macos: {semantic: 'controlBackgroundColor'}, // TODO(macOS ISS#2323203)
+      default: '#f9f9f9',
+    }),
     alignItems: 'center',
   },
   textBlock: {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Refs #402 

This PR is a follow up for the PR mentioned above. 

Adjusting the default Text color based on the current mode/appearance caused some display issues in the RNTester app. Changes included in this PR fixes bunch of those display issues (at least the most annoying ones, but at least few minor ones left).

I have also skipped `Platform` API and the TODO ref comment in the macOS specific components. If it is a wrong approach let me know, I would updated the code.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - RNTester: adjust the app UI after Text default color changes

## Test Plan

All the changes has been tested in the RNTester build from local working copy.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/403)