### PR TITLE
Working around ndk paths containing spaces in it

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -103,9 +103,15 @@ jobs:
         inputs:
           script: node cli.js bundle --entry-file .\RNTester\js\RNTesterApp.android.js --bundle-output RNTesterApp.android.bundle --platform android
 
+      - task: CmdLine@2
+        displayName: Workaround for NDK path containing spaces in it
+        inputs:
+          script: .ado\android_symlink_ndk.bat
+
       - task: Gradle@1
         displayName: gradlew installArchives
-#        env:
+        env:
+          ANDROID_NDK=c:\android_ndk_symlink__
 #          REACT_NATIVE_DEPENDENCIES: $(System.DefaultWorkingDirectory)\build_deps
         inputs:
           gradleWrapperFile: gradlew

--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -111,7 +111,7 @@ jobs:
       - task: Gradle@1
         displayName: gradlew installArchives
         env:
-          ANDROID_NDK=c:\android_ndk_symlink__
+          ANDROID_NDK: c:\android_ndk_symlink__
 #          REACT_NATIVE_DEPENDENCIES: $(System.DefaultWorkingDirectory)\build_deps
         inputs:
           gradleWrapperFile: gradlew

--- a/.ado/android_symlink_ndk.bat
+++ b/.ado/android_symlink_ndk.bat
@@ -1,0 +1,28 @@
+REM @if "%DEBUG%" == "" @echo off
+
+REM Android tools doesn't support SDK/NDK paths containing space in it.
+REM This scrip creates a symlink to Android NDK to work around the limitation.
+REM We use the 
+
+set ANDROID_NDK_SYMLINK_PATH=c:\android_ndk_symlink__
+
+REM 1. Try ANDROID_NDK environment variable
+set ANDROID_NDK_PATH=%ANDROID_NDK%
+
+REM 2. May be SDK has ndk-bundle in it.
+IF "%ANDROID_NDK_PATH%"=="" set ANDROID_NDK_PATH=%ANDROID_home%\ndk-bundle
+
+echo %ANDROID_NDK_PATH%
+
+if exist %ANDROID_NDK_PATH% (
+    mklink /J %ANDROID_NDK_SYMLINK_PATH% "%ANDROID_NDK_PATH%"
+    goto :success
+) else (
+    goto :error
+)
+
+:success
+exit /b 0
+
+:error
+exit /b 1

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -181,9 +181,15 @@ jobs:
 #        inputs:
 #          script: .ado\setup_droid_deps.bat
 
+      - task: CmdLine@2
+        displayName: Workaround for NDK path containing spaces in it
+        inputs:
+          script: .ado\android_symlink_ndk.bat
+
       - task: Gradle@1
         displayName: gradlew installArchives
-#        env:
+        env:
+          ANDROID_NDK=c:\android_ndk_symlink__
 #          REACT_NATIVE_DEPENDENCIES: $(System.DefaultWorkingDirectory)\build_deps
         inputs:
           gradleWrapperFile: gradlew

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -189,7 +189,7 @@ jobs:
       - task: Gradle@1
         displayName: gradlew installArchives
         env:
-          ANDROID_NDK=c:\android_ndk_symlink__
+          ANDROID_NDK: c:\android_ndk_symlink__
 #          REACT_NATIVE_DEPENDENCIES: $(System.DefaultWorkingDirectory)\build_deps
         inputs:
           gradleWrapperFile: gradlew


### PR DESCRIPTION
#419 ## Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

This changes are only in ADO pipeline definitions.

## Summary
Many Android build tools doesn't support spaces in the SDK/NDK paths. But we do sometimes find lab images with paths having spaces in it. This change creates a symlink to the NDK path and feed it into the build task to get around.

## Changelog

Many Android build tools doesn't support spaces in the SDK/NDK paths. But we do sometimes find lab images with paths having spaces in it. This change creates a symlink to the NDK path and feed it into the build task to get around.

[CATEGORY] [TYPE] - Message

## Test Plan

Ensure build pipelines pass

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/445)