### PR TITLE
Disable RCT_PROFILE for macos

### DIFF
--- a/.ado/templates/apple-job-javascript.yml
+++ b/.ado/templates/apple-job-javascript.yml
@@ -8,8 +8,8 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
-  - script: brew link node@10 --overwrite --force
-    displayName: 'ensure node 10'
+  - script: brew link node@12 --overwrite --force
+    displayName: 'ensure node 12'
 
   - template: apple-xcode-select.yml
 

--- a/.ado/templates/apple-job-javascript.yml
+++ b/.ado/templates/apple-job-javascript.yml
@@ -8,6 +8,9 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
+  - script: sudo chown -R $(whoami) /usr/local/*
+    displayName: 'fix node permissions'
+
   - script: brew link node@12 --overwrite --force
     displayName: 'ensure node 12'
 

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -22,6 +22,7 @@ steps:
     displayName: 'brew bundle'
 
   - script: brew link node@12 --overwrite --force
+    displayName: 'ensure node 12'
 
   # Task Group: XCode select proper version
   - template: apple-xcode-select.yml

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -21,6 +21,9 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
+  - script: sudo chown -R $(whoami) /usr/local/*
+    displayName: 'fix node permissions'
+
   - script: brew link node@12 --overwrite --force
     displayName: 'ensure node 12'
 

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -21,7 +21,7 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
-  - script: brew link node@10 --overwrite --force
+  - script: brew link node@12 --overwrite --force
 
   # Task Group: XCode select proper version
   - template: apple-xcode-select.yml

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,2 @@
-brew "node@10"
+brew "node@12"
 brew "watchman"

--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -69,7 +69,7 @@
 #define RCT_IF_DEV(...)
 #endif
 
-#if !TARGET_OS_OSX // TODO [GH #533]
+#if !TARGET_OS_OSX // TODO [GH #533] Turn off for iOS as well so we don't break App Store guidelines
 #ifndef RCT_PROFILE
 #define RCT_PROFILE RCT_DEV
 #endif

--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -69,11 +69,11 @@
 #define RCT_IF_DEV(...)
 #endif
 
-#if !TARGET_OS_OSX
+#if !TARGET_OS_OSX // TODO [GH #533]
 #ifndef RCT_PROFILE
 #define RCT_PROFILE RCT_DEV
 #endif
-#endif // !TARGET_OS_OSX
+#endif // !TARGET_OS_OSX TODO [GH #533]
 
 /**
  * Add the default Metro packager port number

--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -69,9 +69,11 @@
 #define RCT_IF_DEV(...)
 #endif
 
+#if !TARGET_OS_OSX
 #ifndef RCT_PROFILE
 #define RCT_PROFILE RCT_DEV
 #endif
+#endif // !TARGET_OS_OSX
 
 /**
  * Add the default Metro packager port number

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.96",
+  "version": "0.60.0-microsoft.97",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Inside an RCT_PROFILE is the only place we reference RCTProfileTrampoline. We don't actually need this profiler to ship and react-native isn't respecting the _arm64_ macro which would be needed for us to pull in the RCTProfileTrampoline definition.

Leaving it on for iOS for now to reduce the amount of short term changes needed in this area as iOS isn't blocked by this.

## Changelog

[macOS] [Bug] - Disable a profiling macro we don't need

## Test Plan

CI passes and builds produce arm64 bits

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/554)