### PR TITLE
[ado] Do not bump versions in master nor publish as stable

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -34,18 +34,23 @@ jobs:
           script: npm install
 
       - task: CmdLine@2
-        displayName: Bump package version
+        displayName: Bump stable package version
         inputs:
           script: node .ado/bumpFileVersions.js
+        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+
+      - task: CmdLine@2
+        displayName: Bump nightly package version
+        inputs:
+          script: node scripts/bump-oss-version.js --nightly
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - task: Npm@1
         displayName: "Publish latest react-native-macos to npmjs.org"
         inputs:
-          command: 'publish'
+          command: 'custom'
+          customCommand: publish --tag nightly
           publishEndpoint: 'npmjs'
-          script: |
-            node scripts/bump-oss-version.js --nightly
-            npm publish --tag nightly
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
       - task: Npm@1

--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -63,7 +63,7 @@ steps:
   - task: CmdLine@2
     displayName: Bump package version
     inputs:
-      script: node .ado/bumpFileVersions.js
+      script: node scripts/bump-oss-version.js --nightly
 
   - script: |
       npm publish --registry http://localhost:4873

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "1000.0.2",
+  "version": "1000.0.0",
   "bin": "./cli.js",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Amends the changes from https://github.com/microsoft/react-native-macos/pull/565 to no longer bump the version in `master` nor publish with the `latest` tag.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/568)