### PR TITLE
Align some more of the publish/pr logic on android builds

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -27,47 +27,7 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - task: UseNode@1
-        inputs:
-          version: '12.x'
-
-      - template: templates/apple-droid-node-patching.yml
-        parameters:
-          apply_office_patches: true
-
-      # Install NuGet
-      - task: CmdLine@2
-        inputs:
-          script: mkdir $(System.DefaultWorkingDirectory)/nuget-bin/ && curl -o $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-
-
-      # This is currently required as the command task (strangely) always runs elevated .. 
-      # which makes all the files touched by the above patching step unreadable by following non-command tasks without sudo. 
-      # This makes all the files readable.
-      - task: CmdLine@2
-        displayName: chmod
-        inputs:
-          script: chmod -R +rw .
-
-      - task: CmdLine@2
-        displayName: "Rename package to react-native"
-        inputs:
-          script: node .ado/renamePackageForOffice.js
-
-      - task: CmdLine@2
-        displayName: npm install
-        inputs:
-          script: npm install
-
-      - task: CmdLine@2
-        displayName: nuget restore
-        inputs:
-          script: mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe restore $(System.DefaultWorkingDirectory)/ReactAndroid/packages.config -PackagesDirectory  $(System.DefaultWorkingDirectory)/ReactAndroid/packages/ -Verbosity Detailed -NonInteractive
-
-      - task: CmdLine@2
-        displayName: Setup Build Dependencies
-        inputs:
-          script: chmod +x .ado/setup_droid_deps.sh && .ado/setup_droid_deps.sh
+      - template: templates/android-build-office.yml
 
       - task: CmdLine@2
         displayName: Remove RNTesterApp.android.bundle

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -114,37 +114,7 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - task: UseNode@1
-        inputs:
-          version: '12.x'
-
-      - template: templates/apple-droid-node-patching.yml
-        parameters:
-          apply_office_patches: true
-
-      # This is currently required as the command task (strangely) always runs elevated .. 
-      # which makes all the files touched by the above patching step unreadable by following non-command tasks without sudo. 
-      # This makes all the files readable.
-      - task: CmdLine@2
-        displayName: chmod
-        inputs:
-          script: chmod -R +r .
-
-      # Install NuGet
-      - task: CmdLine@2
-        inputs:
-          script: mkdir $(System.DefaultWorkingDirectory)/nuget-bin/ && curl -o $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-        continueOnError: true
-
-      - task: CmdLine@2
-        displayName: "Rename package to react-native"
-        inputs:
-          script: node .ado/renamePackageForOffice.js
-
-      - task: CmdLine@2
-        displayName: npm install
-        inputs:
-          script: npm install
+      - template: templates/android-build-office.yml
 
       - task: CmdLine@2
         displayName: Bump package version

--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -1,0 +1,41 @@
+steps:
+  - task: UseNode@1
+    inputs:
+      version: '12.x'
+
+  - template: templates/apple-droid-node-patching.yml
+    parameters:
+      apply_office_patches: true
+
+  # This is currently required as the command task (strangely) always runs elevated .. 
+  # which makes all the files touched by the above patching step unreadable by following non-command tasks without sudo. 
+  # This makes all the files readable.
+  - task: CmdLine@2
+    displayName: chmod
+    inputs:
+      script: chmod -R +rw .
+
+  # Install NuGet
+  - task: CmdLine@2
+    inputs:
+      script: mkdir $(System.DefaultWorkingDirectory)/nuget-bin/ && curl -o $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+
+  - task: CmdLine@2
+    displayName: "Rename package to react-native"
+    inputs:
+      script: node .ado/renamePackageForOffice.js
+
+  - task: CmdLine@2
+    displayName: npm install
+    inputs:
+      script: npm install
+  
+  - task: CmdLine@2
+    displayName: nuget restore
+    inputs:
+      script: mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe restore $(System.DefaultWorkingDirectory)/ReactAndroid/packages.config -PackagesDirectory  $(System.DefaultWorkingDirectory)/ReactAndroid/packages/ -Verbosity Detailed -NonInteractive
+
+  - task: CmdLine@2
+    displayName: Setup Build Dependencies
+    inputs:
+      script: chmod +x .ado/setup_droid_deps.sh && .ado/setup_droid_deps.sh

--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -3,7 +3,7 @@ steps:
     inputs:
       version: '12.x'
 
-  - template: templates/apple-droid-node-patching.yml
+  - template: apple-droid-node-patching.yml
     parameters:
       apply_office_patches: true
 


### PR DESCRIPTION
The publish build got out of sync during the 0.62 merge.  This moves more of the build logic to a shared yml file to keep them in sync better.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/548)