### PR TITLE
reduce minimum macOS SDK version to 10.13

### DIFF
--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -21,9 +21,6 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
-  - script: 'sudo chown -R $(whoami) /usr/local'
-    displayName: 'take over the rights to /usr/local'
-
   - script: brew link node@12 --overwrite --force
     displayName: 'ensure node 12'
 

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -21,6 +21,9 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
+  - script: 'sudo chown -R $(whoami) /usr/local'
+    displayName: 'take over the rights to /usr/local'
+
   - script: brew link node@12 --overwrite --force
     displayName: 'ensure node 12'
 

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -21,7 +21,7 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
-  - script: brew link node@12 --overwrite --force
+  - script: brew install node@12 || brew link node@12 --overwrite --force
     displayName: 'ensure node 12'
 
   # Task Group: XCode select proper version

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -21,7 +21,7 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
-  - script: brew install node@12 || brew link node@12 --overwrite --force
+  - script: brew link node@12 --overwrite --force
     displayName: 'ensure node 12'
 
   # Task Group: XCode select proper version

--- a/.ado/variables/mac.yml
+++ b/.ado/variables/mac.yml
@@ -1,2 +1,2 @@
 variables:
-  VmImage: macOS-10.13
+  VmImage: macOS-10.14

--- a/.ado/variables/mac.yml
+++ b/.ado/variables/mac.yml
@@ -1,2 +1,2 @@
 variables:
-  VmImage: macOS-10.14
+  VmImage: macOS-10.13

--- a/Libraries/ART/React-ART.podspec
+++ b/Libraries/ART/React-ART.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files           = "**/*.{m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
+++ b/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/actionsheetios"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files           = "*.{m}"
   s.preserve_paths          = "package.json", "LICENSE", "LICENSE-docs"

--- a/Libraries/Blob/React-RCTBlob.podspec
+++ b/Libraries/Blob/React-RCTBlob.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/FBLazyVector/FBLazyVector.podspec
+++ b/Libraries/FBLazyVector/FBLazyVector.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS ISS#2323203)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS ISS#2323203)
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "FBLazyVector"

--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec.podspec
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS ISS#2323203)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS ISS#2323203)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"

--- a/Libraries/Image/React-RCTImage.podspec
+++ b/Libraries/Image/React-RCTImage.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/image"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/linking"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "{Drivers/*,Nodes/*,*}.{m,mm}"

--- a/Libraries/Network/React-RCTNetwork.podspec
+++ b/Libraries/Network/React-RCTNetwork.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/pushnotificationios"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/RCTRequired/RCTRequired.podspec
+++ b/Libraries/RCTRequired/RCTRequired.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS ISS#2323203)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS ISS#2323203)
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "RCTRequired"

--- a/Libraries/Settings/React-RCTSettings.podspec
+++ b/Libraries/Settings/React-RCTSettings.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/settings"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/Text/React-RCTText.podspec
+++ b/Libraries/Text/React-RCTText.podspec
@@ -19,12 +19,12 @@ end
 Pod::Spec.new do |s|
   s.name                   = "React-RCTText"
   s.version                = version
-  s.summary                = "A React component for displaying text." 
+  s.summary                = "A React component for displaying text."
   s.homepage               = "http://facebook.github.io/react-native/"
   s.documentation_url      = "https://facebook.github.io/react-native/docs/text"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files           = "**/*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/Libraries/TypeSafety/RCTTypeSafety.podspec
+++ b/Libraries/TypeSafety/RCTTypeSafety.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS ISS#2323203)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS ISS#2323203)
   s.compiler_flags         = folly_compiler_flags
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"

--- a/Libraries/Vibration/React-RCTVibration.podspec
+++ b/Libraries/Vibration/React-RCTVibration.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/vibration"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can read more about the macOS implementation in our website - [React Native 
 
 ## Requirements
 
