### PR TITLE
Add back [RCTCxxBridge reactInstance] method

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -220,6 +220,13 @@ struct RCTInstanceCallback : public InstanceCallback {
   return _jsMessageThread;
 }
 
+// [TODO(OSS Candidate ISS#2710739)
+- (std::weak_ptr<Instance>)reactInstance
+{
+  return _reactInstance;
+}
+// ]TODO(OSS Candidate ISS#2710739)
+
 - (BOOL)isInspectable
 {
   return _reactInstance ? _reactInstance->isInspectable() : NO;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

This method was removed for 0.63, but the `RCTBridge+Cxx.mm` category (which is marked OSS candidate) relies on it existing. This unblocks moving to 0.63, but we will consider upstreaming this to core.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/647)