### PR TITLE
Fix exception thrown when unfocusing multiline TextInput

### DIFF
--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -284,7 +284,13 @@
 }
 
 - (void)reactBlur {
+#if TARGET_OS_OSX // TODO(macOS ISS#2323203)
+  if (self == [[self window] firstResponder]) {
+    [[self window] makeFirstResponder:[[self window] nextResponder]];
+  }
+#else
   [self resignFirstResponder];
+#endif
 }
 
 #pragma mark - Layout


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

`-resignFirstResponder` is not supposed to be called directly. See https://developer.apple.com/documentation/appkit/nsresponder/1532115-resignfirstresponder?language=objc

Resolves #432

## Changelog

[macOS] [Fixed] - Exception thrown when unfocusing multiline TextInput

## Test Plan

1. Open RNTester and go to the TextInput screen
2. Find a multi-line TextInput and try focusing/unfocusing it several times

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/441)