### PR TITLE
adjust RNTester examples list for macOS

### DIFF
--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -13,12 +13,6 @@
 const RNTesterActions = require('./utils/RNTesterActions');
 const RNTesterExampleContainer = require('./components/RNTesterExampleContainer');
 const RNTesterExampleList = require('./components/RNTesterExampleList');
-// [TODO(macOS ISS#2323203)
-const RNTesterList =
-  Platform.OS === 'macos'
-    ? require('./utils/RNTesterList.macos')
-    : require('./utils/RNTesterList.ios');
-// ]TODO(macOS ISS#2323203)
 const RNTesterNavigationReducer = require('./utils/RNTesterNavigationReducer');
 const React = require('react');
 const SnapshotViewIOS = require('./examples/Snapshot/SnapshotViewIOS.ios');
@@ -38,6 +32,14 @@ const {
   View,
   YellowBox,
 } = require('react-native');
+
+// [TODO(macOS ISS#2323203)
+const RNTesterList =
+  Platform.OS === 'macos'
+    ? /* $FlowFixMe allow iOS to list macOS file */
+      require('./utils/RNTesterList.macos')
+    : require('./utils/RNTesterList.ios');
+// ]TODO(macOS ISS#2323203)
 
 const {TestModule} = NativeModules; // TODO(OSS Candidate ISS#2710739)
 const requestAnimationFrame = require('fbjs/lib/requestAnimationFrame'); // TODO(OSS Candidate ISS#2710739)

--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -13,7 +13,12 @@
 const RNTesterActions = require('./utils/RNTesterActions');
 const RNTesterExampleContainer = require('./components/RNTesterExampleContainer');
 const RNTesterExampleList = require('./components/RNTesterExampleList');
-const RNTesterList = require('./utils/RNTesterList.ios');
+// [TODO(macOS ISS#2323203)
+const RNTesterList =
+  Platform.OS === 'macos'
+    ? require('./utils/RNTesterList.macos')
+    : require('./utils/RNTesterList.ios');
+// ]TODO(macOS ISS#2323203)
 const RNTesterNavigationReducer = require('./utils/RNTesterNavigationReducer');
 const React = require('react');
 const SnapshotViewIOS = require('./examples/Snapshot/SnapshotViewIOS.ios');

--- a/RNTester/js/utils/RNTesterList.ios.js
+++ b/RNTester/js/utils/RNTesterList.ios.js
@@ -39,12 +39,6 @@ const ComponentExamples: Array<RNTesterExample> = [
     module: require('../examples/DatePicker/DatePickerIOSExample'),
     supportsTVOS: false,
   },
