### PR TITLE
Fixing another OS-specific issue in publish script and a patch

### DIFF
--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -40,7 +40,7 @@ function doPublish() {
   const onlyTagSource = !!branchVersionSuffix;
   if (!onlyTagSource) {
     // -------- Generating Android Artifacts with JavaDoc
-    exec("gradlew installArchives");
+    exec(path.join(process.env.BUILD_STAGINGDIRECTORY,"gradlew") + " installArchives");
 
     // undo uncommenting javadoc setting
     exec("git checkout ReactAndroid/gradle.properties");

--- a/android-patches/patches-droid-office-grouped/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
+++ b/android-patches/patches-droid-office-grouped/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
@@ -1,6 +1,6 @@
 --- "e:\\github\\fb-react-native-forpatch-base\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\bridge\\ReactBridge.java"	2020-01-30 13:55:48.274578500 -0800
 +++ "e:\\github\\ms-react-native-forpatch\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\bridge\\ReactBridge.java"	2020-02-20 11:21:17.368516500 -0800
-@@ -28,6 +28,14 @@
+@@ -28,6 +28,15 @@
      sLoadStartTime = SystemClock.uptimeMillis();
      Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "ReactBridge.staticInit::load:reactnativejni");
      ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START);
@@ -12,6 +12,7 @@
 +    SoLoader.loadLibrary("glog_init");
 +    SoLoader.loadLibrary("fb");
 +    SoLoader.loadLibrary("yoga");
++    SoLoader.loadLibrary("jsinspector");
      SoLoader.loadLibrary("reactnativejni");
      ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END);
      Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);


### PR DESCRIPTION
# :warning: Make sure you are targeting microsoft/react-native-macos for your PR :warning:
(then delete these lines)

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

We are adding a line of patch which we missed by mistake earlier.
In addition the PR contains a fix for an error when running publish script in Ubuntu.

## Summary

We are adding a line of patch which we missed by mistake earlier.
In addition the PR contains a fix for an error when running publish script in Ubuntu.

## Changelog

We are adding a line of patch which we missed by mistake earlier.
In addition the PR contains a fix for an error when running publish script in Ubuntu.

## Test Plan

Branch should publish now. Also the app shouldn't crash in devmain.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/461)