### PR TITLE
Use border radius when drawing focus rings

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1337,7 +1337,13 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 - (void)drawFocusRingMask
 {
   if ([self enableFocusRing]) {
-    NSRectFill(self.bounds);
+    CGContextRef context = NSGraphicsContext.currentContext.CGContext;
+    RCTCornerInsets cornerInsets = RCTGetCornerInsets(self.cornerRadii, NSEdgeInsetsZero);
+    CGPathRef path = RCTPathCreateWithRoundedRect(self.bounds, cornerInsets, NULL);
+
+    CGContextAddPath(context, path);
+    CGContextFillPath(context);
+    CGPathRelease(path);
   }
 }
 #endif


### PR DESCRIPTION
### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

For rounded (or partially rounded) buttons, the focus ring would still draw being square. This change allows for focus rings to respect the corner radii.

## Changelog

[macOS] [Fixed] - Use border radius when drawing focus rings

## Test Plan

Focus rings draw circular now with border radius. Also confirmed square focus rings for views without border radius set.

<img width="56" alt="Screen Shot 2020-11-15 at 6 02 54 PM" src="https://user-images.githubusercontent.com/70904/99206055-48bb0000-276f-11eb-907f-0d74c3e8637a.png">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/652)