### PR TITLE
Fix npm publish pipeline to only tag `latest` when publishing from master

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -45,10 +45,19 @@ jobs:
           script: node .ado/renamePackageToMac.js
 
       - task: Npm@1
-        displayName: "Publish react-native-macos to npmjs.org"
+        displayName: "Publish latest react-native-macos to npmjs.org"
         inputs:
           command: 'publish'
           publishEndpoint: 'npmjs'
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+      - task: Npm@1
+        displayName: "Publish stable react-native-macos to npmjs.org"
+        inputs:
+          command: 'custom'
+          customCommand: publish --tag $(Build.SourceBranchName)
+          publishEndpoint: 'npmjs'
+        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
This is a cherry-pick of the PR https://github.com/microsoft/react-native-macos/pull/426 which just landed in master applied to the `0.60-stable` branch.

## Changelog

[macOS] [Fixed] - Fix npm publish pipeline to only tag `latest` when publishing from master

## Test Plan

Publish works

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/427)