### PR TITLE
Fix `backgroundColor` not being applied correctly to TextInput

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -108,6 +108,7 @@ static RCTUIColor *defaultPlaceholderTextColor()
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
     self.bordered = NO;
     self.accessibilityRole = NSAccessibilityTextFieldRole;
+    self.backgroundColor = [NSColor clearColor];
 #endif // ]TODO(macOS ISS#2323203)
 
     _textInputDelegateAdapter = [[RCTBackedTextFieldDelegateAdapter alloc] initWithTextField:self];


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fixes `backgroundColor` not being applied correctly to `TextInput` (single-line).

Resolves #415

## Changelog

[macOS] [Fixed] - Fix `backgroundColor` not being applied correctly to TextInput

## Test Plan

| Before | After |
| :----: | :---: |
| <img width="752" alt="image" src="https://user-images.githubusercontent.com/4123478/84276848-1a3b5800-ab33-11ea-8990-de1243ae00fa.png"> | <img width="752" alt="image" src="https://user-images.githubusercontent.com/4123478/84276905-28897400-ab33-11ea-9ee0-0f60c33c7db7.png"> |

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/443)