### PR TITLE
Publish script argument uses the wrong file path separator

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -178,5 +178,5 @@ jobs:
       - task: PublishBuildArtifacts@1
         displayName: 'Publish final artifacts'
         inputs:
-          PathtoPublish: '$(Build.StagingDirectory)\final'
+          PathtoPublish: '$(Build.StagingDirectory)/final'
           ArtifactName: 'ReactNative-Final' 


### PR DESCRIPTION
Fixing publish script as the task argument uses wrong file path separator to be used on Linux/Ubuntu host

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

No code change

## Summary

Fixing publish script as the task argument uses wrong file path separator to be used on Linux/Ubuntu host

## Changelog

Fixing publish script as the task argument uses wrong file path separator to be used on Linux/Ubuntu host


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/524)