### PR TITLE
[defork] Remove unnecessary refactor

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -160,7 +160,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     // Get new, unique touch identifier for the react touch
     const NSUInteger RCTMaxTouches = 11; // This is the maximum supported by iDevices
     NSInteger touchID = ([_reactTouches.lastObject[@"identifier"] integerValue] + 1) % RCTMaxTouches;
-    touchID = [self _eventWithNumber:touchID]; // TODO(macOS ISS#2323203)
+    for (NSDictionary *reactTouch in _reactTouches) {
+      NSInteger usedID = [reactTouch[@"identifier"] integerValue];
+      if (usedID == touchID) {
+        // ID has already been used, try next value
+        touchID++;
+      } else if (usedID > touchID) {
+        // If usedID > touchID, touchID must be unique, so we can stop looking
+        break;
+      }
+    }
 
     // Create touch
     NSMutableDictionary *reactTouch = [[NSMutableDictionary alloc] initWithCapacity:RCTMaxTouches];
@@ -173,23 +182,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     [_reactTouches addObject:reactTouch];
   }
 }
-
-// [TODO(macOS ISS#2323203)
-- (NSInteger)_eventWithNumber:(NSInteger)touchID
-{
-  for (NSDictionary *reactTouch in _reactTouches) {
-    NSInteger usedID = [reactTouch[@"identifier"] integerValue];
-    if (usedID == touchID) {
-      // ID has already been used, try next value
-      touchID++;
-    } else if (usedID > touchID) {
-      // If usedID > touchID, touchID must be unique, so we can stop looking
-      break;
-    }
-  }
-  return touchID;
-}
-// ]TODO(macOS ISS#2323203)
 
 - (void)_recordRemovedTouches:(NSSet *)touches
 {


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This change intuitively seemed to have been factored out previously so it could be shared, but perhaps it’s being overloaded from a objc category. Either way, I couldn’t figure that out from the git history or comments, hence this isolated PR.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/625)