### PR TITLE
Add missing TextInput properties in SecureTextInput

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
@@ -67,6 +67,10 @@
     } else {
       _backedTextInputView = [[RCTUITextField alloc] initWithFrame:self.bounds];
     }
+    _backedTextInputView.placeholder = previousTextField.placeholder;
+    _backedTextInputView.placeholderColor = previousTextField.placeholderColor;
+    _backedTextInputView.selectionColor = previousTextField.selectionColor;
+    _backedTextInputView.textAlignment = previousTextField.textAlignment;
     _backedTextInputView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _backedTextInputView.textInputDelegate = self;
     _backedTextInputView.text = previousTextField.text;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Currently, secure text edit ignores the placeholder text and is always blank. Add that property to secure text input, as well as a couple others.

## Changelog

[General] [Fixed] - Show placeholder in SecureTextInput

## Test Plan
![2020-10-29 13 54 38](https://user-images.githubusercontent.com/73661416/97631494-5130de00-19ee-11eb-8f75-475a0cf0ec0b.gif)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/642)