### PR TITLE
fix macOS and website naming in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 This repository is a working fork of **facebook/react-native** that adds support for the official React Native for macOS implementation from Microsoft. 
 
-You can read more about the macOS implementation in our website - [React Native for Windows and Mac](https://microsoft.github.io/react-native-windows/)
+You can read more about the macOS implementation in our website - [React Native for Windows + macOS](https://microsoft.github.io/react-native-windows/)
 
 ## Contents
 
@@ -40,7 +40,7 @@ You can run React Native for macOS apps on Mac devices with versions [Mojave (10
 For a full and detailed list of the system requirements and how to set up your development platform, see our [System Requirements](https://microsoft.github.io/react-native-windows/docs/rnm-dependencies) documentation on our website.
 
 ## Getting Started
-See the [Getting Started Guide](https://microsoft.github.io/react-native-windows/docs/rnm-getting-started) on our React Native for Windows and Mac website to build your first React Native for macOS app.
+See the [Getting Started Guide](https://microsoft.github.io/react-native-windows/docs/rnm-getting-started) on our React Native for Windows + macOS website to build your first React Native for macOS app.
 
 ### Logging Issues
 Search the [existing issues](https://github.com/microsoft/react-native-macos/issues) and try to make sure your problem doesn’t already exist before opening a new issue. If your issue doesn't exist yet, try to make sure you provide as much information as possible to us so we can help you sooner. It’s helpful if you include information like:
@@ -55,9 +55,10 @@ See [Contributing guidelines](https://github.com/microsoft/react-native-macos/bl
 [Good First Issue](https://github.com/microsoft/react-native-macos/labels/good%20first%20issue) and [help wanted](https://github.com/microsoft/react-native-macos/labels/help%20wanted) are great starting points for PRs.
 
 ## Documentation
-[React Native already has great documentation](https://reactnative.dev/docs/getting-started.html) and we're working to ensure the React Native for Windows and Mac are part of that documentation story.
+[React Native already has great documentation](https://reactnative.dev/docs/getting-started.html) and we're working to ensure the React Native for Windows + macOS are part of that documentation story.
 
-[React Native for Windows and Mac](https://microsoft.github.io/react-native-windows/) has it's own separate documentation site where Windows and Mac specific information, like API docs and blog updates live. We are bootstrapping documentation for macOS at this time, tune in for updates.
+[React Native for Windows + macOS](https://microsoft.github.io/react-native-windows/) has it's own separate documentation site where Windows and macOS
+specific information, like API docs and blog updates live. We are bootstrapping documentation for macOS at this time, tune in for updates.
 
 ### Examples
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native
- [X] None of above

## Summary

This simple PR updates the documentation website naming and replaces "Mac" with "macOS" where applicable.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/543)