### PR TITLE
[template] Update hermes instruction

### DIFF
--- a/local-cli/generator-macos/templates/macos/Podfile
+++ b/local-cli/generator-macos/templates/macos/Podfile
@@ -4,17 +4,15 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 target 'HelloWorld-macOS' do
   platform :macos, '10.13'
   use_native_modules!
-  use_react_native!(:path => '../node_modules/react-native-macos')
-
-  # Enables Hermes
-  #
-  # Be sure to first install the `hermes-engine-darwin` npm package, e.g.:
-  #
-  #   $ yarn add 'hermes-engine-darwin@~0.5.0'
-  #
-  # pod 'React-Core/Hermes', :path => '../node_modules/react-native-macos/'
-  # pod 'hermes', :path => '../node_modules/hermes-engine-darwin'
-  # pod 'libevent', :podspec => '../node_modules/react-native-macos/third-party-podspecs/libevent.podspec'
+  use_react_native!(
+    :path => '../node_modules/react-native-macos',
+    
+    # To use Hermes, install the `hermes-engine-darwin` npm package, e.g.:
+    #   $ yarn add 'hermes-engine-darwin@~0.5.3'
+    #
+    # Then enable this option:
+    #   :hermes_enabled => true
+  )
 
   # Pods specifically for macOS target
 end


### PR DESCRIPTION
## Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Point to the version that is needed for RN macOS v0.63.0, which includes arm64 support for macOS Big Sur.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/648)