### PR TITLE
adjust default color of the TextInput placeholder

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -89,8 +89,7 @@ static UIFont *defaultPlaceholderFont()
 
 static RCTUIColor *defaultPlaceholderTextColor()
 {
-  // Default placeholder color from UITextField.
-  return [RCTUIColor colorWithRed:0 green:0 blue:0.0980392 alpha:0.22];
+  return [NSColor placeholderTextColor];
 }
 
 #endif // ]TODO(macOS ISS#2323203)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This small PR replaces the static default color of `TextInput` placeholder with `systemPlaceholderColor` platform color. This change improves the `TextInput` appearance in Dark Mode. 

Since whole code block is inside macOS target conditional I have just replaced the value.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[macOS] [Fixed] - TextInput: fix default placeholder appearanace in DarkMode

## Test Plan

All the changes has been tested in the app generated form the init and build from the local working copy.

## Preview

#### Before
<img width="263" alt="Screenshot 2020-05-25 at 16 35 19" src="https://user-images.githubusercontent.com/719641/82822261-c7607000-9ea5-11ea-9afc-31a9316eb663.png">

<img width="263" alt="Screenshot 2020-05-25 at 16 36 09" src="https://user-images.githubusercontent.com/719641/82822319-df37f400-9ea5-11ea-8ea1-aac8958c8b11.png">


#### After
<img width="263" alt="Screenshot 2020-05-25 at 16 34 42" src="https://user-images.githubusercontent.com/719641/82822282-cd565100-9ea5-11ea-8038-8ba7801b3642.png">

<img width="263" alt="Screenshot 2020-05-25 at 16 37 22" src="https://user-images.githubusercontent.com/719641/82822434-11495600-9ea6-11ea-9628-d147f4d7a968.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/417)