### PR TITLE
Fixing the gradle task in publish task and adding publish validation in PR

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -84,6 +84,17 @@ jobs:
           script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(System.DefaultWorkingDirectory) -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
 
       - task: CmdLine@2
+        displayName: Verify publish
+        inputs:
+          script: node .ado/publish.js --fake
+        env:
+          BUILD_STAGINGDIRECTORY: $(Build.StagingDirectory)
+          BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
+          BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          githubApiToken: $(githubApiToken)
+
+      - task: CmdLine@2
         displayName: gradlew clean
         inputs:
           script: ./gradlew clean

--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -59,7 +59,7 @@ function doPublish(fakeMode) {
   console.log(`Copying tar file ${npmTarPath} to: ${finalTarPath}`)
   
   if(fakeMode) {
-    if (!fs.existsSync(finalTarPath))
+    if (!fs.existsSync(npmTarPath))
       throw "The final artefact to be published is missing.";
   } else {
     fs.copyFileSync(npmTarPath, finalTarPath);

--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -20,7 +20,7 @@ function exec(command) {
   }
 }
 
-function doPublish() {
+function doPublish(fakeMode) {
   console.log(`Target branch to publish to: ${publishBranchName}`);
 
   const {releaseVersion, branchVersionSuffix} = gatherVersionInfo()
@@ -34,13 +34,17 @@ function doPublish() {
   exec(`git add ${pkgJsonPath}`);
   exec(`git commit -m "Applying package update to ${releaseVersion} ***NO_CI***"`);
   exec(`git tag v${releaseVersion}`);
-  exec(`git push origin HEAD:${tempPublishBranch} --follow-tags --verbose`);
-  exec(`git push origin tag v${releaseVersion}`);
+  
+  // Don't push the new tags on the PR jobs.
+  if(!fakeMode) {
+    exec(`git push origin HEAD:${tempPublishBranch} --follow-tags --verbose`);
+    exec(`git push origin tag v${releaseVersion}`);
+  }
 
   const onlyTagSource = !!branchVersionSuffix;
   if (!onlyTagSource) {
     // -------- Generating Android Artifacts with JavaDoc
-    exec(path.join(process.env.BUILD_STAGINGDIRECTORY,"gradlew") + " installArchives");
+    exec(path.join(process.env.BUILD_SOURCESDIRECTORY,"gradlew") + " installArchives");
 
     // undo uncommenting javadoc setting
     exec("git checkout ReactAndroid/gradle.properties");
@@ -53,7 +57,17 @@ function doPublish() {
   const npmTarPath = path.resolve(__dirname, '..', npmTarFileName);
   const finalTarPath = path.join(process.env.BUILD_STAGINGDIRECTORY, 'final', npmTarFileName);
   console.log(`Copying tar file ${npmTarPath} to: ${finalTarPath}`)
-  fs.copyFileSync(npmTarPath, finalTarPath);
+  
+  if(fakeMode) {
+    if (!fs.existsSync(finalTarPath))
+      throw "The final artefact to be published is missing.";
+  } else {
+    fs.copyFileSync(npmTarPath, finalTarPath);
+  }
+
+  // Early return on PR jobs.
+  if (fakeMode)
+    return;
 
   const assetUpdateUrl = `https://uploads.github.com/repos/microsoft/react-native/releases/{id}/assets?name=react-native-${releaseVersion}.tgz`;
   const authHeader =
@@ -152,4 +166,10 @@ function doPublish() {
   );
 }
 
-doPublish();
+var args = process.argv.slice(2);
+
+let fakeMode = false;
+if (args.length > 0 && args[0] === '--fake')
+  fakeMode = true;
+
+doPublish(fakeMode);

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -139,6 +139,7 @@ jobs:
           script: node .ado/publish.js
         env:
           BUILD_STAGINGDIRECTORY: $(Build.StagingDirectory)
+          BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
           BUILD_SOURCEBRANCH: $(Build.SourceBranch)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           githubApiToken: $(githubApiToken)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.83",
+  "version": "0.60.0-microsoft.84",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.84",
+  "version": "0.60.0-microsoft.85",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

No code change

## Summary

Fixing the gradle task in publish task and adding publish validation in PR

## Changelog
Fixing the gradle task in publish task and adding publish validation in PR

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/513)