### PR TITLE
Get on that release train

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -43,6 +43,9 @@ jobs:
         inputs:
           command: 'publish'
           publishEndpoint: 'npmjs'
+          script: |
+            node scripts/bump-oss-version.js --nightly
+            npm publish --tag nightly
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
       - task: Npm@1

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -6,7 +6,7 @@ trigger:
   branches:
     include:
       - master
-      - fabric
+      - '*-stable'
   paths:
     exclude:
       - package.json
@@ -70,6 +70,7 @@ jobs:
       vmImage: vs2017-win2016
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+    condition: eq(variables['Build.SourceBranchName'], 'master')
     steps:
       - checkout: self # self represents the repo where the initial Pipelines YAML file was found
         clean: true # whether to fetch clean each time

--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -1,38 +1,3 @@
-# [TODO(macOS GH#217)
-#
-# This monkey-patching of the CocoaPods Specification class will strip our MS versions from the specifications and
-# replace them with `1000.0.0`, which is the version that upstream always has set in `master`.
-module StripMSVersion
-  require 'cocoapods-core/specification'
-  Pod::Specification.prepend(self)
-
-  def source=(source)
-    if source.is_a?(Hash) && source.has_key?(:tag)
-      super(source.merge(:tag => StripMSVersion.strip(source[:tag])))
-    else
-      super
-    end
-  end
-
-  def version=(version)
-    super(StripMSVersion.strip(version))
-  end
-
-  def dependency(dep, *args)
-    version, *other_version_requirements = args
-    super(dep, *[StripMSVersion.strip(version), *other_version_requirements].compact)
-  end
-
-  private
-
-  CURRENT_VERSION = JSON.parse(File.read('../package.json'))['version']
-
-  def self.strip(version)
-    version && (version == CURRENT_VERSION ? '1000.0.0' : version)
-  end
-end
-# ]TODO(macOS GH#214)
-
 source 'https://cdn.cocoapods.org/'
 
 require_relative '../scripts/autolink-ios'
@@ -62,7 +27,6 @@ def pods(options = {})
   # To use fabric: add `fabric_enabled` option to the use_react_native method above, like below
   # use_react_native!(path: "..", fabric_enabled: true)
 end
-
 
 def flipper_pods()
   flipperkit_version = '0.30.1'

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -477,8 +477,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: a1bc12a74baa397a2609e0f10e19b8062d864053
-  FBLazyVector: 608bcd1aa7ed0e8bb2a18ddca41fae8c2d9b2f56
-  FBReactNativeSpec: 0e211f93289c3312ddb5ffe7c79e040b7f4459b5
+  FBLazyVector: 0f0dafaac12e3e808b2237d690158d97ebf221cf
+  FBReactNativeSpec: f6950f1007f1cf09a4f481dd8244ecfe34f2011f
   Flipper: 10b225e352595f521be0e5badddd90e241336e89
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -488,34 +488,34 @@ SPEC CHECKSUMS:
   FlipperKit: 88b7f0d0cf907ddc2137b85eeb7f3d4d8d9395c8
   glog: b3f6d74f3e2d33396addc0ee724d2b2b79fc3e00
   hermes: e6c81c75290bb87d1d62d594c269fba09b84e216
