### PR TITLE
Adding the JS side config for the onFocusChange event on Android

### DIFF
--- a/android-patches/patches-0.62.2/Focus/Libraries/Components/View/ReactNativeViewViewConfigAndroid.js
+++ b/android-patches/patches-0.62.2/Focus/Libraries/Components/View/ReactNativeViewViewConfigAndroid.js
@@ -1,0 +1,15 @@
+--- /home/hermes/code/react-native-macos-fresh/Libraries/Components/View/ReactNativeViewViewConfigAndroid.js	2020-09-21 21:41:24.322788533 -0700
++++ /home/hermes/code/react-native-macos/Libraries/Components/View/ReactNativeViewViewConfigAndroid.js	2020-09-23 12:20:05.571823280 -0700
+@@ -19,6 +19,12 @@
+         captured: 'onSelectCapture',
+       },
+     },
++    topOnFocusChange: {
++      phasedRegistrationNames: {
++        bubbled: 'onFocusChange',
++        captured: 'onFocusChangeCapture',
++      },
++    },
+   },
+   directEventTypes: {
+     topClick: {

--- a/android-patches/patches-0.62.2/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java
+++ b/android-patches/patches-0.62.2/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java
@@ -1,5 +1,5 @@
---- /home/mganandraj/code/rn-macos-fb62merge-fresh/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java	2020-08-17 18:05:31.682674956 -0700
-+++ /home/mganandraj/code/rn-macos-fb62merge/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java	2020-08-17 16:33:22.167577505 -0700
+--- /home/hermes/code/react-native-macos-fresh/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java	2020-09-21 21:41:24.450784558 -0700
++++ /home/hermes/code/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactClippingViewManager.java	2020-09-19 11:06:41.574441701 -0700
 @@ -7,7 +7,10 @@
  
  package com.facebook.react.views.view;

--- a/android-patches/patches-0.62.2/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
+++ b/android-patches/patches-0.62.2/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
@@ -1,5 +1,5 @@
---- /home/mganandraj/code/rn-macos-fb62merge-fresh/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java	1969-12-31 16:00:00.000000000 -0800
-+++ /home/mganandraj/code/rn-macos-fb62merge/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java	2020-08-17 16:32:31.491113001 -0700
+--- /home/hermes/code/react-native-macos-fresh/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java	1969-12-31 16:00:00.000000000 -0800
++++ /home/hermes/code/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java	2020-09-19 11:06:41.574441701 -0700
 @@ -0,0 +1,49 @@
 +/**
 + * Copyright (c) 2015-present, Facebook, Inc.

--- a/android-patches/patches-0.62.2/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/android-patches/patches-0.62.2/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -1,5 +1,5 @@
---- /home/mganandraj/code/rn-macos-fb62merge-fresh/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java	2020-08-17 18:05:31.686674971 -0700
-+++ /home/mganandraj/code/rn-macos-fb62merge/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java	2020-08-17 16:24:38.654706790 -0700
+--- /home/hermes/code/react-native-macos-fresh/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java	2020-09-21 21:41:24.454784434 -0700
++++ /home/hermes/code/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java	2020-09-22 12:07:14.797980137 -0700
 @@ -48,8 +48,13 @@
      Spacing.START,
      Spacing.END,
@@ -28,7 +28,7 @@
 +        "topOnFocusChange",
 +        MapBuilder.of(
 +          "phasedRegistrationNames",
-+          MapBuilder.of("bubbled", "onFocusChange")))
++          MapBuilder.of("bubbled", "onFocusChange","captured", "onFocusChangeCapture")))
 +      .build();
 +  }
 +


### PR DESCRIPTION
Adding the JS side config for the onFocusChange event on Android 

This change is already made in master branch. Now, applying the same to 0.62-stable as well.

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

We already applied the Java changes for an event required for our consumption but the JS side config was missing, which resulted in red-box. This change adds the JS-side changes.

## Changelog

We already applied the Java changes for an event required for our consumption but the JS side config was missing, which resulted in red-box. This change adds the JS-side changes.

[CATEGORY] [TYPE] - Message

## Test Plan

Ensure no redbox shown when loading RN app.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/615)