### PR TITLE
Internal: Add libreactnativeblob to nuget

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -134,7 +134,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'NuGet pack'
         inputs:
-          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(System.DefaultWorkingDirectory) -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
+          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
 
       - task: CmdLine@2
         displayName: 'Npm pack'

--- a/android-patches/patches-0.62.2/BasicBuild/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches-0.62.2/BasicBuild/ReactAndroid/ReactAndroid.nuspec
@@ -1,6 +1,6 @@
 --- "E:\\github\\react-native-v62.2\\ReactAndroid\\ReactAndroid.nuspec"	1969-12-31 16:00:00.000000000 -0800
 +++ "E:\\github\\msrn-62\\ReactAndroid\\ReactAndroid.nuspec"	2020-05-20 21:13:29.624582800 -0700
-@@ -0,0 +1,130 @@
+@@ -0,0 +1,140 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
@@ -44,6 +44,11 @@
 +    <file src="build\react-ndk\all\armeabi-v7a\libjsinspector.so" target="lib\droidarm"/>
 +    <file src="build\react-ndk\all\x86\libjsinspector.so" target="lib\droidx86"/>
 +    <file src="build\react-ndk\all\arm64-v8a\libjsinspector.so" target="lib\droidarm64"/>
++
++    <file src="build\react-ndk\all\x86_64\libreactnativeblob.so" target="lib\droidx64"/>
++    <file src="build\react-ndk\all\armeabi-v7a\libreactnativeblob.so" target="lib\droidarm"/>
++    <file src="build\react-ndk\all\x86\libreactnativeblob.so" target="lib\droidx86"/>
++    <file src="build\react-ndk\all\arm64-v8a\libreactnativeblob.so" target="lib\droidarm64"/>
 +
 +    <file src="build\react-ndk\all\x86_64\libreactnativejni.so" target="lib\droidx64"/>
 +    <file src="build\react-ndk\all\armeabi-v7a\libreactnativejni.so" target="lib\droidarm"/>
@@ -95,6 +100,11 @@
 +    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libjsinspector.so" target="lib\droidarm\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\x86\libjsinspector.so" target="lib\droidx86\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libjsinspector.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\tmp\buildReactNdkLib\local\x86_64\libreactnativeblob.so" target="lib\droidx64\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libreactnativeblob.so" target="lib\droidarm\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\x86\libreactnativeblob.so" target="lib\droidx86\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libreactnativeblob.so" target="lib\droidarm64\unstripped"/>
 +
 +    <file src="build\tmp\buildReactNdkLib\local\x86_64\libreactnativejni.so" target="lib\droidx64\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libreactnativejni.so" target="lib\droidarm\unstripped"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "bin": "./cli.js",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "1000.0.0",
+  "version": "0.62.1",
   "bin": "./cli.js",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

The nuget is missing libreactnativeblob.so


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/577)