-  libevent: c2d56c8554ac18101d9c5f4c66ef762798209682
+  libevent: ee9265726a1fc599dea382964fa304378affaa5f
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
-  RCT-Folly: 2a6bc6b1d37b83324c2c36358a32c7d445f3a723
-  RCTRequired: 1a4a6deb04ef543cb6cffb21ee3a179e6b3e6865
-  RCTTypeSafety: 2532ad546e8347efd5f373f690263f51dfa94423
-  React: 47b69af9919235656cc25e2e86debf6839636214
-  React-ART: 08c29f830aadd2b27674c31f247f59b494d50a8c
-  React-Core: bfd749140a498e345fe189cfdd64eafa384e989b
-  React-CoreModules: e163e0889963feb30d6e92f734b12b377a227c40
-  React-cxxreact: efe809b9f613cfb093e01f12b9cf901dd36d10cd
-  React-jsi: 7a7d5760223cd78ceebedb4112fb4dc9b1e95d8e
-  React-jsiexecutor: 95b7e2383f25243ef1e36555a6f75bce5c857949
-  React-jsinspector: a3c898224e45efb69304a79e8c6d560e9067e7fc
-  React-RCTActionSheet: d57eda7986cf2b137b0eae25dc8cb945d4299a27
-  React-RCTAnimation: 3d0715141579f0a8d1a8875d9f4a9eaa651e0daa
-  React-RCTBlob: 5821a16d00783cc370429d8992adb0102b9a227c
-  React-RCTImage: 7987d067ac83e4e4978764738bd04d6de4c52cf6
-  React-RCTLinking: 40694502840d758d5795fb92db7e3298de184c87
-  React-RCTNetwork: 85f1f77bf10927afe802816b398a34b0debca1b2
-  React-RCTPushNotification: 7f6f5f6ffeaad730be18102aa9f2ecba4ffd6611
-  React-RCTSettings: 7a45d20ca5cb14c4edde6613cea95ebb98a9f586
-  React-RCTTest: d22d238152ab61d1b5a1a3aa602339e3a657efea
-  React-RCTText: 1c68c9fccbeeea190df0a1e56727bbe6e4db0a48
-  React-RCTVibration: a77d5b69d1542199721085d3c1828c269ad4250c
-  ReactCommon: c942d0813e1921710d25a939cbb036211d77cfc2
-  Yoga: eb6965db3660dae59600f6fbaa0cc0e6fb04b87b
+  RCT-Folly: 71ece0166f9c96c1ec9279eeb0317baf533c020f
+  RCTRequired: f2794205be8a3b2ba61382240df529f0dd009880
+  RCTTypeSafety: 76cf36fbf585ac17d4af1768f72e51e0b1717b2d
+  React: ae7117f577e3e61edc1bdd1f262bc3580a13b9f4
+  React-ART: 0db154cad0b1c07e7d6c42bdae38b28decffb9e3
+  React-Core: d154b6cf2fae9591f769f87018848c784c609995
+  React-CoreModules: a2a6c6b4bb6d41fb29673e754eead4373a4f6237
+  React-cxxreact: e204f665014dddb57b5467b4095585c9564948a1
+  React-jsi: 0aaf953b7eafa256686e6c42aa10644ed6247708
+  React-jsiexecutor: c66152f7e470a664ff76613d76f2cb6f2585a907
+  React-jsinspector: e00233acb2f7a9ce55cbb4d447fd42771310c25b
+  React-RCTActionSheet: 5268a445ce84a692c864f8c57f0aeb3235d84fe2
+  React-RCTAnimation: 154d09d475f2ede991fea04d4d3288a6c5d97022
+  React-RCTBlob: 7d35c0505beda95f0bb920e605df947b34463b91
+  React-RCTImage: 985f88d383119e69f1f0b07e6048347b6bd42c4a
+  React-RCTLinking: 65c6380b1a3a928f5b50a83189cff079ecf2b3dc
+  React-RCTNetwork: 9a78d16dbb98b9750027203a4cbe4f44b2972abc
+  React-RCTPushNotification: c39e51d1da80b573347b6cdd2fa677eb750592a5
+  React-RCTSettings: 17c87ad0843f023608b6a714f4aa64d467cc81c9
+  React-RCTTest: 5fc5fafa40b85266b5276186f8c6236d5e92ce04
+  React-RCTText: 7b9a0af0babcade250b3c6409de133984ed80c7b
+  React-RCTVibration: ed82d66986a1226359ea8f1ff9bd6b308d15c418
+  ReactCommon: e35c0871c05280d11b8fccc5f0efa7d4b8250376
+  Yoga: d5cf0a8d24d4c80cdee81aa11cc8d3c029eef0fe
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 0e2c0cafaedd257c0e62d6125ab016426ed6da18
+PODFILE CHECKSUM: 8a50297c26ad9d948d1614b33e20d755094cb377
 
 COCOAPODS: 1.8.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.62.1",
+  "version": "1000.0.0",
   "bin": "./cli.js",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -23,29 +23,42 @@ const yargs = require('yargs');
 let argv = yargs.option('r', {
   alias: 'remote',
   default: 'origin',
+})
+.option('n', {
+  alias: 'nightly',
+  type: 'boolean',
+  default: false,
 }).argv;
 
-// Check we are in release branch, e.g. 0.33-stable
-let branch = exec('git symbolic-ref --short HEAD', {
-  silent: true,
-}).stdout.trim();
+const nightlyBuild = argv.nightly;
 
