### PR TITLE
Fix -[RCTDynamicColor effectiveColor] being called off UI thread

### DIFF
--- a/React/Base/macOS/RCTDynamicColor.m
+++ b/React/Base/macOS/RCTDynamicColor.m
@@ -61,9 +61,9 @@ static NSString *const RCTDarkAquaColor = @"darkAquaColor";
   NSColor *effectiveColor = _aquaColor;
   if (@available(macOS 10.14, *)) {
     NSAppearance *appearance = [NSAppearance currentAppearance] ?: [NSApp effectiveAppearance];
-    
+
     NSAppearanceName appearanceName = [appearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
-    
+
     if (_darkAquaColor != nil && [appearanceName isEqualToString:NSAppearanceNameDarkAqua]) {
       effectiveColor = _darkAquaColor;
     }
@@ -179,6 +179,39 @@ RCT_FORWARD_PROPERTY(localizedColorNameComponent, NSString *)
 - (NSColor *)colorWithSystemEffect:(NSColorSystemEffect)systemEffect NS_AVAILABLE_MAC(10_14)
 {
   return [[self effectiveColor] colorWithSystemEffect:systemEffect];
+}
+
+- (NSUInteger)hash
+{
+  const NSUInteger prime = 31;
+  NSUInteger result = 1;
+  result = prime * result + [_aquaColor hash];
+  result = prime * result + [_darkAquaColor hash];
+  return result;
+}
+
+- (BOOL)isEqual:(id)other {
+  if (other == self) {
+    return YES;
+  }
+
+  return other != nil && [other isKindOfClass:[self class]] && [self isEqualToDynamicColor:other];
+}
+
+- (BOOL)isEqualToDynamicColor:(RCTDynamicColor *)other {
+  if (self == other) {
+    return YES;
+  }
+
+  if ([_aquaColor isNotEqualTo:other->_aquaColor]) {
+    return NO;
+  }
+
+  if ([_darkAquaColor isNotEqualTo:other->_darkAquaColor]) {
+    return NO;
+  }
+
+  return YES;
 }
 
 @end


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Xcode logs warnings to console about the use of the appearance API on a non-UI thread. This fix should allow the current behaviour.

Resolves #335

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[macOS] [Fixed] - Allow `-[RCTDynamicColor effectiveColor]` to be called off UI thread

## Test Plan

Xcode should warn about the use of the appearance API on a non-UI thread.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/438)