### PR TITLE
Fix overflow:'hidden' github issue #399 change to 0.60-stable

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -892,6 +892,11 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x) {
 
   RCTUpdateShadowPathForView(self);
 
+#if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+   // clipsToBounds is stubbed out on macOS because it's not part of NSView
+   layer.masksToBounds = self.clipsToBounds;
+ #endif // ]TODO(macOS ISS#2323203)
+
   const RCTCornerRadii cornerRadii = [self cornerRadii];
   const UIEdgeInsets borderInsets = [self bordersAsInsets];
   const RCTBorderColors borderColors = [self borderColors];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.102",
+  "version": "0.60.0-microsoft.103",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Fix in master is [here](https://github.com/microsoft/react-native-macos/pull/457). This is a direct port of the change over to our stable branch.

Fixes `overflow:'hidden'` #399 by setting`layer.masksToBounds = self.clipsToBounds;` in the `displayLayer:` method

`overflow: 'hidden'` doesn't work in macOS, but it does work in iOS and Android (not sure about Windows). This change brings functional parity with minimal complexity/conflict.

This also fixes borderRadius on `<Image>` which broke recently because the implementation of `RCTImage` changes from subclass to composition with the image view being a subview and thus now relies on functional clipping behavior.

Note we don't mutate `self.layer.masksToBounds` inside `setClipsToBounds` because modifying `self.layer` is undefined behavior on macOS and we have seen issues (e.g. with transforms) where the backing layer gets replaced by the system and mutations are not transferred over.

## Changelog

[MacOS] [Fixed] - Fix `overflow:'hidden'` #399 in 0.60-stable

## Test Plan

Before | After
------- | ------
<img width="346" alt="Screen Shot 2020-05-26 at 1 15 51 PM" src="https://user-images.githubusercontent.com/1509831/82950161-b1ac8280-9f59-11ea-89aa-c2effe9378c7.png"> | <img width="350" alt="Screen Shot 2020-05-26 at 1 15 30 PM" src="https://user-images.githubusercontent.com/1509831/82950190-bcffae00-9f59-11ea-83b0-e86861220e23.png">
<img width="254" alt="Screen Shot 2020-05-26 at 12 01 18 PM" src="https://user-images.githubusercontent.com/1509831/82950229-ca1c9d00-9f59-11ea-80f5-4c12bb667d63.png"> | <img width="262" alt="Screen Shot 2020-05-26 at 1 15 16 PM" src="https://user-images.githubusercontent.com/1509831/82950358-051ed080-9f5a-11ea-8004-e40232050fe2.png">

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/419)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/457)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/586)