### PR TITLE
Fix reloading from dev menu

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -366,12 +366,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   // Sanitize the bundle URL
   _bundleURL = [RCTConvert NSURL:_bundleURL.absoluteString];
 
-#if !TARGET_OS_OSX
   RCTExecuteOnMainQueue(^{
     RCTRegisterReloadCommandListener(self);
     RCTReloadCommandSetBundleURL(self->_bundleURL);
   });
-#endif // !TARGET_OS_OSX
 
   self.batchedBridge = [[bridgeClass alloc] initWithParentBridge:self];
   [self.batchedBridge start];


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

It appears the registration of the reload listener was excluded from macOS before `RCTReloadCommand.m` was updated to support macOS. It's now essential for reloading to work because `RCTTriggerReloadCommandListeners` is called from `RCTDevMenu`.

## Changelog

[macOS] [Fixed] - Fix reloading from dev menu

## Test Plan

Right-clicking inside RNTester then selecting **Reload** will now reload (before it would no-op).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/594)