### PR TITLE
Fix builds that don't use prefix headers

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -14,9 +14,10 @@
 //   limitations under the License.
 //
 
-#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
+#import <TargetConditionals.h> // [TODO(macOS ISS#2323203)
+#if !TARGET_OS_OSX
 #import <Endian.h>
-#endif // TODO(macOS ISS#2323203)b
+#endif // ]TODO(macOS ISS#2323203)
 #import <React/RCTSRWebSocket.h>
 
 #import <Availability.h>

--- a/React/Views/ScrollView/MacOS/RCTScrollContentLocalData.h
+++ b/React/Views/ScrollView/MacOS/RCTScrollContentLocalData.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

These files would not build on their own without using prefix header, which we don't use in our internal build system.

**Request:** Can we adjust the CI builds to not use any prefix headers to help catch these in the future?

## Changelog

[macOS] [Fixed] - Fixed compilation without prefix headers

## Test Plan

Builds without prefix headers.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/590)