### PR TITLE
Remove outdated version guards

### DIFF
--- a/React/Base/RCTMultipartDataTask.m
+++ b/React/Base/RCTMultipartDataTask.m
@@ -90,7 +90,7 @@ static BOOL isStreamTaskSupported() {
                                                       range:NSMakeRange(0, contentType.length)];
     if (match) {
       _boundary = [contentType substringWithRange:[match rangeAtIndex:1]];
-      if (@available(macOS 10.11, iOS 9.0, *)) { // TODO(OSS Candidate ISS#2710739)
+      if (@available(macOS 10.11, *)) { // TODO(OSS Candidate ISS#2710739)
         completionHandler(NSURLSessionResponseBecomeStream);
       }
       return;

--- a/React/Base/RCTMultipartDataTask.m
+++ b/React/Base/RCTMultipartDataTask.m
@@ -90,9 +90,7 @@ static BOOL isStreamTaskSupported() {
                                                       range:NSMakeRange(0, contentType.length)];
     if (match) {
       _boundary = [contentType substringWithRange:[match rangeAtIndex:1]];
-      if (@available(macOS 10.11, *)) { // TODO(OSS Candidate ISS#2710739)
-        completionHandler(NSURLSessionResponseBecomeStream);
-      }
+      completionHandler(NSURLSessionResponseBecomeStream);
       return;
     }
   }

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -241,11 +241,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
   // should we expose a `normalTouchForce` constant somewhere (which would
   // have a value of `1.0 / nativeTouch.maximumPossibleForce`)?
   if (RCTForceTouchAvailable()) {
-    if (@available(iOS 9.0, *)) { // TODO(OSS Candidate ISS#2710739)
-      reactTouch[@"force"] = @(RCTZeroIfNaN(nativeTouch.force / nativeTouch.maximumPossibleForce));
-    } else {
-      reactTouch[@"force"] = @(0);
-    }
+    reactTouch[@"force"] = @(RCTZeroIfNaN(nativeTouch.force / nativeTouch.maximumPossibleForce));
   }
 #else // [TODO(macOS ISS#2323203)
   NSEventModifierFlags modifierFlags = nativeTouch.modifierFlags;

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -558,12 +558,8 @@ BOOL RCTForceTouchAvailable(void)
         [UITraitCollection class] && [UITraitCollection instancesRespondToSelector:@selector(forceTouchCapability)];
   });
 
-  if (@available(iOS 9.0, *)) { // TODO(OSS Candidate ISS#2710739)
-    return forceSupported &&
+  return forceSupported &&
       (RCTKeyWindow() ?: [UIView new]).traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable;
-  } else { // [TODO(OSS Candidate ISS#2710739)
-    return NO;
-  } // ]TODO(OSS Candidate ISS#2710739)
 }
 #endif // TODO(macOS ISS#2323203)
 

--- a/React/CoreModules/RCTAlertManager.mm
+++ b/React/CoreModules/RCTAlertManager.mm
@@ -242,9 +242,7 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
 	id (^textFieldDefaults)(NSTextField *, BOOL) = ^id(NSTextField *textField, BOOL isPassword) {
 		textField.cell.scrollable = YES;
 		textField.cell.wraps = YES;
-		if (@available(macOS 10.11, *)) {
-			textField.maximumNumberOfLines = 1;
-		}
+    textField.maximumNumberOfLines = 1;
 		textField.stringValue = (isPassword ? defaultInputs.lastObject[@"default"] : defaultInputs.firstObject[@"default"]) ?: @"";
 		textField.placeholderString = isPassword ? defaultInputs.lastObject[@"placeholder"] : defaultInputs.firstObject[@"placeholder"];
 		return textField;

--- a/React/Views/RCTSegmentedControl.m
+++ b/React/Views/RCTSegmentedControl.m
@@ -105,18 +105,12 @@
 
 - (void)setMomentary:(BOOL)momentary
 {
-  if (@available(macOS 10.10.3, *)) {
-    self.trackingMode = momentary ? NSSegmentSwitchTrackingMomentary : NSSegmentSwitchTrackingSelectOne;
-  }
+  self.trackingMode = momentary ? NSSegmentSwitchTrackingMomentary : NSSegmentSwitchTrackingSelectOne;
 }
 
 - (BOOL)isMomentary
 {
-  if (@available(macOS 10.10.3, *)) {
-    return self.trackingMode == NSSegmentSwitchTrackingMomentary;
-  } else {
-    return NO;
-  }
+  return self.trackingMode == NSSegmentSwitchTrackingMomentary;
 }
 
 - (void)setSelectedSegmentIndex:(NSInteger)selectedSegmentIndex

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -65,9 +65,7 @@
       // We intentionally force `UIScrollView`s `semanticContentAttribute` to `LTR` here
       // because this attribute affects a position of vertical scrollbar; we don't want this
       // scrollbar flip because we also flip it with whole `UIScrollView` flip.
-      if (@available(iOS 9.0, *)) { // TODO(OSS Candidate ISS#2710739)
-        self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-      }
+      self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     }
 #endif
 


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

RN currently has deployment targets of iOS 10 and macOS 10.13. Office supports the most recent macOS-2 (so 10.13, 10.14, 10.15) and most recent iOS-1 (so iOS13, iOS14).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/626)