### PR TITLE
Manually bump to .87.

### DIFF
--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -102,7 +102,7 @@ function doPublish(fakeMode) {
         console.log('Response: ' + body);
 
         fs.unlinkSync(npmTarPath);
-        
+
         exec(`git checkout ${publishBranchName}`);
         exec(`git pull origin ${publishBranchName}`);
         exec(`git merge ${tempPublishBranch} --no-edit`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.85",
+  "version": "0.60.0-microsoft.87",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Manually bump to .87 since the last publish failed.

Inconsequential whitespace change to a .js file just to force the publish pipeline to run since it filters out package.json only changes.

## Changelog

[Fixed] [macOS] - Manually bump to .87.

## Test Plan

No code changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/515)