### PR TITLE
Fix isSelected not being passed to FlatList.renderItem

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -2021,6 +2021,7 @@ class CellRenderer extends React.Component<
       return renderItem({
         item,
         index,
+        isSelected, // TODO(macOS ISS#2323203)
         separators: this._separators,
       });
     }


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

`FlatList` doesn't pass `isSelected` to `renderItem`.

Resolves #462 

## Changelog

[macOS] [Fixed] - Fix `isSelected` not being passed to `FlatList.renderItem`

## Test Plan

1. Patch `RNTester/js/examples/FlatList/FlatListExample.js` to output `isSelected` (see patch below)
2. Go to RNTester > FlatList
3. Observe that `undefined` is no longer output, but proper boolean values

```diff
diff --git a/RNTester/js/examples/FlatList/FlatListExample.js b/RNTester/js/examples/FlatList/FlatListExample.js
index 733285229..4936ee212 100644
--- a/RNTester/js/examples/FlatList/FlatListExample.js
+++ b/RNTester/js/examples/FlatList/FlatListExample.js
@@ -191,6 +191,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
       renderItem: undefined,
       [flatListPropKey]: ({item, isSelected, separators}) => {
         // TODO(macOS ISS#2323203)
+        console.log(JSON.stringify(item), isSelected);
         return (
           <ItemComponent
             item={item}
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/464)