-You can run React Native for macOS apps on Mac devices with versions [Mojave (10.14.6)](https://support.apple.com/en-us/HT209149#macos10146) or newer.
+You can run React Native for macOS apps on Mac devices with versions [High Sierra (10.13)](https://www.apple.com/newsroom/2017/09/macos-high-sierra-now-available-as-a-free-update/) or newer.
 
 For a full and detailed list of the system requirements and how to set up your development platform, see our [System Requirements](https://microsoft.github.io/react-native-windows/docs/rnm-dependencies) documentation on our website.
 

--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -63,7 +63,7 @@ def pods(options = {})
   # use_react_native!(path: "..", fabric_enabled: true)
 end
 
-  
+
 def flipper_pods()
   flipperkit_version = '0.30.1'
   pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
@@ -116,7 +116,7 @@ target 'RNTester' do
 end
 
 target 'RNTester-macOS' do
-  platform :osx, '10.14'
+  platform :osx, '10.13'
   pods(:hermes_enabled => true)
 end
 
@@ -127,7 +127,7 @@ target 'RNTesterUnitTests' do
 end
 
 target 'RNTester-macOSUnitTests' do
-  platform :osx, '10.14'
+  platform :osx, '10.13'
   pods()
   pod 'React-RCTTest', :path => "RCTTest"
 end
@@ -139,7 +139,7 @@ target 'RNTesterIntegrationTests' do
 end
 
 target 'RNTester-macOSIntegrationTests' do
-  platform :osx, '10.14'
+  platform :osx, '10.13'
   pods()
   pod 'React-RCTTest', :path => "RCTTest"
 end
@@ -156,7 +156,7 @@ target 'iosSimulatorBuild' do
 end
 
 target 'macOSBuild' do
-  platform :osx, '10.14'
+  platform :osx, '10.13'
   pods()
 end
 # ]TODO(macOS ISS#2323203)

--- a/RNTester/RCTTest/React-RCTTest.podspec
+++ b/RNTester/RCTTest/React-RCTTest.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files           = "**/*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/RNTester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/RNTester/RNTesterPods.xcodeproj/project.pbxproj
@@ -1851,7 +1851,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
@@ -1886,7 +1886,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1920,7 +1920,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
@@ -1956,7 +1956,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1991,7 +1991,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
@@ -2024,7 +2024,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS ISS#2323203)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS ISS#2323203)
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
@@ -85,7 +85,7 @@ Pod::Spec.new do |s|
 
   # [TODO(macOS GH#214)
   s.subspec "Hermes" do |ss|
-    ss.platforms = { :osx => "10.14" }
+    ss.platforms = { :osx => "10.13" }
     ss.source_files = "ReactCommon/hermes/executor/*.{cpp,h}",
                       "ReactCommon/hermes/inspector/*.{cpp,h}",
                       "ReactCommon/hermes/inspector/chrome/*.{cpp,h}",

--- a/React.podspec
+++ b/React.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.cocoapods_version      = ">= 1.2.0"

--- a/React/CoreModules/React-CoreModules.podspec
+++ b/React/CoreModules/React-CoreModules.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS ISS#2323203)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS ISS#2323203)
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{c,m,mm,cpp}"

--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.header_dir             = "ReactCommon" # Use global header_dir for all subspecs for use_frameworks! compatibility
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"

--- a/ReactCommon/jsi/React-jsi.podspec
+++ b/ReactCommon/jsi/React-jsi.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.exclude_files          = "**/test/*"

--- a/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files         = "jsireact/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/ReactCommon/jsinspector/React-jsinspector.podspec
+++ b/ReactCommon/jsinspector/React-jsinspector.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "http://facebook.github.io/react-native/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  s.platforms              = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = 'jsinspector'

--- a/ReactCommon/yoga/Yoga.podspec
+++ b/ReactCommon/yoga/Yoga.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |spec|
   ]
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
+  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" }
 
   # Set this environment variable when *not* using the `:path` option to install the pod.
   # E.g. when publishing this spec to a spec repo.

--- a/local-cli/generator-macos/templates/macos/HelloWorld.xcodeproj/project.pbxproj
+++ b/local-cli/generator-macos/templates/macos/HelloWorld.xcodeproj/project.pbxproj
@@ -465,7 +465,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				INFOPLIST_FILE = "HelloWorld-macos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -485,7 +485,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = "HelloWorld-macos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/local-cli/generator-macos/templates/macos/Podfile
+++ b/local-cli/generator-macos/templates/macos/Podfile
@@ -78,13 +78,13 @@ abstract_target 'Shared' do
   pod 'boost-for-react-native', :podspec => '../node_modules/react-native-macos/third-party-podspecs/boost-for-react-native.podspec'
 
   target 'HelloWorld-macOS' do
-    platform :macos, '10.14'
+    platform :macos, '10.13'
     use_native_modules!
 
     # Enables Hermes
     #
     # Be sure to first install the `hermes-engine-darwin` npm package, e.g.:
-    # 
+    #
     #   $ yarn add --dev 'hermes-engine-darwin@^0.4.3'
     #
     # pod 'React-Core/Hermes', :path => '../node_modules/react-native-macos/'

--- a/third-party-podspecs/DoubleConversion.podspec
+++ b/third-party-podspecs/DoubleConversion.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |spec|
   spec.compiler_flags = '-Wno-unreachable-code'
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
 
 end

--- a/third-party-podspecs/RCT-Folly.podspec
+++ b/third-party-podspecs/RCT-Folly.podspec
@@ -116,5 +116,5 @@ Pod::Spec.new do |spec|
   # ]TODO(macOS GH#214)
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
 end

--- a/third-party-podspecs/boost-for-react-native.podspec
+++ b/third-party-podspecs/boost-for-react-native.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   # Pinning to the same version as React.podspec.
   # TODO: Move this osx addition back upstream to https://github.com/react-native-community/boost-for-react-native
-  spec.platforms = { :ios => '8.0', :tvos => '9.2', :osx => "10.14" }
+  spec.platforms = { :ios => '8.0', :tvos => '9.2', :osx => "10.13" }
   spec.requires_arc = false
 
   spec.module_name = 'boost'

--- a/third-party-podspecs/glog.podspec
+++ b/third-party-podspecs/glog.podspec
@@ -34,6 +34,6 @@ Pod::Spec.new do |spec|
                                "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" } # TODO(macOS GH#214)
+  spec.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.13" } # TODO(macOS GH#214)
 
 end

--- a/third-party-podspecs/libevent.podspec
+++ b/third-party-podspecs/libevent.podspec
@@ -469,7 +469,7 @@ CONFIG_WITHOUT_OPENSSL = <<-END_OF_CONFIG
 #ifdef __USE_UNUSED_DEFINITIONS__
 /* Define to necessary symbol if this constant uses a non-standard name on your system. */
 /* XXX: Hello, this isn't even used, nor is it defined anywhere... - Ellzey */
-#define EVENT__PTHREAD_CREATE_JOINABLE 
+#define EVENT__PTHREAD_CREATE_JOINABLE
 #endif
 
 /* The size of `pthread_t', as computed by sizeof. */
@@ -544,7 +544,7 @@ Pod::Spec.new do |spec|
   spec.homepage        = "https://libevent.org"
   spec.license         = { :type => "BSD 3-Clause", :file => "LICENSE" }
   spec.author          = "Niels Provos and Nick Mathewson"
-  spec.platforms       = { :osx => "10.14" }
+  spec.platforms       = { :osx => "10.13" }
   spec.source          = { :git => "https://github.com/libevent/libevent.git", :tag => "release-#{spec.version}-stable" }
   spec.default_subspec = "core"
   spec.prepare_command = "touch evconfig-private.h; echo -e #{Shellwords.escape(CONFIG_WITHOUT_OPENSSL)} > include/event2/event-config.h"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

According to the latest conversation on the Discord the minimum macOS SDK version can be safely reduced to the 10.13 release. This PR updates all the `podspec` files, project files, deployment targets and ~~CI VM image~~ (there is no CI image for 10.13) to the selected version.

For the link in the Readme file I have used the Apple release post, refs microsoft/react-native-windows-samples#196.

CC @alloy & @tom-un 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[macOS] [Changed] - reduce the minim macOS SDK from 10.14 to 10.13

## Test Plan

After introducing the changes I was able to build and run RNTester locally.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/555)