### PR TITLE
[ado] Get rid of trailing quote in npm dist-tag

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -35,15 +35,15 @@ jobs:
         displayName: Validate variables
         condition: eq(variables.latestStableBranch, '')
 
-      - script: echo '##vso[task.setvariable variable=npmDistTag]latest'
+      - bash: echo "##vso[task.setvariable variable=npmDistTag]latest"
         displayName: Set dist-tag to latest
         condition: eq(variables['Build.SourceBranchName'], variables.latestStableBranch)
 
-      - script: echo '##vso[task.setvariable variable=npmDistTag]canary'
+      - bash: echo "##vso[task.setvariable variable=npmDistTag]canary"
         displayName: Set dist-tag to canary
         condition: eq(variables['Build.SourceBranchName'], 'master')
 
-      - script: echo '##vso[task.setvariable variable=npmDistTag]v${{variables['Build.SourceBranchName']}}'
+      - bash: echo "##vso[task.setvariable variable=npmDistTag]v${{variables['Build.SourceBranchName']}}"
         displayName: Set dist-tag to v0.x-stable
         condition: and(ne(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.SourceBranchName'], variables.latestStableBranch))
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

While the docs give an example of using a plain script task, I couldn't get the trailing quote to be gone. The only way appears to be to use a bash script.

Also filed a ADO doc PR https://github.com/MicrosoftDocs/azure-devops-docs/pull/9235


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/584)