### PR TITLE
Making cleanup code in publish task cross platform

### DIFF
--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -101,8 +101,8 @@ function doPublish(fakeMode) {
 
         console.log('Response: ' + body);
 
-
-        exec(`del ${npmTarPath}`);
+        fs.unlinkSync(npmTarPath);
+        
         exec(`git checkout ${publishBranchName}`);
         exec(`git pull origin ${publishBranchName}`);
         exec(`git merge ${tempPublishBranch} --no-edit`);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

No code change

## Summary

Making cleanup code in publish task cross platform

## Changelog
Making cleanup code in publish task cross platform

## Test Plan

Publish should pass

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/514)