### PR TITLE
[LogBox] Add NSWindow based version

### DIFF
--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -519,8 +519,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: bc7a5826efda3b1df099ffa1dc2bb8b69f62c418
-  FBReactNativeSpec: 60ff5d97d3e0a65a835f417c4de6209832bb6262
+  FBLazyVector: 47a80afd4323ff3b4017e58c3fd958b88f4c384d
+  FBReactNativeSpec: ebefd70afb1983a0ec822c6a8e43df0ef89ba9e0
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -533,32 +533,32 @@ SPEC CHECKSUMS:
   libevent: ee9265726a1fc599dea382964fa304378affaa5f
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 8495f5115746c8ad4a0b7db015a74b77303f5271
-  RCTTypeSafety: 0a4445852aac7597f3e12b4ab25c1b5169c0437c
-  React: e46527450ad6e8c21ebdd33aa1d0f4e1a622e4b7
-  React-ART: 0502f614453ac14f2c5e8ce2c25825779b3a2ae5
-  React-callinvoker: 9493f9fe4ad57834153cd5265bab15b1125a01ff
-  React-Core: dcffc68cf8e3764525bb7b6f92032fcc93179f1d
-  React-CoreModules: b5bd802601a6b8586d834a2f45d2f455f3e822e5
-  React-cxxreact: 7bebc99bd6ab7fe62396bef306bd11a457f30256
-  React-jsi: bb95e6144b5ba9cc10f31a5289ec007fedb99deb
-  React-jsiexecutor: 2ab9f32808f7d396b4db43d2f40b0f55b45d5348
-  React-jsinspector: 050a845f6a64c0da6521948c7f6ffd63c945213c
-  React-RCTActionSheet: 787fc63ff5feea11ac2bcbb88a3aae8bf1826eb3
-  React-RCTAnimation: 255e51871a0744e2e7cc4be1e8b7ea3114d617fa
-  React-RCTBlob: 0c3a2e97cc237b390816093e30fa9c705a57493e
-  React-RCTImage: 4af81afbecd118544b97d906da6eda0aa048e21c
-  React-RCTLinking: 135c4800178210954b2ae5b7d12819d56c614d5f
-  React-RCTNetwork: 76a16bfac4f2f686a299aa5f8daabf5558616c83
-  React-RCTPushNotification: d5739e0d6c8f84d8b296ef4a694562fafdafe5eb
-  React-RCTSettings: 4a0cf3a15f1da794d00988c0c5ceab73f33691db
-  React-RCTTest: 78cb7960fe0cacc4cb006bfd8486d096621db49a
-  React-RCTText: ee8edf71224d11f6cd2527a7709704be13b08db6
-  React-RCTVibration: 044e17bf5bcbe7184a54cc40a7ebb8cd28024476
+  RCTRequired: 4f8d73e05d8b7e47d1acd0ad29508c464433dc5a
+  RCTTypeSafety: 78266df7835d664750aa39ed648c6a751dd3d89f
+  React: 0dd28f326359ab0d8136aaba2a2321375e1ae91c
+  React-ART: 43b7a32d9407cb0658160e873b980574d2844399
+  React-callinvoker: 08bf9b4de34bbbe2ed9d8263671fc570f821f2ac
+  React-Core: 6b513f158d1bf425499534c2f7469eb8fa691f44
+  React-CoreModules: 8d4efcee4db932916bd9d18e0d89214ec2dddd30
+  React-cxxreact: cedde96a15da8b9a638a57ce6c9824c8a3a7e6e9
+  React-jsi: 15dcefa823c29e25c04bb2a7160f0d1d0cf5d780
+  React-jsiexecutor: edede1ed546d5e7ecbd51127f7b240def3e7f38b
+  React-jsinspector: 523ec880bdfe9381aca9714a205e53a59d44bc8b
+  React-RCTActionSheet: 60f330e00bdce09e6c242028e5eaa0160d824e5c
+  React-RCTAnimation: 5b084e805c43b4555deb556e284f61ee69f5d7ee
+  React-RCTBlob: 7ae376e35c1bb12d55f6c52d78728475ac39e132
+  React-RCTImage: 159d06344c1d1b7beef29e435855be95d44a331d
+  React-RCTLinking: f84b0e7e36c84504601771634d1905d9366f6863
+  React-RCTNetwork: de6756a9658ea6601956126cd89c24c48350f907
+  React-RCTPushNotification: 82284cc73da54ef94e5dd5fb64e1a9d81f9705b6
+  React-RCTSettings: 5c71585d0e5ad4dc910920e2be2e53d259cdbb74
+  React-RCTTest: aa7252c07e188803f310f370936402ddd031b094
+  React-RCTText: 18f27ecea7b6476f6cdf9fb520f0273b9b06f5d9
+  React-RCTVibration: 396a1b306a0f908c3a694466c1a6c5765726e674
   React-TurboModuleCxx-RNW: 4da8eb44b10ab3c5bbab9fcb0a8ae415c20ea3c9
