### PR TITLE
Port `--ci` switch into `bump-oss-version.js` and remove superfluous `--testing` switch.

### DIFF
--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -63,7 +63,7 @@ steps:
   - task: CmdLine@2
     displayName: Bump package version
     inputs:
-      script: node scripts/bump-oss-version.js --testing
+      script: node scripts/bump-oss-version.js --ci 0.0.1000
 
   - script: |
       npm publish --registry http://localhost:4873

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -24,33 +24,30 @@ let argv = yargs.option('r', {
   alias: 'remote',
   default: 'origin',
 })
-.option('n', {
-  alias: 'nightly',
+.option('ci', {
   type: 'boolean',
   default: false,
-}).option('t', {
-  alias: 'testing',
+})
+.option('n', {
+  alias: 'nightly',
   type: 'boolean',
   default: false,
 }).argv;
 
 const nightlyBuild = argv.nightly;
-const testingBuild = argv.testing;
+const ci = argv.ci;
 
 let version, branch;
 if (nightlyBuild) {
   const currentCommit = exec('git rev-parse HEAD', {silent: true}).stdout.trim();
   version = `0.0.0-${currentCommit.slice(0, 9)}`;
-} else if (testingBuild) {
-  const currentCommit = exec('git rev-parse HEAD', {silent: true}).stdout.trim();
-  version = `1000.0.0-${currentCommit.slice(0, 9)}`;
 } else {
   // Check we are in release branch, e.g. 0.33-stable
   branch = exec('git symbolic-ref --short HEAD', {
     silent: true,
   }).stdout.trim();
 
-  if (branch.indexOf('-stable') === -1) {
+  if (!ci && branch.indexOf('-stable') === -1) {
     echo('You must be in 0.XX-stable branch to bump a version');
     exit(1);
   }
@@ -159,7 +156,7 @@ let numberOfChangedLinesWithNewVersion = exec(
 
 // Release builds should commit the version bumps, and create tags.
 // Nightly builds do not need to do that.
-if (!nightlyBuild && !testingBuild) {
+if (!nightlyBuild) {
   if (+numberOfChangedLinesWithNewVersion !== 3) {
     echo(
       'Failed to update all the files. package.json and gradle.properties must have versions in them',


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The `bump-oss-version.js` script is used during npm publishing and during PR testing of the `react-native-macos-init` command line tool.   Both the canary builds and the PR test use the `--nightly` switch which rename the package version to `0.0.0-<commithash>`.

A version number of all zeros in a `.podspec` causes `pod install` to fail, so in `0.62-stable` branch a `--ci` switch was added that changes the version to the passed in string and `react-native-macos-init.yml` passes in `0.62.1000` (https://github.com/microsoft/react-native-macos/pull/596).   In a recent PR to master (https://github.com/microsoft/react-native-macos/pull/603), I made a similar but different fix to add a `--testing` flag that uses the version `1000.0.0` not realizing that this fix was already in the `0.62-stable branch`. 

This PR removes that script changes I made in https://github.com/microsoft/react-native-macos/pull/603 and replaces them with the fixes already made in `0.62-stable` by https://github.com/microsoft/react-native-macos/pull/596.

## Changelog

[macOS] [fixed] - Port `--ci` switch into `bump-oss-version.js` and remove superfluous `--testing` switch.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/607)