### PR TITLE
fix transforms #280

### DIFF
--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -121,6 +121,8 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
  */
 @property (nonatomic, assign) UIEdgeInsets hitTestEdgeInsets;
 
+@property (nonatomic, assign) CATransform3D transform3D;
+
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
 /**
  * macOS Properties

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -192,15 +192,14 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 
 RCT_CUSTOM_VIEW_PROPERTY(transform, CATransform3D, RCTView)
 {
-#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
-  view.layer.transform = json ? [RCTConvert CATransform3D:json] : defaultView.layer.transform;
+  CATransform3D transform = json ? [RCTConvert CATransform3D:json] : defaultView.layer.transform;
+  view.transform3D = transform;
+#if !TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+  view.layer.transform = transform;
   // Enable edge antialiasing in perspective transforms
   view.layer.allowsEdgeAntialiasing = !(view.layer.transform.m34 == 0.0f);
-#elif TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-  view.layer.sublayerTransform = json ? [RCTConvert CATransform3D:json] : defaultView.layer.sublayerTransform;
-  // TODO: Improve this by enabling edge antialiasing only for transforms with rotation or skewing
-  view.layer.edgeAntialiasingMask = !CATransform3DIsIdentity(view.layer.sublayerTransform) ? kCALayerLeftEdge | kCALayerRightEdge | kCALayerBottomEdge | kCALayerTopEdge : 0;
 #endif // ]TODO(macOS ISS#2323203)
+  [view setNeedsDisplay];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes #280 by making the effective origin of transforms {0.5, 0.5} with some additional matrix magic. I haven't been able to figure out why the `anchorPoint` default on macOS/`NSView` is `{0, 0}` rather than the iOS default `{0.5, 0.5}` (which matches the `CALayer` docs: https://developer.apple.com/documentation/quartzcore/calayer/1410817-anchorpoint)).

This also fixes application of the transform so it works on initial render. The underlying issue was that we were setting `view.layer.transform` directly (which is identified as undefined behavior in the `NSView` docs) and in practice doesn't work because the initial layer gets replaced after setting the initial values without copying the transform over to the new one, so it gets wiped out. The fix here is to save `transform3D` on the `RCTView` and apply it to the layer every time `displayLayer:` is called, along with all our existing custom layer rendering logic for border etc.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[macOS] [Fixed] - fix transforms #280

## Test Plan


Before | After
------- | ------
![image](https://user-images.githubusercontent.com/1509831/85078968-85f87300-b17a-11ea-8e0c-378df9f78086.png) | ![image](https://user-images.githubusercontent.com/1509831/85078996-91e43500-b17a-11ea-9dff-282f85fa5d42.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/460)