### PR TITLE
Fix passthrough props on TouchableWithoutFeedback

### DIFF
--- a/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2,8 +2,10 @@
 
 exports[`TextInput tests should render as expected: should deep render when mocked (please verify output manually) 1`] = `
 <RCTSinglelineTextInputView
+  acceptsKeyboardFocus={true}
   accessible={true}
   allowFontScaling={true}
+  enableFocusRing={true}
   focusable={true}
   forwardedRef={null}
   onBlur={[Function]}
@@ -28,8 +30,10 @@ exports[`TextInput tests should render as expected: should deep render when mock
 
 exports[`TextInput tests should render as expected: should deep render when not mocked (please verify output manually) 1`] = `
 <RCTSinglelineTextInputView
+  acceptsKeyboardFocus={true}
   accessible={true}
   allowFontScaling={true}
+  enableFocusRing={true}
   focusable={true}
   forwardedRef={null}
   onBlur={[Function]}

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -105,7 +105,12 @@ const PASSTHROUGH_PROPS = [
   'onFocus',
   'onLayout',
   'onMouseEnter', // [TODO(macOS ISS#2323203)
-  'onMouseLeave', // ]TODO(macOS ISS#2323203)
+  'onMouseLeave',
+  'onDragEnter',
+  'onDragLeave',
+  'onDrop',
+  'draggedTypes',
+  'tooltip', // ]TODO(macOS ISS#2323203)
   'testID',
 ];
 
@@ -190,6 +195,10 @@ class TouchableWithoutFeedback extends React.Component<Props, State> {
       accessible: this.props.accessible !== false,
       focusable:
         this.props.focusable !== false && this.props.onPress !== undefined,
+      acceptsKeyboardFocus:
+        this.props.acceptsKeyboardFocus !== false && !this.props.disabled, // [TODO(macOS ISS#2323203)
+      enableFocusRing:
+        this.props.enableFocusRing !== false && !this.props.disabled, // ]TODO(macOS ISS#2323203)
     };
     for (const prop of PASSTHROUGH_PROPS) {
       if (this.props[prop] !== undefined) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Most of the macOS-specific props should be passed through, but `acceptsKeyboardFocus` and `enableFocusRing` should default to `true` (when not disabled) like the other Touchable components.

## Changelog

[macOS] [Fixed] - Fix passthrough props on TouchableWithoutFeedback

## Test Plan

The `TouchableWithoutFeedback` in RNTester is now correctly keyboard focusable.

<img width="683" alt="Screen Shot 2020-09-10 at 7 56 06 AM" src="https://user-images.githubusercontent.com/70904/92750480-f1964a80-f33b-11ea-8b22-5faf3e02c2b4.png">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/592)