### PR TITLE
[ado] Don't tag nightly releases

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -62,6 +62,7 @@ jobs:
           BUILD_SOURCEBRANCH: $(Build.SourceBranch)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           githubApiToken: $(githubApiToken)
+        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
 
   - job: RNMacOSInitNpmJSPublish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.0.0-f56865821",
+  "version": "1000.0.0",
   "bin": "./cli.js",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

No need for tags of nightly releases—the versions actually have the commit hash encoded.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/570)