### PR TITLE
Fix styling of single-line TextInput

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -37,9 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, getter=isEditable) BOOL editable;
 #endif
 #if TARGET_OS_OSX
-@property (nonatomic, assign) NSTextAlignment textAlignment;
-@property (nonatomic, copy, nullable) NSAttributedString *attributedText;
 @property (nonatomic, copy, nullable) NSString *text;
+@property (nonatomic, copy, nullable) NSAttributedString *attributedText;
+@property (nonatomic, copy) NSDictionary<NSAttributedStringKey, id> *defaultTextAttributes;
+@property (nonatomic, assign) NSTextAlignment textAlignment;
 @property (nonatomic, getter=isAutomaticTextReplacementEnabled) BOOL automaticTextReplacementEnabled;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor;

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -82,11 +82,6 @@
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
 @dynamic delegate;
 
-static UIFont *defaultPlaceholderFont()
-{
-  return [UIFont systemFontOfSize:17];
-}
-
 static RCTUIColor *defaultPlaceholderTextColor()
 {
   return [NSColor placeholderTextColor];
@@ -106,8 +101,9 @@ static RCTUIColor *defaultPlaceholderTextColor()
                                                object:self];
 
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-    self.bordered = NO;
-    self.accessibilityRole = NSAccessibilityTextFieldRole;
+    [self setBordered:NO];
+    [self setAllowsEditingTextAttributes:YES];
+    [self setAccessibilityRole:NSAccessibilityTextFieldRole];
 #endif // ]TODO(macOS ISS#2323203)
 
     _textInputDelegateAdapter = [[RCTBackedTextFieldDelegateAdapter alloc] initWithTextField:self];
@@ -124,6 +120,10 @@ static RCTUIColor *defaultPlaceholderTextColor()
 - (void)_textDidChange
 {
   _textWasPasted = NO;
+#if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+  [self setAttributedText:[[NSAttributedString alloc] initWithString:[self text]
+                                                          attributes:[self defaultTextAttributes]]];
+#endif // ]TODO(macOS ISS#2323203)
 }
 
 #pragma mark - Accessibility
@@ -246,11 +246,14 @@ static RCTUIColor *defaultPlaceholderTextColor()
   if ([reactTextAttributes isEqual:_reactTextAttributes]) {
     return;
   }
-#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
   self.defaultTextAttributes = reactTextAttributes.effectiveTextAttributes;
-#endif // TODO(macOS ISS#2323203)
   _reactTextAttributes = reactTextAttributes;
   [self _updatePlaceholder];
+
+#if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+  [self setAttributedText:[[NSAttributedString alloc] initWithString:[self text]
+                                                          attributes:[self defaultTextAttributes]]];
+#endif // ]TODO(macOS ISS#2323203)
 }
 
 - (RCTTextAttributes *)reactTextAttributes
@@ -264,8 +267,8 @@ static RCTUIColor *defaultPlaceholderTextColor()
     return;
   }
 
-  NSMutableDictionary *attributes = [NSMutableDictionary new];
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
+  NSMutableDictionary *attributes = [NSMutableDictionary new];
   if (_placeholderColor) {
     [attributes setObject:_placeholderColor forKey:NSForegroundColorAttributeName];
   }
@@ -273,9 +276,8 @@ static RCTUIColor *defaultPlaceholderTextColor()
   self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholder
                                                                attributes:attributes];
 #else // [TODO(macOS ISS#2323203)
+  NSMutableDictionary *attributes = [[self defaultTextAttributes] mutableCopy];
   attributes[NSForegroundColorAttributeName] = _placeholderColor ?: defaultPlaceholderTextColor();
-  attributes[NSFontAttributeName] = self.font ?: defaultPlaceholderFont();
-  
   self.placeholderAttributedString = [[NSAttributedString alloc] initWithString:self.placeholder
                                                                      attributes:attributes];
 #endif // ]TODO(macOS ISS#2323203)


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

In single line TextInput controls, most text stylings in the `style` prop are being ignored.

Resolves #447

## Changelog

[macOS] [Fixed] - Fix styling of single-line TextInput

## Test Plan

|   |   |
| - | - |
| <img width="752" alt="image" src="https://user-images.githubusercontent.com/4123478/84508655-eabb5580-acc2-11ea-93b0-75e17736b7f4.png"> | <img width="752" alt="image" src="https://user-images.githubusercontent.com/4123478/84508564-c19ac500-acc2-11ea-8acd-3dcacc0e3983.png"> |



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/449)