### PR TITLE
[ado] Fix variable reference

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -55,8 +55,8 @@ jobs:
           script: node scripts/bump-oss-version.js --nightly
         condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
-      - script: npm publish --tag ${{npmDistTag}} --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
-        displayName: Publish ${{npmDistTag}} react-native-macos to npmjs.org
+      - script: npm publish --tag ${{variables.npmDistTag}} --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+        displayName: Publish ${{variables.npmDistTag}} react-native-macos to npmjs.org
 
       - task: CmdLine@2
         displayName: 'Tag published release'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Need to refer to the `variables` global, most probably: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#variables

https://dev.azure.com/ms/react-native/_build/results?buildId=106339&view=results


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/572)