-  React-TurboModuleCxx-WinRTPort: 0dbf7417bec666c64fb7a1cbc144d39fa9ba7755
-  ReactCommon: 5af47049b7708fb4332338c6a3b5da11c30e9170
-  Yoga: c143ab8e59835ec8507fb28950cde950188aa2c1
+  React-TurboModuleCxx-WinRTPort: 51e04bbc39b89ebce9d5e90ecec8c8154607c490
+  ReactCommon: e8bc44a0c8bc53124f5fd27eded4c5bfaee9901b
+  Yoga: dff12ed39c5641db46ae6e312eef2f837d799359
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 18ca7d3b0e7db79041574a8bb6200b9e1c2d5359

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -519,8 +519,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: 47a80afd4323ff3b4017e58c3fd958b88f4c384d
-  FBReactNativeSpec: ebefd70afb1983a0ec822c6a8e43df0ef89ba9e0
+  FBLazyVector: e99626a767684cd45377cfb2d270260b08612394
+  FBReactNativeSpec: 4caa8b770647aad3624a57c46871bf01c1e1ef59
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -533,32 +533,32 @@ SPEC CHECKSUMS:
   libevent: ee9265726a1fc599dea382964fa304378affaa5f
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 4f8d73e05d8b7e47d1acd0ad29508c464433dc5a
-  RCTTypeSafety: 78266df7835d664750aa39ed648c6a751dd3d89f
-  React: 0dd28f326359ab0d8136aaba2a2321375e1ae91c
-  React-ART: 43b7a32d9407cb0658160e873b980574d2844399
-  React-callinvoker: 08bf9b4de34bbbe2ed9d8263671fc570f821f2ac
-  React-Core: 6b513f158d1bf425499534c2f7469eb8fa691f44
-  React-CoreModules: 8d4efcee4db932916bd9d18e0d89214ec2dddd30
-  React-cxxreact: cedde96a15da8b9a638a57ce6c9824c8a3a7e6e9
-  React-jsi: 15dcefa823c29e25c04bb2a7160f0d1d0cf5d780
-  React-jsiexecutor: edede1ed546d5e7ecbd51127f7b240def3e7f38b
-  React-jsinspector: 523ec880bdfe9381aca9714a205e53a59d44bc8b
-  React-RCTActionSheet: 60f330e00bdce09e6c242028e5eaa0160d824e5c
-  React-RCTAnimation: 5b084e805c43b4555deb556e284f61ee69f5d7ee
-  React-RCTBlob: 7ae376e35c1bb12d55f6c52d78728475ac39e132
-  React-RCTImage: 159d06344c1d1b7beef29e435855be95d44a331d
-  React-RCTLinking: f84b0e7e36c84504601771634d1905d9366f6863
-  React-RCTNetwork: de6756a9658ea6601956126cd89c24c48350f907
-  React-RCTPushNotification: 82284cc73da54ef94e5dd5fb64e1a9d81f9705b6
-  React-RCTSettings: 5c71585d0e5ad4dc910920e2be2e53d259cdbb74
-  React-RCTTest: aa7252c07e188803f310f370936402ddd031b094
-  React-RCTText: 18f27ecea7b6476f6cdf9fb520f0273b9b06f5d9
-  React-RCTVibration: 396a1b306a0f908c3a694466c1a6c5765726e674
+  RCTRequired: 7803a0a3a3d56e3cec84ae1ccbe0f4a2476f9f69
+  RCTTypeSafety: ae513041fa8773699d99833a8691d2e8b8d6ee8a
+  React: d6306405782c4669fd3d4d0125a7b2cc2bb19233
+  React-ART: 65684f957e38c119918b2ad8e2f2c386790b20d0
+  React-callinvoker: edc229ccab488b3b57895e830d2b825e79f9f04c
+  React-Core: 50805a8b5eb817533763ae0132a0a61fc740fddf
+  React-CoreModules: 3147038a51e5a1a1819be556efb3c22855816aec
+  React-cxxreact: 88f9c5fbd0c391488fb884ab4bf8af85c548230c
+  React-jsi: e7b3496404f24299beb067b0e4fa38e836f1d6a4
+  React-jsiexecutor: f214cb9bebf408f6deeea9f6fe6ca610ab88eb6e
+  React-jsinspector: 7fba9bc98d5047bf5c8dae0cd8acd36b86448d04
+  React-RCTActionSheet: c4b92af34b6f64c786a972f5c196a375b7ce6cea
+  React-RCTAnimation: 5a0f7f7b3eaf0520e53d119f8352fdc622d0a90b
+  React-RCTBlob: 37befa1be701fe18ab0d63eb986b65829c843fc6
+  React-RCTImage: a02ff4f1882f35574ae589556b5c94b9eee973da
+  React-RCTLinking: 70240d29450241879339d7384b0903232d30e2c6
+  React-RCTNetwork: 17a1cd202a4566c25244444644a1fadd092466db
+  React-RCTPushNotification: eec1e289dfb203ee5360a9065c4009de0c16e097
+  React-RCTSettings: 490435d0c7767d085ebc9218d6cc9f9e2018ff1c
+  React-RCTTest: 06e4d480573015d42b0acb110aeb343c16d0c595
+  React-RCTText: a2a64b9c882d9b9a8e26c27773ca305ce910f4a6
+  React-RCTVibration: d32b07b6c9e821cb784b04e1c65cee3b35099b54
   React-TurboModuleCxx-RNW: 4da8eb44b10ab3c5bbab9fcb0a8ae415c20ea3c9
