### PR TITLE
Fix 'Publish final artifacts' publish step

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -147,5 +147,5 @@ jobs:
       - task: PublishBuildArtifacts@1
         displayName: 'Publish final artifacts'
         inputs:
-          PathtoPublish: '$(Build.StagingDirectory)\final'
+          PathtoPublish: '$(Build.StagingDirectory)/final'
           ArtifactName: 'ReactNative-Final' 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.88",
+  "version": "0.60.0-microsoft.89",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

The last publish attempt failed in the 'Publish final artifacts' because a path had a Windows separator instead of a Posix separator.

Bump the package.json version number again just in case.

## Changelog

[macOS] [Fixed] - Fix 'Publish final artifacts' publish step

## Test Plan

no code changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/516)