### PR TITLE
Don't exclude RCTProfileTrampoline for OS X

### DIFF
--- a/React/React-Core.podspec
+++ b/React/React-Core.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.osx.exclude_files      = "Modules/RCTRedBoxExtraDataViewController.{h,m}",
                              "UIUtils/*",
                              "Profiler/{RCTFPSGraph,RCTPerfMonitor}.*",
-                             "Profiler/RCTProfileTrampoline-{arm,arm64,i386}.S",
+                             "Profiler/RCTProfileTrampoline-{arm,i386}.S",
                              "Base/RCTKeyCommands.*",
                              "Base/RCTPlatform.m",
                              "Base/Surface/SurfaceHostingView/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.93",
+  "version": "0.60.0-microsoft.95",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

We have this fix in master already. We need to add it to the 0.60-stable branch which pulls it into downstream repos.

## Changelog

[macOS] [Bug] - Compile on Silicon from the 0.60-stable branch.

## Test Plan

If CI passes then it's correct.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/547)