### PR TITLE
cherry-pick VoiceOver accessibility issues from master to 0.62-stable

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1145,22 +1145,50 @@ RCT_ENUM_CONVERTER(RCTAnimationType, (@{
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
 + (NSString*)accessibilityRoleFromTrait:(NSString*)trait
 {
-  // a subset of iOS accessibilityTraits map to macOS accessiblityRoles:
-  if ([trait isEqualToString:@"button"]) {
-    return NSAccessibilityButtonRole;
-  } else if ([trait isEqualToString:@"text"]) {
-    return NSAccessibilityStaticTextRole;
-  } else if ([trait isEqualToString:@"link"]) {
-    return NSAccessibilityLinkRole;
-  } else if ([trait isEqualToString:@"image"]) {
-    return NSAccessibilityImageRole;
-    // a set of RN accessibilityTraits are macOS specific accessiblity roles:
-  }	else if ([trait isEqualToString:@"group"]) {
-    return NSAccessibilityGroupRole;
-  } else if ([trait isEqualToString:@"list"]) {
-    return NSAccessibilityListRole;
+  static NSDictionary<NSString *, NSString *> *traitOrRoleToAccessibilityRole;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    traitOrRoleToAccessibilityRole = @{
+      // from https://reactnative.dev/docs/accessibility#accessibilityrole
+      @"adjustable": NSAccessibilitySliderRole,
+      @"alert": NSAccessibilityStaticTextRole, // no exact match on macOS
+      @"button": NSAccessibilityButtonRole, // also a legacy iOS accessibilityTraits
+      @"checkbox": NSAccessibilityCheckBoxRole,
+      @"combobox": NSAccessibilityComboBoxRole,
+      @"header": NSAccessibilityStaticTextRole, // no exact match on macOS
+      @"image": NSAccessibilityImageRole, // also a legacy iOS accessibilityTraits
+      @"imagebutton": NSAccessibilityButtonRole, // no exact match on macOS
+      @"keyboardkey": NSAccessibilityButtonRole, // no exact match on macOS
+      @"link": NSAccessibilityLinkRole, // also a legacy iOS accessibilityTraits
+      @"menu": NSAccessibilityMenuRole,
+      @"menubar": NSAccessibilityMenuBarRole,
+      @"menuitem": NSAccessibilityMenuBarItemRole,
+      @"none": NSAccessibilityUnknownRole,
+      @"progressbar": NSAccessibilityProgressIndicatorRole,
+      @"radio": NSAccessibilityRadioButtonRole,
+      @"radiogroup": NSAccessibilityRadioGroupRole,
+      @"scrollbar": NSAccessibilityScrollBarRole,
+      @"search": NSAccessibilityTextFieldRole, // no exact match on macOS
+      @"spinbutton": NSAccessibilityIncrementorRole,
+      @"summary": NSAccessibilityStaticTextRole, // no exact match on macOS
+      @"switch": NSAccessibilityCheckBoxRole, // no exact match on macOS
+      @"tab": NSAccessibilityButtonRole, // no exact match on macOS
+      @"tablist": NSAccessibilityTabGroupRole,
+      @"text": NSAccessibilityStaticTextRole, // also a legacy iOS accessibilityTraits
+      @"timer": NSAccessibilityStaticTextRole, // no exact match on macOS
+      @"toolbar": NSAccessibilityToolbarRole,
+      // Roles/traits that are macOS specific and are used by some of the core components (Lists):
+      @"disclosure": NSAccessibilityDisclosureTriangleRole,
+      @"group": NSAccessibilityGroupRole,
+      @"list": NSAccessibilityListRole,
+    };
+  });
+
+  NSString *role = [traitOrRoleToAccessibilityRole valueForKey:trait];
+  if (role == nil) {
+    role = NSAccessibilityUnknownRole;
   }
-  return NSAccessibilityUnknownRole;
+  return role;
 }
 
 + (NSString *)accessibilityRoleFromTraits:(id)json

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -270,6 +270,9 @@ void UIGraphicsEndImageContext(void);
 // semantically equivalent types
 //
 
+// UIAccessibility.h/NSAccessibility.h
+@compatibility_alias UIAccessibilityCustomAction NSAccessibilityCustomAction;
+
 // UIColor.h/NSColor.h
 #define RCTUIColor NSColor
 

--- a/React/Views/UIView+React.h
+++ b/React/Views/UIView+React.h
@@ -118,7 +118,7 @@
 /**
  * Accessibility properties
  */
-@property (nonatomic, copy) NSString *accessibilityRole;
+@property (nonatomic, copy) NSString *accessibilityRoleInternal; // TODO(OSS Candidate ISS#2710739): renamed so it doesn't conflict with -[NSAccessibility accessibilityRole].
 @property (nonatomic, copy) NSDictionary<NSString *, id> *accessibilityState;
 @property (nonatomic, copy) NSArray <NSDictionary *> *accessibilityActions;
 @property (nonatomic, copy) NSDictionary *accessibilityValueInternal;

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -351,17 +351,15 @@
   objc_setAssociatedObject(self, @selector(accessibilityActions), accessibilityActions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
-- (NSString *)accessibilityRole
+- (NSString *)accessibilityRoleInternal // TODO(OSS Candidate ISS#2710739): renamed so it doesn't conflict with -[NSAccessibility accessibilityRole].
 {
   return objc_getAssociatedObject(self, _cmd);
 }
 
-- (void)setAccessibilityRole:(NSString *)accessibilityRole
+- (void)setAccessibilityRoleInternal:(NSString *)accessibilityRole // TODO(OSS Candidate ISS#2710739): renamed so it doesn't conflict with -[NSAccessibility setAccessibilityRole].
 {
-  objc_setAssociatedObject(self, @selector(accessibilityRole), accessibilityRole, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  objc_setAssociatedObject(self, @selector(accessibilityRoleInternal), accessibilityRole, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
-#endif // TODO(macOS ISS#2323203)
 
 - (NSDictionary<NSString *, id> *)accessibilityState
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The previous PR to master https://github.com/microsoft/react-native-macos/pull/603 made several fixes for VoiceOver accessibility.   This change cherry-picks those fixes (commit aac33da5bf3fbb5a6aefb807c0634b86b1e0a508) into the 0.62-stable branch.

## Changelog

[macOS] [fixed] - cherry-pick VoiceOver accessibility issues from master to 0.62-stable

## Test Plan

The original PR https://github.com/microsoft/react-native-macos/pull/603 contains comprehensive test notes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/606)