### PR TITLE
Fix publish on 0.60 branch

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -6,6 +6,7 @@ trigger: none # will disable CI builds entirely
 pr:
 - master
 - 0.59-stable
+- 0.60-stable
 
 jobs:
   - job: AndroidRNPR

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -9,6 +9,7 @@ trigger: none # will disable CI builds entirely
 pr:
 - master
 - 0.59-stable
+- 0.60-stable
 
 jobs:
   - job: JavaScriptRNPR

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -45,10 +45,19 @@ jobs:
           script: node .ado/renamePackageToMac.js
 
       - task: Npm@1
-        displayName: "Publish react-native-macos to npmjs.org"
+        displayName: "Publish latest react-native-macos to npmjs.org"
         inputs:
           command: 'publish'
           publishEndpoint: 'npmjs'
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+      - task: Npm@1
+        displayName: "Publish stable react-native-macos to npmjs.org"
+        inputs:
+          command: 'custom'
+          customCommand: publish --tag $(Build.SourceBranchName)
+          publishEndpoint: 'npmjs'
+        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -5,6 +5,7 @@ trigger:
   batch: true
   branches:
     include:
+      - 0.60-stable
       - master
       - fabric
   paths:
@@ -48,43 +49,6 @@ jobs:
         inputs:
           command: 'publish'
           publishEndpoint: 'npmjs'
-
-  - job: RNMacOSInitNpmJSPublish
-    displayName: react-native-macos-init Publish to npmjs.org
-    pool:
-      vmImage: vs2017-win2016
-    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
-    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-    steps:
-      - checkout: self # self represents the repo where the initial Pipelines YAML file was found
-        clean: true # whether to fetch clean each time
-        # fetchDepth: 2 # the depth of commits to ask Git to fetch
-        lfs: false # whether to download Git-LFS files
-        submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
-        persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
-
-      - template: templates/configure-git.yml
-
-      - task: CmdLine@2
-        displayName: yarn install
-        inputs:
-          script: |
-            cd packages/react-native-macos-init
-            yarn install
-
-      - task: CmdLine@2
-        displayName: yarn build
-        inputs:
-          script: |
-            cd packages/react-native-macos-init
-            yarn build
-
-      - task: CmdLine@2
-        displayName: "Publish react-native-macos-init to npmjs.org"
-        inputs:
-          script: |
-            cd packages/react-native-macos-init
-            npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --access public
 
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -51,6 +51,10 @@ jobs:
           publishEndpoint: 'npmjs'
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
+      # When using npm custom instead of npm publish, we need to ensure that auth still happens.
+      - task: npmAuthenticate@0
+        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+
       - task: Npm@1
         displayName: "Publish stable react-native-macos to npmjs.org"
         inputs:

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -150,33 +150,23 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
     [menu addItem:item];
   }
   
-  NSPoint origin = NSZeroPoint;
-  NSEvent *event = nil;
   RCTPlatformView *view = nil;
   if (anchorViewTag) {
     view = [self.bridge.uiManager viewForReactTag:anchorViewTag];
-    event = [view.window currentEvent];
   }
-  NSView *superview = [view superview];
-  if (event && view) {
-    // On a macOS trackpad, soft taps are received as sysDefined event types. SysDefined event locations are relative to the screen so we have to convert those separately.
-    NSPoint eventLocationRelativeToWindow = NSZeroPoint;
-    CGPoint eventLocationInWindow = [event locationInWindow];
-    if ([event type] == NSEventTypeSystemDefined) { // light tap event relative to screen
-      eventLocationRelativeToWindow = [[view window] convertRectFromScreen:NSMakeRect(eventLocationInWindow.x, eventLocationInWindow.y, 0, 0)].origin;
-    } else { // full click events are relative to the window
-      eventLocationRelativeToWindow = eventLocationInWindow;
-    }
-    origin = [view convertPoint:eventLocationRelativeToWindow fromView:nil];
-  } else if (view) {
-    CGRect superviewFrame = [superview frame];
-    origin = NSMakePoint(NSMidX(superviewFrame), NSMidY(superviewFrame));
+  NSPoint location = CGPointZero;
+  if (view != nil) {
+    // Display under the anchorview
+    CGRect bounds = [view bounds];
+
+    CGFloat originX = [view userInterfaceLayoutDirection] == NSUserInterfaceLayoutDirectionRightToLeft ? NSMaxX(bounds) : NSMinX(bounds);
+    location = NSMakePoint(originX, NSMaxY(bounds));
   } else {
-    origin = [NSEvent mouseLocation];
+    // Display at mouse location if no anchorView provided
+    location = [NSEvent mouseLocation];
   }
-  
-  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:origin inView:superview];
-#endif // ]TODO(macOS ISS#2323203)
+  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:location inView:view];
+#endif // ]TODO(macOS ISS#2323203)  #endif // ]TODO(macOS ISS#2323203)
 }
 
 RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.79",
+  "version": "0.60.0-microsoft.80",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.78",
+  "version": "0.60.0-microsoft.79",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.77",
+  "version": "0.60.0-microsoft.78",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {

--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/microsoft/react-native-macos",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "scripts": {
     "change": "beachball change",
     "check": "beachball check",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Need to properly authenticate to publish to npm

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/433)