-  React-TurboModuleCxx-WinRTPort: 51e04bbc39b89ebce9d5e90ecec8c8154607c490
-  ReactCommon: e8bc44a0c8bc53124f5fd27eded4c5bfaee9901b
-  Yoga: dff12ed39c5641db46ae6e312eef2f837d799359
+  React-TurboModuleCxx-WinRTPort: cbe13444db8dc3af024947610c537a27cea1c1cb
+  ReactCommon: d849f99f384dafff03d56ac7e9fd173e117b1509
+  Yoga: 5ba9af3554885e152355679790ed9be0b1d01695
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 18ca7d3b0e7db79041574a8bb6200b9e1c2d5359

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -124,7 +124,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
       continue;
     }
 #else // [TODO(macOS ISS#2323203)
-    CGPoint touchLocation = [self.view convertPoint:touch.locationInWindow fromView:nil];
+    // -[NSView hitTest:] takes coordinates in a view's superview coordinate system.
+    // The assumption here is that a RCTUIView/RCTSurfaceView will always have a superview.
+    CGPoint touchLocation = [self.view.superview convertPoint:touch.locationInWindow fromView:nil];
     NSView *targetView = [self.view hitTest:touchLocation];
     // Pair the mouse down events with mouse up events so our _nativeTouches cache doesn't get stale
     if ([targetView isKindOfClass:[NSControl class]]) {

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -136,7 +136,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     } else {
       _shouldSendMouseUpOnSystemBehalf = NO;
     }
