### PR TITLE
Fix bugs with multiline TextInput

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -86,7 +86,7 @@
 {
   [super setReactBorderInsets:reactBorderInsets];
   // We apply `borderInsets` as `_scrollView` layout offset on mac.
-  _scrollView.frame = UIEdgeInsetsInsetRect(self.frame, reactBorderInsets);
+  _scrollView.frame = UIEdgeInsetsInsetRect(self.bounds, reactBorderInsets);
   [self setNeedsLayout];
 }
 #endif // ]TODO(macOS ISS#2323203)

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -56,7 +56,14 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
     self.backgroundColor = [RCTUIColor clearColor]; // TODO(macOS ISS#2323203)
     self.textColor = [RCTUIColor blackColor]; // TODO(macOS ISS#2323203)
     // This line actually removes 5pt (default value) left and right padding in UITextView.
+#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
     self.textContainer.lineFragmentPadding = 0;
+#else
+    // macOS has a bug where setting this to 0 will cause the scroll view to scroll to top when
+    // inserting a newline at the bottom of a NSTextView when it has more rows than can be displayed
+    // on screen.
+    self.textContainer.lineFragmentPadding = 1;
+#endif
 #if !TARGET_OS_OSX && !TARGET_OS_TV // TODO(macOS ISS#2323203)
     self.scrollsToTop = NO;
 #endif


### PR DESCRIPTION
fixes #639
fixes #611

# :warning: Make sure you are targeting microsoft/react-native-macos for your PR :warning:
(then delete these lines)

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

fixes #639
fixes #611

## Changelog

[macOS] [Fixed] - Fixed bugs #639 and #611 with multiline TextInput

## Test Plan

Verify in RNTester > TextInput > Multiline these bugs are fixed.
![image](https://user-images.githubusercontent.com/359157/97039012-90f45300-1520-11eb-943b-c409898bbb77.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/640)