### PR TITLE
Fix onSubmitEditing not being called on single-line TextInput

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -175,6 +175,9 @@ BOOL RCTEventIsCommandEnterEvent(NSEvent *event) {
   // enter/return
   if (commandSelector == @selector(insertNewline:) || commandSelector == @selector(insertNewlineIgnoringFieldEditor:)) {
     [self textFieldDidEndEditingOnExit];
+    if ([[_backedTextInputView textInputDelegate] textInputShouldReturn]) {
+      [[_backedTextInputView window] makeFirstResponder:nil];
+    }
     commandHandled = YES;
     //backspace
   } else if (commandSelector == @selector(deleteBackward:)) {


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

`onSubmitEditing` does not get called when pressing `Enter` in single-line `TextInput`.

Resolves #451

## Changelog

[macOS] [Fixed] - Fix onSubmitEditing not being called on single-line TextInput

## Test Plan

![textinput-single-submit](https://user-images.githubusercontent.com/4123478/85005254-d068f800-b158-11ea-8460-ff89c4ad7354.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/458)