### PR TITLE
Fix onMouseEnter/Leave on Touchable* components (#588)

### DIFF
--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -142,6 +142,8 @@ class TouchableBounce extends React.Component<Props, State> {
     const {
       onBlur,
       onFocus,
+      onMouseEnter, // [TODO(macOS/win ISS#2323203)
+      onMouseLeave, // ]TODO(macOS/win ISS#2323203)
       ...eventHandlersWithoutBlurAndFocus
     } = this.state.pressability.getEventHandlers();
 

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -290,6 +290,8 @@ class TouchableHighlight extends React.Component<Props, State> {
     const {
       onBlur,
       onFocus,
+      onMouseEnter, // [TODO(macOS/win ISS#2323203)
+      onMouseLeave, // ]TODO(macOS/win ISS#2323203)
       ...eventHandlersWithoutBlurAndFocus
     } = this.state.pressability.getEventHandlers();
 

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -227,6 +227,8 @@ class TouchableOpacity extends React.Component<Props, State> {
     const {
       onBlur,
       onFocus,
+      onMouseEnter, // [TODO(macOS/win ISS#2323203)
+      onMouseLeave, // ]TODO(macOS/win ISS#2323203)
       ...eventHandlersWithoutBlurAndFocus
     } = this.state.pressability.getEventHandlers();
 

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -104,6 +104,8 @@ const PASSTHROUGH_PROPS = [
   'onBlur',
   'onFocus',
   'onLayout',
+  'onMouseEnter', // [TODO(macOS ISS#2323203)
+  'onMouseLeave', // ]TODO(macOS ISS#2323203)
   'testID',
 ];
 
@@ -178,6 +180,8 @@ class TouchableWithoutFeedback extends React.Component<Props, State> {
     const {
       onBlur,
       onFocus,
+      onMouseEnter, // [TODO(macOS/win ISS#2323203)
+      onMouseLeave, // ]TODO(macOS/win ISS#2323203)
       ...eventHandlersWithoutBlurAndFocus
     } = this.state.pressability.getEventHandlers();
 

--- a/Libraries/Pressability/HoverState.js
+++ b/Libraries/Pressability/HoverState.js
@@ -51,6 +51,10 @@ if (Platform.OS === 'web') {
     document.addEventListener('touchmove', disableHover, true);
     document.addEventListener('mousemove', enableHover, true);
   }
+  // [TODO(macOS ISS#2323203)
+} else if (Platform.OS === 'macos') {
+  isEnabled = true;
+  // ]TODO(macOS ISS#2323203)
 }
 
 export function isHoverEnabled(): boolean {

--- a/RNTester/js/examples/Touchable/TouchableExample.js
+++ b/RNTester/js/examples/Touchable/TouchableExample.js
@@ -435,12 +435,13 @@ class TouchableHover extends React.Component<{}, $FlowFixMeState> {
   state = {
     hoverOver: false,
   };
+
   render() {
     return (
       <View>
         <TouchableOpacity
-          onMouseEnter={this._handlePress}
-          onMouseLeave={this._handlePress}
+          onMouseEnter={() => this._handleHover(true)}
+          onMouseLeave={() => this._handleHover(false)}
           style={[styles.row, styles.block]}>
           <Text style={this.state.hoverOver ? {color: 'red'} : {color: 'blue'}}>
             Touchable Opacity with mouse enter/exit events
@@ -462,8 +463,9 @@ class TouchableHover extends React.Component<{}, $FlowFixMeState> {
       </View>
     );
   }
-  _handlePress = () => {
-    this.setState({hoverOver: !this.state.hoverOver});
+
+  _handleHover = hoverOver => {
+    this.setState({hoverOver});
   };
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes a regression (#588) in 0.62 where `onMouseEnter` and `onMouseLeave` are no longer being called from the `Touchable*` components. It also enables hover callbacks for `Pressability`.

## Test Plan

![gif](https://user-images.githubusercontent.com/70904/92522941-5cc50d00-f1d4-11ea-972a-b04277827732.gif)

## Changelog

[macOS] [Fixed] - Fix onMouseEnter/Leave on Touchable* components 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/589)