### PR TITLE
Push up intel fixes to RCT_PROFILE

### DIFF
--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -69,7 +69,7 @@
 #define RCT_IF_DEV(...)
 #endif
 
-#if !TARGET_OS_OSX // TODO [GH #533] Turn off for iOS as well so we don't break App Store guidelines
+#if 0 // TODO [GH #533] The swizzling done under RCT_PROFILE puts us at high risk of app store rejection
 #ifndef RCT_PROFILE
 #define RCT_PROFILE RCT_DEV
 #endif

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.100",
+  "version": "0.60.0-microsoft.101",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

A previous commit attempted to compile out all RCT_PROFILE code for macOS using !TARGET_OS_OSX since it wasn't building with Xcode 12 universal and is a severe App Store rejection risk as well as code quality risk due to the swizzling. This successfully removed usage of it in one compilation unit that was indirectly including TargetConditionals.h but not in another where TARGET_OS_OSX was then undefined.

Ultimately we don't want this code lit up on either macOS or iOS in bits we submit to the App Store so let's just compile it out for now with #if 0 and avoid the need for TargetConditionals.h

## Changelog

[iOS] [macOS] [Fixed] - Compile out any code under RCT_PROFILE

## Test Plan

Just confirming build and CI since it is just removing debug-only code

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/566)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/567)