### PR TITLE
Menu location fix

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -150,33 +150,23 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
     [menu addItem:item];
   }
   
-  NSPoint origin = NSZeroPoint;
-  NSEvent *event = nil;
   RCTPlatformView *view = nil;
   if (anchorViewTag) {
     view = [self.bridge.uiManager viewForReactTag:anchorViewTag];
-    event = [view.window currentEvent];
   }
-  NSView *superview = [view superview];
-  if (event && view) {
-    // On a macOS trackpad, soft taps are received as sysDefined event types. SysDefined event locations are relative to the screen so we have to convert those separately.
-    NSPoint eventLocationRelativeToWindow = NSZeroPoint;
-    CGPoint eventLocationInWindow = [event locationInWindow];
-    if ([event type] == NSEventTypeSystemDefined) { // light tap event relative to screen
-      eventLocationRelativeToWindow = [[view window] convertRectFromScreen:NSMakeRect(eventLocationInWindow.x, eventLocationInWindow.y, 0, 0)].origin;
-    } else { // full click events are relative to the window
-      eventLocationRelativeToWindow = eventLocationInWindow;
-    }
-    origin = [view convertPoint:eventLocationRelativeToWindow fromView:nil];
-  } else if (view) {
-    CGRect superviewFrame = [superview frame];
-    origin = NSMakePoint(NSMidX(superviewFrame), NSMidY(superviewFrame));
+  NSPoint location = CGPointZero;
+  if (view != nil) {
+    // Display under the anchorview
+    CGRect bounds = [view bounds];
+
+    CGFloat originX = [view userInterfaceLayoutDirection] == NSUserInterfaceLayoutDirectionRightToLeft ? NSMaxX(bounds) : NSMinX(bounds);
+    location = NSMakePoint(originX, NSMaxY(bounds));
   } else {
-    origin = [NSEvent mouseLocation];
+    // Display at mouse location if no anchorView provided
+    location = [NSEvent mouseLocation];
   }
-  
-  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:origin inView:superview];
-#endif // ]TODO(macOS ISS#2323203)
+  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:location inView:view];
+#endif // ]TODO(macOS ISS#2323203)  #endif // ]TODO(macOS ISS#2323203)
 }
 
 RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options


### PR DESCRIPTION
We can always just fallback to using the mouse location.

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This change was approved in master, but we need it in the 0.60-stable branch to get into repos depending on the 0.60-stable branch this month.

When launching a menu, if the manager fails to find an event associated with the view then it enters an invalid fallback scenario for where to display the menu. We shouldn't ever launch the menu in the middle of the view.

It's more correct to fallback to the mouse location, which mirrors the actual intent of the presenter.

There could be an issue here if an SDX puts a control that drops a big menu too low then we'd redbox and go off the screen. That would require more refactoring and probably some of the positioning logic from callouts. Let's wait until we actually find a reason to update that behavior.

## Test Plan

Enabled both the fallback scenario and the default scenario for test runs in an internal test app and RNTester. Both show menus where expected. With this removal of an erroneous fallback, we no longer can pop up menus in unexpected locations.

RNTester
- Launch a menu without an anchorView and see it appears at the mouse location
- Launch a menu with an anchorView and see it appears below the anchorView (left aligned)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/361)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/424)