-    touchLocation = [targetView convertPoint:touchLocation fromView:self.view];
+    touchLocation = [targetView convertPoint:touchLocation fromView:self.view.superview];
     
     while (targetView) {
       BOOL isUserInteractionEnabled = NO;

--- a/React/Base/Surface/RCTSurfaceView.mm
+++ b/React/Base/Surface/RCTSurfaceView.mm
@@ -31,6 +31,13 @@ RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
   return self;
 }
 
+#if TARGET_OS_OSX
+- (BOOL)isFlipped
+{
+  return YES;
+}
+#endif
+
 #pragma mark - Internal Interface
 
 - (void)setRootView:(RCTSurfaceRootView *)rootView

--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -97,23 +97,17 @@
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge
 {
-//  NSRect minimumFrame = NSMakeRect(0, 0, 500, 500);
-//  // TODO: Figure out why we actually need to specify a max size.
-//  NSRect maximumFrame = NSMakeRect(0, 0, CGFLOAT_MAX, CGFLOAT_MAX);
-//  for (NSScreen *screen in [NSScreen screens]) {
-//    maximumFrame = NSIntersectionRect(maximumFrame, (NSRect){ NSZeroPoint, screen.visibleFrame.size });
-//  }
-
   NSRect minimumFrame = NSMakeRect(0, 0, 600, 800);
   NSRect maximumFrame = minimumFrame;
 
   if ((self = [self initWithContentRect:minimumFrame
-                              styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskResizable
+                              styleMask:NSWindowStyleMaskTitled
                                 backing:NSBackingStoreBuffered
                                   defer:YES])) {
     _surface = [[RCTSurface alloc] initWithBridge:bridge moduleName:@"LogBox" initialProperties:@{}];
 
     [_surface start];
+    // TODO: It is not entirely clear to me why there needs to be a range. For now we'll use a fixed size.
     [_surface setMinimumSize:minimumFrame.size maximumSize:maximumFrame.size];
 
     if (![_surface synchronouslyWaitForStage:RCTSurfaceStageSurfaceDidInitialMounting timeout:1]) {

--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -26,17 +26,17 @@
 
 #if RCT_DEV_MENU
 
-@class RCTLogBoxView;
-
-@interface RCTLogBoxView : UIWindow
+#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
+@interface RCTLogBoxWindow : UIWindow // TODO(OSS Candidate ISS#2710739) Renamed from RCTLogBoxView to RCTLogBoxWindow
 @end
 
-@implementation RCTLogBoxView {
+@implementation RCTLogBoxWindow {
   RCTSurface *_surface;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame bridge:(RCTBridge *)bridge
+- (instancetype)initWithBridge:(RCTBridge *)bridge // TODO(OSS Candidate ISS#2710739) Dropped `frame` parameter to make it compatible with NSWindow based version
 {
+  CGRect frame = [UIScreen mainScreen].bounds;
   if ((self = [super initWithFrame:frame])) {
     self.windowLevel = UIWindowLevelStatusBar - 1;
     self.backgroundColor = [UIColor clearColor];
@@ -72,11 +72,80 @@
 
 @end
 
+#else // [TODO(macOS ISS#2323203)
+
+@interface _RCTLogBoxView : NSView
+@end
+
+@implementation _RCTLogBoxView
+- (BOOL)isFlipped
+{
+  return YES;
+}
+- (NSView *)hitTest:(NSPoint)point
+{
+  return self.subviews[0];
+}
+@end
+
+@interface RCTLogBoxWindow : NSWindow
+@end
+
+@implementation RCTLogBoxWindow {
+  RCTSurface *_surface;
+}
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+{
+//  NSRect minimumFrame = NSMakeRect(0, 0, 500, 500);
+//  // TODO: Figure out why we actually need to specify a max size.
+//  NSRect maximumFrame = NSMakeRect(0, 0, CGFLOAT_MAX, CGFLOAT_MAX);
+//  for (NSScreen *screen in [NSScreen screens]) {
+//    maximumFrame = NSIntersectionRect(maximumFrame, (NSRect){ NSZeroPoint, screen.visibleFrame.size });
+//  }
+
+  NSRect minimumFrame = NSMakeRect(0, 0, 600, 800);
+  NSRect maximumFrame = minimumFrame;
+
+  if ((self = [self initWithContentRect:minimumFrame
+                              styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskResizable
+                                backing:NSBackingStoreBuffered
+                                  defer:YES])) {
+    _surface = [[RCTSurface alloc] initWithBridge:bridge moduleName:@"LogBox" initialProperties:@{}];
+
+    [_surface start];
+    [_surface setMinimumSize:minimumFrame.size maximumSize:maximumFrame.size];
+
+    if (![_surface synchronouslyWaitForStage:RCTSurfaceStageSurfaceDidInitialMounting timeout:1]) {
+      RCTLogInfo(@"Failed to mount LogBox within 1s");
+    }
+
+    self.contentView = (NSView *)_surface.view;
+    self.contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  }
+  return self;
+}
+
+//- (void)dealloc
+//{
+//  [RCTSharedApplication().delegate.window makeKeyWindow];
+//}
+
+- (void)show
+{
+  [NSApp activateIgnoringOtherApps:YES];
+  [self makeKeyAndOrderFront:nil];
+}
+
+@end
+
+#endif // ]TODO(macOS ISS#2323203)
+
 @interface RCTLogBox () <NativeLogBoxSpec>
 @end
 
 @implementation RCTLogBox {
-  RCTLogBoxView *_view;
+  RCTLogBoxWindow *_window; // TODO(OSS Candidate ISS#2710739) Renamed from _view to _window
 }
 
 @synthesize bridge = _bridge;
@@ -97,10 +166,10 @@ RCT_EXPORT_METHOD(show)
       if (!strongSelf) {
         return;
       }
-      if (!strongSelf->_view) {
-        strongSelf->_view = [[RCTLogBoxView alloc] initWithFrame:[UIScreen mainScreen].bounds bridge:self->_bridge];
+      if (!strongSelf->_window) {
+        strongSelf->_window = [[RCTLogBoxWindow alloc] initWithBridge:self->_bridge];
       }
-      [strongSelf->_view show];
+      [strongSelf->_window show];
     });
   }
 }
@@ -114,7 +183,7 @@ RCT_EXPORT_METHOD(hide)
       if (!strongSelf) {
         return;
       }
-      strongSelf->_view = nil;
+      strongSelf->_window = nil;
     });
   }
 }

