### PR TITLE
[template] Hermes is a runtime dependency

### DIFF
--- a/local-cli/generator-macos/templates/macos/Podfile
+++ b/local-cli/generator-macos/templates/macos/Podfile
@@ -85,7 +85,7 @@ abstract_target 'Shared' do
     #
     # Be sure to first install the `hermes-engine-darwin` npm package, e.g.:
     #
-    #   $ yarn add --dev 'hermes-engine-darwin@^0.4.3'
+    #   $ yarn add 'hermes-engine-darwin@^0.4.3'
     #
     # pod 'React-Core/Hermes', :path => '../node_modules/react-native-macos/'
     # pod 'hermes', :path => '../node_modules/hermes-engine-darwin'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Hermes is a runtime dependency


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/561)