### PR TITLE
Fixes in the Nuget spec to unblock the publish task

### DIFF
--- a/android-patches/patches-0.61.5/BasicBuild/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches-0.61.5/BasicBuild/ReactAndroid/ReactAndroid.nuspec
@@ -1,6 +1,6 @@
 --- "D:\\code\\work\\react-native-v0.61.5\\ReactAndroid\\ReactAndroid.nuspec"	1969-12-31 16:00:00.000000000 -0800
 +++ "D:\\code\\work\\react-native-fb61merge\\ReactAndroid\\ReactAndroid.nuspec"	2020-03-30 21:05:08.615724600 -0700
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,110 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
@@ -45,11 +45,6 @@
 +    <file src="build\react-ndk\all\x86\libreactnativejni.so" target="lib\droidx86"/>
 +    <file src="build\react-ndk\all\arm64-v8a\libreactnativejni.so" target="lib\droidarm64"/>
 +
-+    <file src="build\react-ndk\all\x86_64\libv8executor.so" target="lib\droidx64"/>
-+    <file src="build\react-ndk\all\armeabi-v7a\libv8executor.so" target="lib\droidarm"/>
-+    <file src="build\react-ndk\all\x86\libv8executor.so" target="lib\droidx86"/>
-+    <file src="build\react-ndk\all\arm64-v8a\libv8executor.so" target="lib\droidarm64"/>
-+
 +    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64"/>
 +    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm"/>
 +    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86"/>
@@ -91,11 +86,6 @@
 +    <file src="build\tmp\buildReactNdkLib\local\x86\libreactnativejni.so" target="lib\droidx86\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libreactnativejni.so" target="lib\droidarm64\unstripped"/>
 +
-+    <file src="build\tmp\buildReactNdkLib\local\x86_64\libv8executor.so" target="lib\droidx64\unstripped"/>
-+    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libv8executor.so" target="lib\droidarm\unstripped"/>
-+    <file src="build\tmp\buildReactNdkLib\local\x86\libv8executor.so" target="lib\droidx86\unstripped"/>
-+    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libv8executor.so" target="lib\droidarm64\unstripped"/>
-+
 +    <file src="build\tmp\buildReactNdkLib\local\x86_64\libyoga.so" target="lib\droidx64\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libyoga.so" target="lib\droidarm\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\x86\libyoga.so" target="lib\droidx86\unstripped"/>
@@ -115,7 +105,7 @@
 +    <file src="..\ReactCommon\cxxreact\**\*.h" target="inc\cxxreact"/>
 +    <file src="..\ReactCommon\jsi\**\*.h" target="inc\jsi"/>
 +    <file src="..\ReactCommon\yoga\yoga\**\*.h" target="inc\Yoga"/>
-+    <file src="..\folly\**\*.*" target="inc" />
++    <file src="..\Folly\**\*.*" target="inc" />
 +    <file src="..\glog\src\glog\*.h" target="inc\glog" />
 +    <file src="..\jsc\jsc-headers\*.h" target="inc\jsc"/>
 +  </files>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

Not a code change

## Summary

Fix the nuget spec to pass the nuget pack step

## Changelog

Fixes in the nuget spec to clear non-existing v8executor and a case sensitivity fix

## Test Plan

Publish task should pass

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/508)