### PR TITLE
Align multi-line TextInput onSubmitEditing with Android

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -14,13 +14,6 @@
 
 static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingContext;
 
-#if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-BOOL RCTEventIsCommandEnterEvent(NSEvent *event) {
-  NSEventModifierFlags modifierFlags = event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
-  return (modifierFlags & NSEventModifierFlagCommand) == NSEventModifierFlagCommand && event.keyCode == 0x24;
-}
-#endif // ]TODO(macOS ISS#2323203)
-
 @interface RCTBackedTextFieldDelegateAdapter ()
 #if !TARGET_OS_OSX // [TODO(macOS ISS#2323203)
 <UITextFieldDelegate>
@@ -357,12 +350,12 @@ BOOL RCTEventIsCommandEnterEvent(NSEvent *event) {
 {
   BOOL commandHandled = NO;
   id<RCTBackedTextInputDelegate> textInputDelegate = [_backedTextInputView textInputDelegate];
-  // cmd + enter/return
-  if (commandSelector == @selector(noop:) && RCTEventIsCommandEnterEvent(NSApp.currentEvent)) {
+  // enter/return
+  if ((commandSelector == @selector(insertNewline:) || commandSelector == @selector(insertNewlineIgnoringFieldEditor:))) {
     if (textInputDelegate.textInputShouldReturn) {
       [_backedTextInputView.window makeFirstResponder:nil];
+      commandHandled = YES;
     }
-    commandHandled = YES;
     //backspace
   } else if (commandSelector == @selector(deleteBackward:)) {
     commandHandled = textInputDelegate != nil && ![textInputDelegate textInputShouldHandleDeleteBackward:_backedTextInputView];

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -407,11 +407,17 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   // `onSubmitEditing` is called when "Submit" button
   // (the blue key on onscreen keyboard) did pressed
   // (no connection to any specific "submitting" process).
-  [_eventDispatcher sendTextEventWithType:RCTTextEventTypeSubmit
-                                 reactTag:self.reactTag
-                                     text:self.backedTextInputView.attributedText.string
-                                      key:nil
-                               eventCount:_nativeEventCount];
+#if TARGET_OS_OSX // [TODO(macOS Candidate ISS#2710739)
+  if (_blurOnSubmit) {
+#endif // ]TODO(macOS Candidate ISS#2710739)
+    [_eventDispatcher sendTextEventWithType:RCTTextEventTypeSubmit
+                                   reactTag:self.reactTag
+                                       text:self.backedTextInputView.attributedText.string
+                                        key:nil
+                                 eventCount:_nativeEventCount];
+#if TARGET_OS_OSX // [TODO(macOS Candidate ISS#2710739)
+  }
+#endif // ]TODO(macOS Candidate ISS#2710739)
 
   return _blurOnSubmit;
 }


### PR DESCRIPTION
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The current multi-line `TextInput` `onSubmitEditing` behaviour in macOS deviates from upstream.

Setting `blurOnSubmit` to `true` means that pressing return will blur
the field and trigger the `onSubmitEditing` event instead of inserting
a newline into the field.

-- https://reactnative.dev/docs/textinput#bluronsubmit

## Changelog

[macOS] [Fixed] - Align multi-line TextInput onSubmitEditing with Android

## Test Plan

1. Go to RNTester > TextInput
2. Search for "submit"
3. Enter something in the multi-line TextInput and press enter
4. An alert should appear and no newline is inserted
5. Modify the example to set `onSubmitEditing=false` (patch provided below)
6. Repeat step 1-3, no alert should appear and newlines should be inserted

```diff
diff --git a/RNTester/js/examples/TextInput/TextInputExample.ios.js b/RNTester/js/examples/TextInput/TextInputExample.ios.js
index f21ca72d3..9e07c903b 100644
--- a/RNTester/js/examples/TextInput/TextInputExample.ios.js
+++ b/RNTester/js/examples/TextInput/TextInputExample.ios.js
@@ -898,9 +898,9 @@ exports.examples = [
         <View>
           <TextInput
             style={styles.multiline}
-            placeholder="blurOnSubmit = true"
+            placeholder="blurOnSubmit = false"
             returnKeyType="next"
-            blurOnSubmit={true}
+            blurOnSubmit={false}
             multiline={true}
             onSubmitEditing={event =>
               Alert.alert('Alert', event.nativeEvent.text)
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/463)