### PR TITLE
[aod] Allow tagging a stable branch as latest

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -19,9 +19,9 @@ variables:
   ${{ if eq(variables['Build.SourceBranchName'], variables['latestStableBranch']) }}:
     npmDistTag: latest
   ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
-    npmDistTag: nightly
+    npmDistTag: canary
   ${{ if and(ne(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.SourceBranchName'], variables['latestStableBranch'])) }}:
-    npmDistTag: ${{variables['Build.SourceBranchName']}}
+    npmDistTag: v${{variables['Build.SourceBranchName']}}
 
 jobs:
   - job: RNGithubNpmJSPublish
@@ -50,7 +50,7 @@ jobs:
         condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - task: CmdLine@2
-        displayName: Bump nightly package version
+        displayName: Bump canary package version
         inputs:
           script: node scripts/bump-oss-version.js --nightly
         condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -13,6 +13,15 @@ trigger:
 
 pr: none
 
+variables:
+  latestStableBranch: 0.62-stable
+  ${{ if eq(variables['Build.SourceBranchName'], variables['latestStableBranch']) }}:
+    npmDistTag: latest
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+    npmDistTag: nightly
+  ${{ if and(ne(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.SourceBranchName'], variables['latestStableBranch'])) }}:
+    npmDistTag: ${{variables['Build.SourceBranchName']}}
+
 jobs:
   - job: RNGithubNpmJSPublish
     displayName: React-Native GitHub Publish to npmjs.org
@@ -45,13 +54,8 @@ jobs:
           script: node scripts/bump-oss-version.js --nightly
         condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
-      - script: npm publish --tag nightly --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
-        displayName: Publish nightly react-native-macos to npmjs.org
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-
-      - script: npm publish --tag $(Build.SourceBranchName) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
-        displayName: Publish stable react-native-macos to npmjs.org
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+      - script: npm publish --tag ${{npmDistTag}} --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+        displayName: Publish ${{npmDistTag}} react-native-macos to npmjs.org
 
       - task: CmdLine@2
         displayName: 'Tag published release'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -13,8 +13,9 @@ trigger:
 
 pr: none
 
+# It is expected that a `latestStableBranch` variable is set in the pipeline's settings:
+# https://dev.azure.com/ms/react-native/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=221
 variables:
-  latestStableBranch: 0.62-stable
   ${{ if eq(variables['Build.SourceBranchName'], variables['latestStableBranch']) }}:
     npmDistTag: latest
   ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Allow tagging a stable branch as latest and refactor npm publish task to be more DRY.

This is all per [these ADO docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops), but I couldn't figure out if there’s some tooling to test how these things get evaluated.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/571)