### PR TITLE
Disable npmjs.orj publish slice from 0.60-stable branch.

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -15,53 +15,53 @@ trigger:
 pr: none
 
 jobs:
-  - job: RNGithubNpmJSPublish
-    displayName: React-Native GitHub Publish to npmjs.org
-    pool:
-      vmImage: vs2017-win2016
-    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
-    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-    steps:
-      - checkout: self # self represents the repo where the initial Pipelines YAML file was found
-        clean: true # whether to fetch clean each time
-        # fetchDepth: 2 # the depth of commits to ask Git to fetch
-        lfs: false # whether to download Git-LFS files
-        submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
-        persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+  # - job: RNGithubNpmJSPublish
+  #   displayName: React-Native GitHub Publish to npmjs.org
+  #   pool:
+  #     vmImage: vs2017-win2016
+  #   timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+  #   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+  #   steps:
+  #     - checkout: self # self represents the repo where the initial Pipelines YAML file was found
+  #       clean: true # whether to fetch clean each time
+  #       # fetchDepth: 2 # the depth of commits to ask Git to fetch
+  #       lfs: false # whether to download Git-LFS files
+  #       submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+  #       persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - task: CmdLine@2
-        displayName: npm install
-        inputs:
-          script: npm install
+  #     - task: CmdLine@2
+  #       displayName: npm install
+  #       inputs:
+  #         script: npm install
 
-      - task: CmdLine@2
-        displayName: Bump package version
-        inputs:
-          script: node .ado/bumpFileVersions.js
+  #     - task: CmdLine@2
+  #       displayName: Bump package version
+  #       inputs:
+  #         script: node .ado/bumpFileVersions.js
 
-      - task: CmdLine@2
-        displayName: "Prepare package.json for npm publishing as react-native-macos"
-        inputs:
-          script: node .ado/renamePackageToMac.js
+  #     - task: CmdLine@2
+  #       displayName: "Prepare package.json for npm publishing as react-native-macos"
+  #       inputs:
+  #         script: node .ado/renamePackageToMac.js
 
-      - task: Npm@1
-        displayName: "Publish latest react-native-macos to npmjs.org"
-        inputs:
-          command: 'publish'
-          publishEndpoint: 'npmjs'
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #     - task: Npm@1
+  #       displayName: "Publish latest react-native-macos to npmjs.org"
+  #       inputs:
+  #         command: 'publish'
+  #         publishEndpoint: 'npmjs'
+  #       condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-      # When using npm custom instead of npm publish, we need to ensure that auth still happens.
-      - task: npmAuthenticate@0
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #     # When using npm custom instead of npm publish, we need to ensure that auth still happens.
+  #     - task: npmAuthenticate@0
+  #       condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-      - task: Npm@1
-        displayName: "Publish stable react-native-macos to npmjs.org"
-        inputs:
-          command: 'custom'
-          customCommand: publish --tag $(Build.SourceBranchName)
-          publishEndpoint: 'npmjs'
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #     - task: Npm@1
+  #       displayName: "Publish stable react-native-macos to npmjs.org"
+  #       inputs:
+  #         command: 'custom'
+  #         customCommand: publish --tag $(Build.SourceBranchName)
+  #         publishEndpoint: 'npmjs'
+  #       condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Disable npmjs.orj publish slice from 0.60-stable branch.

## Changelog

[macOS] [Fixed] - Disable npmjs.orj publish slice from 0.60-stable branch.

## Test Plan

No code changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/517)