### PR TITLE
Fix unending RedBoxes when starting an app with Chrome debug mode enabled

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -400,7 +400,7 @@ struct RCTInstanceCallback : public InstanceCallback {
     dispatch_group_leave(prepareBridge);
   } onProgress:^(RCTLoadingProgress *progressData) {
 #if (RCT_DEV | RCT_ENABLE_LOADING_VIEW) && __has_include(<React/RCTDevLoadingView.h>)
-    if ([[self devSettings] isDevModeEnabled]) { // TODO(OSS Candidate ISS#2710739)
+    if ([weakSelf isValid] && [[weakSelf devSettings] isDevModeEnabled]) { // TODO(OSS Candidate ISS#2710739)
       // Note: RCTDevLoadingView should have been loaded at this point, so no need to allow lazy loading.
       RCTDevLoadingView *loadingView = [weakSelf moduleForName:RCTBridgeModuleNameForClass([RCTDevLoadingView class])
                                         lazilyLoadIfNecessary:NO];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes an issue where starting an app already in Chrome debug mode would result in a massive number of RedBoxes being queued up because `devSettings` was being accessed on an invalidated bridge.

## Changelog

[macOS] [Fixed] - Fix unending RedBoxes when starting an app with Chrome debug mode enabled

## Test Plan

Our app now loads correctly when Chrome debug mode is already enabled.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/614)