-if (branch.indexOf('-stable') === -1) {
-  echo('You must be in 0.XX-stable branch to bump a version');
-  exit(1);
-}
+let version, branch;
+if (nightlyBuild) {
+  const currentCommit = exec('git rev-parse HEAD', {silent: true}).stdout.trim();
+  version = `0.0.0-${currentCommit.slice(0, 9)}`;
+} else {
+  // Check we are in release branch, e.g. 0.33-stable
+  branch = exec('git symbolic-ref --short HEAD', {
+    silent: true,
+  }).stdout.trim();
 
-// e.g. 0.33
-let versionMajor = branch.slice(0, branch.indexOf('-stable'));
+  if (branch.indexOf('-stable') === -1) {
+    echo('You must be in 0.XX-stable branch to bump a version');
+    exit(1);
+  }
 
-// - check that argument version matches branch
-// e.g. 0.33.1 or 0.33.0-rc4
-let version = argv._[0];
-if (!version || version.indexOf(versionMajor) !== 0) {
-  echo(
-    `You must pass a tag like 0.${versionMajor}.[X]-rc[Y] to bump a version`,
-  );
-  exit(1);
+  // e.g. 0.33
+  let versionMajor = branch.slice(0, branch.indexOf('-stable'));
+
+  // - check that argument version matches branch
+  // e.g. 0.33.1 or 0.33.0-rc4
+  version = argv._[0];
+  if (!version || version.indexOf(versionMajor) !== 0) {
+    echo(
+      `You must pass a tag like 0.${versionMajor}.[X]-rc[Y] to bump a version`,
+    );
+    exit(1);
+  }
 }
 
 // Generate version files to detect mismatches between JS and native.
@@ -80,6 +93,19 @@ fs.writeFileSync(
     .replace(
       '${prerelease}',
       prerelease !== undefined ? `@"${prerelease}"` : '[NSNull null]',
+    ),
+  'utf-8',
+);
+
+fs.writeFileSync(
+  'ReactCommon/cxxreact/ReactNativeVersion.h',
+  cat('scripts/versiontemplates/ReactNativeVersion.h.template')
+    .replace('${major}', major)
+    .replace('${minor}', minor)
+    .replace('${patch}', patch)
+    .replace(
+      '${prerelease}',
+      prerelease !== undefined ? `"${prerelease}"` : '""',
     ),
   'utf-8',
 );
@@ -122,43 +148,48 @@ let numberOfChangedLinesWithNewVersion = exec(
   `git diff -U0 | grep '^[+]' | grep -c ${version} `,
   {silent: true},
 ).stdout.trim();
-if (+numberOfChangedLinesWithNewVersion !== 3) {
-  echo(
-    'Failed to update all the files. package.json and gradle.properties must have versions in them',
-  );
-  echo('Fix the issue, revert and try again');
-  exec('git diff');
-  exit(1);
+
+// Release builds should commit the version bumps, and create tags.
+// Nightly builds do not need to do that.
+if (!nightlyBuild) {
+  if (+numberOfChangedLinesWithNewVersion !== 3) {
+    echo(
+      'Failed to update all the files. package.json and gradle.properties must have versions in them',
+    );
+    echo('Fix the issue, revert and try again');
+    exec('git diff');
+    exit(1);
+  }
+
+  // Make commit [0.21.0-rc] Bump version numbers
+  if (exec(`git commit -a -m "[${version}] Bump version numbers"`).code) {
+    echo('failed to commit');
+    exit(1);
+  }
+
+  // Add tag v0.21.0-rc
+  if (exec(`git tag v${version}`).code) {
+    echo(
+      `failed to tag the commit with v${version}, are you sure this release wasn't made earlier?`,
+    );
+    echo('You may want to rollback the last commit');
+    echo('git reset --hard HEAD~1');
+    exit(1);
+  }
+
+  // Push newly created tag
+  let remote = argv.remote;
+  exec(`git push ${remote} v${version}`);
+
+  // Tag latest if doing stable release
+  if (version.indexOf('rc') === -1) {
+    exec('git tag -d latest');
+    exec(`git push ${remote} :latest`);
+    exec('git tag latest');
+    exec(`git push ${remote} latest`);
+  }
+
+  exec(`git push ${remote} ${branch} --follow-tags`);
 }
-
-// Make commit [0.21.0-rc] Bump version numbers
-if (exec(`git commit -a -m "[${version}] Bump version numbers"`).code) {
-  echo('failed to commit');
-  exit(1);
-}
-
-// Add tag v0.21.0-rc
-if (exec(`git tag v${version}`).code) {
-  echo(
-    `failed to tag the commit with v${version}, are you sure this release wasn't made earlier?`,
-  );
-  echo('You may want to rollback the last commit');
-  echo('git reset --hard HEAD~1');
-  exit(1);
-}
-
-// Push newly created tag
-let remote = argv.remote;
-exec(`git push ${remote} v${version}`);
-
-// Tag latest if doing stable release
-if (version.indexOf('rc') === -1) {
-  exec('git tag -d latest');
-  exec(`git push ${remote} :latest`);
-  exec('git tag latest');
-  exec(`git push ${remote} latest`);
-}
-
-exec(`git push ${remote} ${branch} --follow-tags`);
 
 exit(0);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

* Publish changes to `master` as `0.0.0-canary.x` releases
* Publish changes to `*-stable` as `0.x.y` releases

Next step, if this succeeds, is to create a `0.62-stable` branch and continue onward from `0.62.3`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/565)