-  // [TODO(macOS ISS#2323203)
-  {
-    key: 'DatePickerMacOSExample',
-    module: require('../examples/DatePicker/DatePickerMacOSExample'),
-    supportsTVOS: false,
-  }, // ]TODO(macOS ISS#2323203)
   {
     key: 'FlatListExample',
     module: require('../examples/FlatList/FlatListExample'),
@@ -220,12 +214,6 @@ const APIExamples: Array<RNTesterExample> = [
     module: require('../examples/Alert/AlertIOSExample'),
     supportsTVOS: true,
   },
-  // [TODO(macOS ISS#2323203)
-  {
-    key: 'AlertMacOSExample',
-    module: require('../examples/Alert/AlertMacOSExample'),
-    supportsTVOS: true,
-  }, // ]TODO(macOS ISS#2323203)
   {
     key: 'AnimatedExample',
     module: require('../examples/Animated/AnimatedExample'),

--- a/RNTester/js/utils/RNTesterList.macos.js
+++ b/RNTester/js/utils/RNTesterList.macos.js
@@ -13,43 +13,43 @@
 /* $FlowFixMe allow macOS to share iOS file */
 const RNTesterListIOS = require('./RNTesterList.ios.js');
 
-const AlertMacOSExample = {
-  key: 'AlertMacOSExample',
-  module: require('../examples/Alert/AlertMacOSExample'),
-};
+const APIExamples = [
+  ...RNTesterListIOS.APIExamples.filter(
+    ex =>
+      !ex.key.includes('IOS') &&
+      ex.key !== 'OrientationChangeExample' &&
+      ex.key !== 'TVEventHandlerExample' &&
+      ex.key !== 'VibrationExample',
+  ),
+  {
+    key: 'AlertMacOSExample',
+    module: require('../examples/Alert/AlertMacOSExample'),
+  },
+];
 
-const DatePickerMacOSExample = {
-  key: 'DatePickerMacOSExample',
-  module: require('../examples/DatePicker/DatePickerMacOSExample'),
-};
+const ComponentExamples = [
+  ...RNTesterListIOS.ComponentExamples.filter(
+    ex =>
+      !ex.key.includes('IOS') &&
+      ex.key !== 'InputAccessoryViewExample' &&
+      ex.key !== 'KeyboardAvoidingViewExample' &&
+      ex.key !== 'StatusBarExample',
+  ),
+  {
+    key: 'DatePickerMacOSExample',
+    module: require('../examples/DatePicker/DatePickerMacOSExample'),
+  },
+];
 
-const Modules = RNTesterListIOS.Modules;
+const Modules = {};
 
-[AlertMacOSExample, DatePickerMacOSExample].forEach(Example => {
+APIExamples.concat(ComponentExamples).forEach(Example => {
   Modules[Example.key] = Example.module;
 });
 
 const RNTesterList = {
-  APIExamples: [
-    ...RNTesterListIOS.APIExamples.filter(
-      ex =>
-        !ex.key.includes('IOS') &&
-        ex.key !== 'OrientationChangeExample' &&
-        ex.key !== 'TVEventHandlerExample' &&
-        ex.key !== 'VibrationExample',
-    ),
-    AlertMacOSExample,
-  ],
-  ComponentExamples: [
-    ...RNTesterListIOS.ComponentExamples.filter(
-      ex =>
-        !ex.key.includes('IOS') &&
-        ex.key !== 'InputAccessoryViewExample' &&
-        ex.key !== 'KeyboardAvoidingViewExample' &&
-        ex.key !== 'StatusBarExample',
-    ),
-    DatePickerMacOSExample,
-  ],
+  APIExamples,
+  ComponentExamples,
   Modules,
 };
 

--- a/RNTester/js/utils/RNTesterList.macos.js
+++ b/RNTester/js/utils/RNTesterList.macos.js
@@ -11,6 +11,46 @@
 // TODO(macOS ISS#2323203)
 
 /* $FlowFixMe allow macOS to share iOS file */
-const RNTesterList = require('./RNTesterList.ios.js');
+const RNTesterListIOS = require('./RNTesterList.ios.js');
+
+const AlertMacOSExample = {
+  key: 'AlertMacOSExample',
+  module: require('../examples/Alert/AlertMacOSExample'),
+};
+
+const DatePickerMacOSExample = {
+  key: 'DatePickerMacOSExample',
+  module: require('../examples/DatePicker/DatePickerMacOSExample'),
+};
+
+const Modules = RNTesterListIOS.Modules;
+
+[AlertMacOSExample, DatePickerMacOSExample].forEach(Example => {
+  Modules[Example.key] = Example.module;
+});
+
+const RNTesterList = {
+  APIExamples: [
+    ...RNTesterListIOS.APIExamples.filter(
+      ex =>
+        !ex.key.includes('IOS') &&
+        ex.key !== 'OrientationChangeExample' &&
+        ex.key !== 'TVEventHandlerExample' &&
+        ex.key !== 'VibrationExample',
+    ),
+    AlertMacOSExample,
+  ],
+  ComponentExamples: [
+    ...RNTesterListIOS.ComponentExamples.filter(
+      ex =>
+        !ex.key.includes('IOS') &&
+        ex.key !== 'InputAccessoryViewExample' &&
+        ex.key !== 'KeyboardAvoidingViewExample' &&
+        ex.key !== 'StatusBarExample',
+    ),
+    DatePickerMacOSExample,
+  ],
+  Modules,
+};
 
 module.exports = RNTesterList;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This PR introduces the following changes:
* introduces custom tests list for `macOS` in `RNTesterList.macos.js` file rather than returning the iOS one
* skips the examples that are `iOS` or mobile platform only
* moves the `macOS` only tests out of `iOS` test list (this should also fix at least one issue in e2e CI in #403 PR)

The initial list of disabled tests is very subjective, I'm happy to tweak or change it completely if needed.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Changed] - implement custom RNTester example list for macOS

## Test Plan

I have testes those changes using local copy of `react-native-macos` repository and RNTester build in from this source. ESLint, `yarn flow-check-ios` and `yarn flow-check-macos` checks has been successful. 

There is a probability that the CI fails so I'm going to investigate those errors too.

## Preview
![May-31-2020 17-13-34](https://user-images.githubusercontent.com/719641/83355842-333d4f80-a362-11ea-8323-5ebf36b13132.gif)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/430)