### PR TITLE
Fix ActivityIndicator with custom color causing brief flicker

### DIFF
--- a/React/Views/RCTActivityIndicatorView.m
+++ b/React/Views/RCTActivityIndicatorView.m
@@ -30,6 +30,9 @@
 
 - (void)startAnimating
 {
+  // `wantsLayer` gets reset after the animation is stopped. We have to
+  // reset it in order for CALayer filters to take effect.
+  [self setWantsLayer:YES];
   [self startAnimation:self];
 }
 
@@ -66,7 +69,7 @@
   }
 }
 
-- (void)setColor: (RCTUIColor*)color
+- (void)setColor:(RCTUIColor*)color
 {
   if (_color != color) {
     _color = color;
@@ -77,19 +80,23 @@
 - (void)updateLayer
 {
   [super updateLayer];
-  if (_color) {
+  if (_color != nil) {
     CGFloat r, g, b, a;
     [[_color colorUsingColorSpaceName:NSCalibratedRGBColorSpace] getRed:&r green:&g blue:&b alpha:&a];
 
     CIFilter *colorPoly = [CIFilter filterWithName:@"CIColorPolynomial"];
     [colorPoly setDefaults];
+
     CIVector *redVector = [CIVector vectorWithX:r Y:0 Z:0 W:0];
     CIVector *greenVector = [CIVector vectorWithX:g Y:0 Z:0 W:0];
     CIVector *blueVector = [CIVector vectorWithX:b Y:0 Z:0 W:0];
     [colorPoly setValue:redVector forKey:@"inputRedCoefficients"];
     [colorPoly setValue:greenVector forKey:@"inputGreenCoefficients"];
     [colorPoly setValue:blueVector forKey:@"inputBlueCoefficients"];
-    self.contentFilters = @[colorPoly];
+
+    [[self layer] setFilters:@[colorPoly]];
+  } else {
+    [[self layer] setFilters:nil];
   }
 }
 


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The window flickers when rendering a view with an `ActivityIndicator` and a custom colour. This is caused by setting `-[NSView setContentFilters:]`.

Resolves #412

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[macOS] [Fixed] - Fix ActivityIndicator with custom color causing brief flicker

## Test Plan

![indicator-flicker](https://user-images.githubusercontent.com/4123478/84386470-b3c93f00-abf1-11ea-9176-426b987baeb1.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/446)