### PR TITLE
[Text] Fix color defaults for light/dark mode

### DIFF
--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -31,6 +31,9 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
     _textShadowRadius = NAN;
     _opacity = NAN;
     _textTransform = RCTTextTransformUndefined;
+#if TARGET_OS_OSX // TODO(macOS ISS#2323203)
+    _foregroundColor = [NSColor labelColor];
+#endif // TODO(macOS ISS#2323203)
   }
 
   return self;

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -30,8 +30,7 @@ static UIFont *defaultPlaceholderFont()
 
 static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
 {
-  // Default placeholder color from UITextField.
-  return [RCTUIColor colorWithRed:0 green:0 blue:0.0980392 alpha:0.22]; // TODO(OSS Candidate ISS#2710739)
+  return [RCTUIColor placeholderTextColor]; // TODO(OSS Candidate ISS#2710739)
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -227,7 +226,7 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
       [self.textStorage setAttributedString:[NSAttributedString new]];
     }
   } else {
-  // But if the text is preserved, we just copying the attributes from the source string.
+    // But if the text is preserved, we just copy the attributes from the source string.
     if (![self.textStorage isEqualToAttributedString:attributedText]) {
       [self copyTextAttributesFrom:attributedText];
     }

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -320,7 +320,11 @@ static RCTUIColor *defaultPlaceholderTextColor()
   if (self.placeholderColor) {
     [textAttributes setValue:self.placeholderColor forKey:NSForegroundColorAttributeName];
   } else {
+#if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+    [textAttributes setValue:defaultPlaceholderTextColor() forKey:NSForegroundColorAttributeName];
+#else
     [textAttributes removeObjectForKey:NSForegroundColorAttributeName];
+#endif // ]TODO(macOS ISS#2323203)
   }
 
   return textAttributes;


### PR DESCRIPTION
#### Please select one of the following

- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Currently we are not using dynamic system colours for our text needs. Either it was hardcoded (such as `RCTUITextView`’s default placeholder colour) or it was implicitly using black as that’s the default for attributed strings (which you can find on slide 231 of [this WWDC deck](https://devstreaming-cdn.apple.com//videos/wwdc/2018/218o6oial8c68yom/218/218_advanced_dark_mode.pdf?dl=1))

## Changelog

[macOS] [Fixed] - Use text color defaults that respect light/dark mode settings

## Test Plan

### Placeholders

#### Before

<img width="834" alt="Screenshot 2020-08-12 at 19 54 28" src="https://user-images.githubusercontent.com/2320/90049979-e1a43000-dcd5-11ea-8fa3-dc3d3b8db476.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 54 40" src="https://user-images.githubusercontent.com/2320/90049995-e5d04d80-dcd5-11ea-9271-90f7202e1e10.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 55 05" src="https://user-images.githubusercontent.com/2320/90050018-ec5ec500-dcd5-11ea-92ad-b1b0b6156446.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 55 11" src="https://user-images.githubusercontent.com/2320/90050032-ef59b580-dcd5-11ea-94a1-2e2194996fda.png">

#### After

<img width="834" alt="Screenshot 2020-08-12 at 19 49 03" src="https://user-images.githubusercontent.com/2320/90050064-fb457780-dcd5-11ea-8891-fac3ff050ca6.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 48 55" src="https://user-images.githubusercontent.com/2320/90050076-fed8fe80-dcd5-11ea-8cb8-503cf4dc804b.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 49 40" src="https://user-images.githubusercontent.com/2320/90050097-04cedf80-dcd6-11ea-8654-c291adbe9486.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 49 32" src="https://user-images.githubusercontent.com/2320/90050101-0698a300-dcd6-11ea-9725-409c389e9f43.png">

### Text

#### Before

<img width="834" alt="Screenshot 2020-08-12 at 19 54 28" src="https://user-images.githubusercontent.com/2320/90050251-3a73c880-dcd6-11ea-8e7c-47d8a887e63d.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 54 40" src="https://user-images.githubusercontent.com/2320/90050260-3d6eb900-dcd6-11ea-8f4a-c31eb572bffd.png">

#### After

<img width="834" alt="Screenshot 2020-08-12 at 19 49 10" src="https://user-images.githubusercontent.com/2320/90050303-4b243e80-dcd6-11ea-91fb-42b4608e65eb.png">

<img width="834" alt="Screenshot 2020-08-12 at 19 49 23" src="https://user-images.githubusercontent.com/2320/90050325-524b4c80-dcd6-11ea-8c6e-0fd43ff709b0.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/538)