### PR TITLE
Fix multiline TextInput crash when inserting/removing lots of text

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -375,7 +375,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
                                  reactTag:self.reactTag
-                                     text:self.backedTextInputView.attributedText.string
+                                     text:[self.backedTextInputView.attributedText.string copy] // [TODO(macOS Candidate ISS#2710739)
                                       key:nil
                                eventCount:_nativeEventCount];
 }
@@ -389,13 +389,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 {
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeEnd
                                  reactTag:self.reactTag
-                                     text:self.backedTextInputView.attributedText.string
+                                     text:[self.backedTextInputView.attributedText.string copy] // [TODO(macOS Candidate ISS#2710739)
                                       key:nil
                                eventCount:_nativeEventCount];
 
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeBlur
                                  reactTag:self.reactTag
-                                     text:self.backedTextInputView.attributedText.string
+                                     text:[self.backedTextInputView.attributedText.string copy] // [TODO(macOS Candidate ISS#2710739)
                                       key:nil
                                eventCount:_nativeEventCount];
 }
@@ -412,7 +412,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 #endif // ]TODO(macOS Candidate ISS#2710739)
     [_eventDispatcher sendTextEventWithType:RCTTextEventTypeSubmit
                                    reactTag:self.reactTag
-                                       text:self.backedTextInputView.attributedText.string
+                                       text:[self.backedTextInputView.attributedText.string copy] // [TODO(macOS Candidate ISS#2710739)
                                         key:nil
                                  eventCount:_nativeEventCount];
 #if TARGET_OS_OSX // [TODO(macOS Candidate ISS#2710739)
@@ -475,7 +475,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
     }
   }
 
-  NSString *previousText = backedTextInputView.attributedText.string ?: @"";
+  NSString *previousText = [backedTextInputView.attributedText.string copy] ?: @""; // TODO(OSS Candidate ISS#2710739)
 
   if (range.location + range.length > backedTextInputView.attributedText.string.length) {
     _predictedText = backedTextInputView.attributedText.string;
@@ -522,7 +522,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
   if (_onChange) {
     _onChange(@{
-       @"text": self.attributedText.string,
+       @"text": [self.attributedText.string copy], // [TODO(macOS Candidate ISS#2710739)
        @"target": self.reactTag,
        @"eventCount": @(_nativeEventCount),
     });


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

It seems that the returned string that we use to set `previousText` can be mutated while it is waiting to be processed by `RCTBridge `.

Resolves #486

## Changelog

[macOS] [Fixed] - Fix multiline `TextInput` crash when inserting/removing lots of text

## Test Plan

Here's a screenshot showing that the length of `previousText` (`0x600000d952c0`) was 29483 when first accessed, but is 0 when the exception is thrown.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/4123478/86901560-14726b80-c10d-11ea-96d7-c5540af0b1eb.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/489)