### PR TITLE
Fix RCTImageView not rendering images

### DIFF
--- a/.ado/templates/apple-job-javascript.yml
+++ b/.ado/templates/apple-job-javascript.yml
@@ -2,9 +2,6 @@ parameters:
   apply_office_patches: ''
 
 steps:
-  - script: 'brew update'
-    displayName: 'brew update'
-
   - script: 'brew bundle'
     displayName: 'brew bundle'
 

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -14,10 +14,6 @@ steps:
       rm -rf $(Build.Repository.LocalPath)/DerivedData
     displayName: 'Clean DerivedData'
 
-  # Install the required components specified in the Brewfile file.
-  - script: 'brew update'
-    displayName: 'brew update'
-
   - script: 'brew bundle'
     displayName: 'brew bundle'
 

--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -47,7 +47,9 @@ static NSImage *RCTFillImagePreservingAspectRatio(NSImage *originalImage, NSSize
   }
 
   NSSize originalImageSize = originalImage.size;
-  if (NSEqualSizes(originalImageSize, NSZeroSize) || [[originalImage representations] count] == 0) {
+  if (NSEqualSizes(originalImageSize, NSZeroSize) ||
+      NSEqualSizes(originalImageSize, targetSize) ||
+      [[originalImage representations] count] == 0) {
     return originalImage;
   }
 
@@ -146,11 +148,11 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
     self.wantsLayer = YES;
 #endif
-#if !TARGET_OS_OSX // [TODO(macOS ISS#2323203)
     _imageView = [[RCTUIImageViewAnimated alloc] init];
     _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self addSubview:_imageView];
 
+#if !TARGET_OS_OSX // [TODO(macOS ISS#2323203)
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center addObserver:self
                selector:@selector(clearImageIfDetached)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The `_imageView` was not being created for macOS. The macro was in the wrong spot. This also adds a check against unnecessarily copying an image inside `RCTFillImagePreservingAspectRatio`.

## Test Plan

Confirmed images appearing in RNTester


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/637)