--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -111,9 +111,6 @@
                               styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskResizable
                                 backing:NSBackingStoreBuffered
                                   defer:YES])) {
-    // The instance already gets released when we `nil` it from the `-[RCTLogBox hide]` method.
-    self.releasedWhenClosed = NO;
-
     _surface = [[RCTSurface alloc] initWithBridge:bridge moduleName:@"LogBox" initialProperties:@{}];
 
     [_surface start];
@@ -134,7 +131,7 @@
   if (NSApp.modalWindow == self) {
     [NSApp stopModal];
   }
-  [self close];
+  [self orderOut:nil];
 }
 
 - (void)show

--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -74,20 +74,6 @@
 
 #else // [TODO(macOS ISS#2323203)
 
-@interface _RCTLogBoxView : NSView
-@end
-
-@implementation _RCTLogBoxView
-- (BOOL)isFlipped
-{
-  return YES;
-}
-- (NSView *)hitTest:(NSPoint)point
-{
-  return self.subviews[0];
-}
-@end
-
 @interface RCTLogBoxWindow : NSWindow
 @end
 
@@ -97,18 +83,15 @@
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge
 {
-  NSRect minimumFrame = NSMakeRect(0, 0, 600, 800);
-  NSRect maximumFrame = minimumFrame;
-
-  if ((self = [self initWithContentRect:minimumFrame
+  NSRect bounds = NSMakeRect(0, 0, 600, 800);
+  if ((self = [self initWithContentRect:bounds
                               styleMask:NSWindowStyleMaskTitled
                                 backing:NSBackingStoreBuffered
                                   defer:YES])) {
     _surface = [[RCTSurface alloc] initWithBridge:bridge moduleName:@"LogBox" initialProperties:@{}];
 
     [_surface start];
-    // TODO: It is not entirely clear to me why there needs to be a range. For now we'll use a fixed size.
-    [_surface setMinimumSize:minimumFrame.size maximumSize:maximumFrame.size];
+    [_surface setSize:bounds.size];
 
     if (![_surface synchronouslyWaitForStage:RCTSurfaceStageSurfaceDidInitialMounting timeout:1]) {
       RCTLogInfo(@"Failed to mount LogBox within 1s");

--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -59,7 +59,7 @@
   return self;
 }
 
-- (void)dealloc
+- (void)hide
 {
   [RCTSharedApplication().delegate.window makeKeyWindow];
 }
@@ -108,9 +108,12 @@
   NSRect maximumFrame = minimumFrame;
 
   if ((self = [self initWithContentRect:minimumFrame
-                              styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskResizable
+                              styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskResizable
                                 backing:NSBackingStoreBuffered
                                   defer:YES])) {
+    // The instance already gets released when we `nil` it from the `-[RCTLogBox hide]` method.
+    self.releasedWhenClosed = NO;
+
     _surface = [[RCTSurface alloc] initWithBridge:bridge moduleName:@"LogBox" initialProperties:@{}];
 
     [_surface start];
@@ -126,10 +129,10 @@
   return self;
 }
 
-//- (void)dealloc
-//{
-//  [RCTSharedApplication().delegate.window makeKeyWindow];
-//}
+- (void)hide
+{
+  [self close];
+}
 
 - (void)show
 {
@@ -183,6 +186,7 @@ RCT_EXPORT_METHOD(hide)
       if (!strongSelf) {
         return;
       }
+      [strongSelf->_window hide];
       strongSelf->_window = nil;
     });
   }

--- a/React/CoreModules/React-CoreModules.podspec
+++ b/React/CoreModules/React-CoreModules.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.source_files           = "**/*.{c,m,mm,cpp}"
   # [TODO(macOS ISS#2323203)
                              "**/MacOS/*"
-  s.osx.exclude_files     =  "{RCTLogBox,RCTFPSGraph,RCTPerfMonitor,RCTPlatform}.*"
+  s.osx.exclude_files     =  "{RCTFPSGraph,RCTPerfMonitor,RCTPlatform}.*"
   # ]TODO(macOS ISS#2323203)
   s.header_dir             = "CoreModules"
   s.pod_target_xcconfig    = {

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1007,9 +1007,7 @@ RCT_EXPORT_METHOD(createView
     RCTShadowView *rootView = _shadowViewRegistry[rootTag];
     RCTAssert(
         [rootView isKindOfClass:[RCTRootShadowView class]]
-#if !TARGET_OS_OSX // [TODO(macOS ISS#2323203)
         || [rootView isKindOfClass:[RCTSurfaceRootShadowView class]]
-#endif // ]TODO(macOS ISS#2323203)
         ,
         @"Given `rootTag` (%@) does not correspond to a valid root shadow view instance.",
         rootTag);


### PR DESCRIPTION
Related to #621

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

LogBox is the preferred way to view warnings/errors in v0.63.0.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Added] - NSWindow based version of LogBox

## TODO

Still minor things to do, but the meat of the patch can be reviewed.

- [x] Navigation buttons in header don't work yet
- [x] Source-maps seem wrong, but that may just be a RNTester thing that doesn’t need to block this PR

## Test Plan

<img width="715" alt="Screenshot 2020-11-03 at 14 53 31" src="https://user-images.githubusercontent.com/2320/97993723-bd438580-1de4-11eb-96ec-0acdab4a004b.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/645)