### PR TITLE
Support focusable, Yellowbox on acceptsKeyboardFocus

### DIFF
--- a/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`TextInput tests should render as expected: should deep render when mocked (please verify output manually) 1`] = `
 <RCTSinglelineTextInputView
-  focusable={true}
   accessible={true}
   allowFontScaling={true}
   enableFocusRing={true}
@@ -31,7 +30,6 @@ exports[`TextInput tests should render as expected: should deep render when mock
 
 exports[`TextInput tests should render as expected: should deep render when not mocked (please verify output manually) 1`] = `
 <RCTSinglelineTextInputView
-  focusable={true}
   accessible={true}
   allowFontScaling={true}
   enableFocusRing={true}

--- a/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput tests should render as expected: should deep render when mocked (please verify output manually) 1`] = `
 <RCTSinglelineTextInputView
-  acceptsKeyboardFocus={true}
+  focusable={true}
   accessible={true}
   allowFontScaling={true}
   enableFocusRing={true}
@@ -31,7 +31,7 @@ exports[`TextInput tests should render as expected: should deep render when mock
 
 exports[`TextInput tests should render as expected: should deep render when not mocked (please verify output manually) 1`] = `
 <RCTSinglelineTextInputView
-  acceptsKeyboardFocus={true}
+  focusable={true}
   accessible={true}
   allowFontScaling={true}
   enableFocusRing={true}

--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -168,7 +168,7 @@ class TouchableBounce extends React.Component<Props, State> {
         nativeID={this.props.nativeID}
         testID={this.props.testID}
         hitSlop={this.props.hitSlop}
-        // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+        // [macOS #656 We need to reconcile between focusable and acceptsKeyboardFocus
         // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
         // other on the underlying view). Prefer passing acceptsKeyboardFocus if
         // passed explicitly to preserve original behavior, and trigger view warnings.

--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -160,11 +160,6 @@ class TouchableBounce extends React.Component<Props, State> {
         accessibilityLiveRegion={this.props.accessibilityLiveRegion}
         accessibilityViewIsModal={this.props.accessibilityViewIsModal}
         accessibilityElementsHidden={this.props.accessibilityElementsHidden}
-        acceptsKeyboardFocus={
-          (this.props.acceptsKeyboardFocus === undefined ||
-            this.props.acceptsKeyboardFocus === true) &&
-          !this.props.disabled
-        } // TODO(macOS/win ISS#2323203)
         enableFocusRing={
           (this.props.enableFocusRing === undefined ||
             this.props.enableFocusRing === true) &&
@@ -173,11 +168,23 @@ class TouchableBounce extends React.Component<Props, State> {
         nativeID={this.props.nativeID}
         testID={this.props.testID}
         hitSlop={this.props.hitSlop}
-        focusable={
-          this.props.focusable !== false &&
-          this.props.onPress !== undefined &&
-          !this.props.disabled
-        }
+        // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+        // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
+        // other on the underlying view). Prefer passing acceptsKeyboardFocus if
+        // passed explicitly to preserve original behavior, and trigger view warnings.
+        {...(this.props.acceptsKeyboardFocus !== undefined
+          ? {
+              acceptsKeyboardFocus:
+                this.props.acceptsKeyboardFocus === true &&
+                !this.props.disabled,
+            }
+          : {
+              focusable:
+                this.props.focusable !== false &&
+                this.props.onPress !== undefined &&
+                !this.props.disabled,
+            })}
+        // macOS]
         tooltip={this.props.tooltip} // TODO(macOS/win ISS#2323203)
         onMouseEnter={this.props.onMouseEnter} // [TODO(macOS ISS#2323203)
         onMouseLeave={this.props.onMouseLeave}

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -307,11 +307,6 @@ class TouchableHighlight extends React.Component<Props, State> {
         accessibilityLiveRegion={this.props.accessibilityLiveRegion}
         accessibilityViewIsModal={this.props.accessibilityViewIsModal}
         accessibilityElementsHidden={this.props.accessibilityElementsHidden}
-        acceptsKeyboardFocus={
-          (this.props.acceptsKeyboardFocus === undefined ||
-            this.props.acceptsKeyboardFocus === true) &&
-          !this.props.disabled
-        } // TODO(macOS/win ISS#2323203)
         enableFocusRing={
           (this.props.enableFocusRing === undefined ||
             this.props.enableFocusRing === true) &&
@@ -329,9 +324,22 @@ class TouchableHighlight extends React.Component<Props, State> {
         nextFocusLeft={this.props.nextFocusLeft}
         nextFocusRight={this.props.nextFocusRight}
         nextFocusUp={this.props.nextFocusUp}
-        focusable={
-          this.props.focusable !== false && this.props.onPress !== undefined
-        }
+        // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+        // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
+        // other on the underlying view). Prefer passing acceptsKeyboardFocus if
+        // passed explicitly to preserve original behavior, and trigger view warnings.
+        {...(this.props.acceptsKeyboardFocus !== undefined
+          ? {
+              acceptsKeyboardFocus:
+                this.props.acceptsKeyboardFocus === true &&
+                !this.props.disabled,
+            }
+          : {
+              focusable:
+                this.props.focusable !== false &&
+                this.props.onPress !== undefined,
+            })}
+        // macOS]
         tooltip={this.props.tooltip} // TODO(macOS/win ISS#2323203)
         onMouseEnter={this.props.onMouseEnter} // [TODO(macOS/win ISS#2323203)
         onMouseLeave={this.props.onMouseLeave}

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -324,7 +324,7 @@ class TouchableHighlight extends React.Component<Props, State> {
         nextFocusLeft={this.props.nextFocusLeft}
         nextFocusRight={this.props.nextFocusRight}
         nextFocusUp={this.props.nextFocusUp}
-        // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+        // [macOS #656 We need to reconcile between focusable and acceptsKeyboardFocus
         // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
         // other on the underlying view). Prefer passing acceptsKeyboardFocus if
         // passed explicitly to preserve original behavior, and trigger view warnings.

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -252,7 +252,7 @@ class TouchableOpacity extends React.Component<Props, State> {
         nextFocusUp={this.props.nextFocusUp}
         hasTVPreferredFocus={this.props.hasTVPreferredFocus}
         hitSlop={this.props.hitSlop}
-        // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+        // [macOS #656 We need to reconcile between focusable and acceptsKeyboardFocus
         // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
         // other on the underlying view). Prefer passing acceptsKeyboardFocus if
         // passed explicitly to preserve original behavior, and trigger view warnings.

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -236,11 +236,6 @@ class TouchableOpacity extends React.Component<Props, State> {
         accessibilityLiveRegion={this.props.accessibilityLiveRegion}
         accessibilityViewIsModal={this.props.accessibilityViewIsModal}
         accessibilityElementsHidden={this.props.accessibilityElementsHidden}
-        acceptsKeyboardFocus={
-          (this.props.acceptsKeyboardFocus === undefined ||
-            this.props.acceptsKeyboardFocus === true) &&
-          !this.props.disabled
-        } // TODO(macOS ISS#2323203)
         enableFocusRing={
           (this.props.enableFocusRing === undefined ||
             this.props.enableFocusRing === true) &&
@@ -257,9 +252,22 @@ class TouchableOpacity extends React.Component<Props, State> {
         nextFocusUp={this.props.nextFocusUp}
         hasTVPreferredFocus={this.props.hasTVPreferredFocus}
         hitSlop={this.props.hitSlop}
-        focusable={
-          this.props.focusable !== false && this.props.onPress !== undefined
-        }
+        // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+        // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
+        // other on the underlying view). Prefer passing acceptsKeyboardFocus if
+        // passed explicitly to preserve original behavior, and trigger view warnings.
+        {...(this.props.acceptsKeyboardFocus !== undefined
+          ? {
+              acceptsKeyboardFocus:
+                this.props.acceptsKeyboardFocus === true &&
+                !this.props.disabled,
+            }
+          : {
+              focusable:
+                this.props.focusable !== false &&
+                this.props.onPress !== undefined,
+            })}
+        // macOS]
         tooltip={this.props.tooltip} // TODO(macOS/win ISS#2323203)
         onMouseEnter={this.props.onMouseEnter} // [TODO(macOS ISS#2323203)
         onMouseLeave={this.props.onMouseLeave}

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -147,15 +147,14 @@ class TouchableWithoutFeedback extends React.Component<Props, State> {
     const elementProps: {[string]: mixed, ...} = {
       ...eventHandlersWithoutBlurAndFocus,
       accessible: this.props.accessible !== false,
-      // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+      // [macOS #656 We need to reconcile between focusable and acceptsKeyboardFocus
       // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
       // other on the underlying view). Prefer passing acceptsKeyboardFocus if
       // passed explicitly to preserve original behavior, and trigger view warnings.
       ...(this.props.acceptsKeyboardFocus !== undefined
         ? {
             acceptsKeyboardFocus:
-              this.props.acceptsKeyboardFocus === true &&
-              !this.props.disabled,
+              this.props.acceptsKeyboardFocus === true && !this.props.disabled,
           }
         : {
             focusable:

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -147,10 +147,22 @@ class TouchableWithoutFeedback extends React.Component<Props, State> {
     const elementProps: {[string]: mixed, ...} = {
       ...eventHandlersWithoutBlurAndFocus,
       accessible: this.props.accessible !== false,
-      focusable:
-        this.props.focusable !== false && this.props.onPress !== undefined,
-      acceptsKeyboardFocus:
-        this.props.acceptsKeyboardFocus !== false && !this.props.disabled, // [TODO(macOS ISS#2323203)
+      // [macOS We need to reconcile between focusable and acceptsKeyboardFocus
+      // (e.g. if one is explicitly disabled, we shouldn't implicitly enable the
+      // other on the underlying view). Prefer passing acceptsKeyboardFocus if
+      // passed explicitly to preserve original behavior, and trigger view warnings.
+      ...(this.props.acceptsKeyboardFocus !== undefined
+        ? {
+            acceptsKeyboardFocus:
+              this.props.acceptsKeyboardFocus === true &&
+              !this.props.disabled,
+          }
+        : {
+            focusable:
+              this.props.focusable !== false &&
+              this.props.onPress !== undefined,
+          }),
+      // macOS]
       enableFocusRing:
         this.props.enableFocusRing !== false && !this.props.disabled, // ]TODO(macOS ISS#2323203)
     };

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TouchableHighlight renders correctly 1`] = `
 <View
-  acceptsKeyboardFocus={true}
+  focusable={true}
   accessible={true}
   enableFocusRing={true}
   focusable={false}

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -5,6 +5,7 @@ exports[`TouchableHighlight renders correctly 1`] = `
   focusable={true}
   accessible={true}
   enableFocusRing={true}
+  focusable={false}
   onClick={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -5,7 +5,6 @@ exports[`TouchableHighlight renders correctly 1`] = `
   focusable={true}
   accessible={true}
   enableFocusRing={true}
-  focusable={false}
   onClick={[Function]}
   onResponderGrant={[Function]}
   onResponderMove={[Function]}

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`TouchableHighlight renders correctly 1`] = `
 <View
-  focusable={true}
   accessible={true}
   enableFocusRing={true}
   focusable={false}

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -15,6 +15,7 @@ import type {ViewProps} from './ViewPropTypes';
 const React = require('react');
 import ViewNativeComponent from './ViewNativeComponent';
 const TextAncestor = require('../../Text/TextAncestor');
+import warnOnce from '../../Utilities/warnOnce'; // [macOS]
 
 export type Props = ViewProps;
 
@@ -29,6 +30,15 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
+  // [macOS Intercept props to warn about them going away
+  if (props.acceptsKeyboardFocus !== undefined) {
+    warnOnce(
+      'deprecated-acceptsKeyboardFocus',
+      '"acceptsKeyboardFocus" has been deprecated in favor of "focusable" and will be removed in a future version of react-native-macos',
+    );
+  }
+  // macOS]
+
   return (
     <TextAncestor.Provider value={false}>
       <ViewNativeComponent {...props} ref={forwardedRef} />

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -15,7 +15,7 @@ import type {ViewProps} from './ViewPropTypes';
 const React = require('react');
 import ViewNativeComponent from './ViewNativeComponent';
 const TextAncestor = require('../../Text/TextAncestor');
-import warnOnce from '../../Utilities/warnOnce'; // [macOS]
+import warnOnce from '../../Utilities/warnOnce'; // [macOS #656]
 
 export type Props = ViewProps;
 
@@ -30,7 +30,7 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
-  // [macOS Intercept props to warn about them going away
+  // [macOS #656 Intercept props to warn about them going away
   if (props.acceptsKeyboardFocus !== undefined) {
     warnOnce(
       'deprecated-acceptsKeyboardFocus',

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -431,7 +431,7 @@ DEPENDENCIES:
   - Yoga (from `../ReactCommon/yoga`)
 
 SPEC REPOS:
-  trunk:
+  https://cdn.cocoapods.org/:
     - CocoaAsyncSocket
     - CocoaLibEvent
     - Flipper
@@ -519,8 +519,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: ccd2b1c6a86017fbfea2b4009cba9fc2d6da9a7f
-  FBReactNativeSpec: dbdc9075c7d8ebe849176e63c21dfef6126fe6dc
+  FBLazyVector: e99626a767684cd45377cfb2d270260b08612394
+  FBReactNativeSpec: 4caa8b770647aad3624a57c46871bf01c1e1ef59
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -530,35 +530,35 @@ SPEC CHECKSUMS:
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   hermes: 12d049af0d8e8379c5b3b54ffb1919d670045bdc
-  libevent: d721abced7738e428c291489465953c9263d78f9
+  libevent: ee9265726a1fc599dea382964fa304378affaa5f
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 1fa869794052e905c322945334e6a991be944b15
-  RCTTypeSafety: a64d2f488e7242e94efde2ef7ab4912d30ce82ca
-  React: 91904833b61ac3b029d6b5d01fae0507e3adea50
-  React-ART: 4a55599d17c5cca51b0522eb51ea6086d0a0be3d
-  React-callinvoker: 1c16bc94c17f90fb502a6632d27596e98d1566d0
-  React-Core: b86304125ea347c4dd1380734811d8ad78abb3fc
-  React-CoreModules: 600a12259e735a9b9c8372d5836cf466f3d7145b
-  React-cxxreact: f1d93f2ee544b68c79d69d2f502fdd25e37bd994
-  React-jsi: a6385183b4c70d69cd6574efc70e099ae014efbd
-  React-jsiexecutor: cd3c5c37c989fcdfa06b1e333d0768c5f623626d
-  React-jsinspector: 2e2e478a80924897aff1214d9b1caa38edcccc4b
-  React-RCTActionSheet: d930349167dfc09226060c0c2a592cebbb2f6cd5
-  React-RCTAnimation: 28a56166afa8c7df91055065f837f91a44f5d281
-  React-RCTBlob: db12a6574c189d60caabc3c20d249cb5c9ede079
-  React-RCTImage: 06b75cdce39f09e7ea6dfe7c2e4d823104f9ea5d
-  React-RCTLinking: 3b146e6a8cbd54157e56eaf88687e51abccd7362
-  React-RCTNetwork: 187fdab4add18e4e660b5c499ecfa125bfad66e5
-  React-RCTPushNotification: c245e0beb02c56b166b170a3c313b9063f77baa0
-  React-RCTSettings: 3bfb8a129b8a698c349cd9842072df90d0a0be51
-  React-RCTTest: 9ae64f57b1f17bf7e9007a87d9b13c255d654d55
-  React-RCTText: 89bef95815de3a6d4f61ae3d6e287f9dfcabbbd9
-  React-RCTVibration: 3ede8d3f6c16dfe5cce11175a2866b742c6ee37b
+  RCTRequired: 7803a0a3a3d56e3cec84ae1ccbe0f4a2476f9f69
+  RCTTypeSafety: ae513041fa8773699d99833a8691d2e8b8d6ee8a
+  React: d6306405782c4669fd3d4d0125a7b2cc2bb19233
+  React-ART: 65684f957e38c119918b2ad8e2f2c386790b20d0
+  React-callinvoker: edc229ccab488b3b57895e830d2b825e79f9f04c
+  React-Core: 50805a8b5eb817533763ae0132a0a61fc740fddf
+  React-CoreModules: 3147038a51e5a1a1819be556efb3c22855816aec
+  React-cxxreact: 88f9c5fbd0c391488fb884ab4bf8af85c548230c
+  React-jsi: e7b3496404f24299beb067b0e4fa38e836f1d6a4
+  React-jsiexecutor: f214cb9bebf408f6deeea9f6fe6ca610ab88eb6e
+  React-jsinspector: 7fba9bc98d5047bf5c8dae0cd8acd36b86448d04
+  React-RCTActionSheet: c4b92af34b6f64c786a972f5c196a375b7ce6cea
+  React-RCTAnimation: 5a0f7f7b3eaf0520e53d119f8352fdc622d0a90b
+  React-RCTBlob: 37befa1be701fe18ab0d63eb986b65829c843fc6
+  React-RCTImage: a02ff4f1882f35574ae589556b5c94b9eee973da
+  React-RCTLinking: 70240d29450241879339d7384b0903232d30e2c6
+  React-RCTNetwork: 17a1cd202a4566c25244444644a1fadd092466db
+  React-RCTPushNotification: eec1e289dfb203ee5360a9065c4009de0c16e097
+  React-RCTSettings: 490435d0c7767d085ebc9218d6cc9f9e2018ff1c
+  React-RCTTest: 06e4d480573015d42b0acb110aeb343c16d0c595
+  React-RCTText: a2a64b9c882d9b9a8e26c27773ca305ce910f4a6
+  React-RCTVibration: d32b07b6c9e821cb784b04e1c65cee3b35099b54
   React-TurboModuleCxx-RNW: 4da8eb44b10ab3c5bbab9fcb0a8ae415c20ea3c9
-  React-TurboModuleCxx-WinRTPort: 925292250d5b871d57d12be851c3fb77b371a07f
-  ReactCommon: 1f44521f0a214babcdb709a8d213adb388ebffb6
-  Yoga: 9fa16a72efe0fba876aaa6108e4590b7821dabde
+  React-TurboModuleCxx-WinRTPort: cbe13444db8dc3af024947610c537a27cea1c1cb
+  ReactCommon: d849f99f384dafff03d56ac7e9fd173e117b1509
+  Yoga: 5ba9af3554885e152355679790ed9be0b1d01695
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 18ca7d3b0e7db79041574a8bb6200b9e1c2d5359

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -431,7 +431,7 @@ DEPENDENCIES:
   - Yoga (from `../ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - CocoaAsyncSocket
     - CocoaLibEvent
     - Flipper
@@ -519,8 +519,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: e99626a767684cd45377cfb2d270260b08612394
-  FBReactNativeSpec: 4caa8b770647aad3624a57c46871bf01c1e1ef59
+  FBLazyVector: ccd2b1c6a86017fbfea2b4009cba9fc2d6da9a7f
+  FBReactNativeSpec: dbdc9075c7d8ebe849176e63c21dfef6126fe6dc
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -530,35 +530,35 @@ SPEC CHECKSUMS:
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   hermes: 12d049af0d8e8379c5b3b54ffb1919d670045bdc
-  libevent: ee9265726a1fc599dea382964fa304378affaa5f
+  libevent: d721abced7738e428c291489465953c9263d78f9
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 7803a0a3a3d56e3cec84ae1ccbe0f4a2476f9f69
-  RCTTypeSafety: ae513041fa8773699d99833a8691d2e8b8d6ee8a
-  React: d6306405782c4669fd3d4d0125a7b2cc2bb19233
-  React-ART: 65684f957e38c119918b2ad8e2f2c386790b20d0
-  React-callinvoker: edc229ccab488b3b57895e830d2b825e79f9f04c
-  React-Core: 50805a8b5eb817533763ae0132a0a61fc740fddf
-  React-CoreModules: 3147038a51e5a1a1819be556efb3c22855816aec
-  React-cxxreact: 88f9c5fbd0c391488fb884ab4bf8af85c548230c
-  React-jsi: e7b3496404f24299beb067b0e4fa38e836f1d6a4
-  React-jsiexecutor: f214cb9bebf408f6deeea9f6fe6ca610ab88eb6e
-  React-jsinspector: 7fba9bc98d5047bf5c8dae0cd8acd36b86448d04
-  React-RCTActionSheet: c4b92af34b6f64c786a972f5c196a375b7ce6cea
-  React-RCTAnimation: 5a0f7f7b3eaf0520e53d119f8352fdc622d0a90b
-  React-RCTBlob: 37befa1be701fe18ab0d63eb986b65829c843fc6
-  React-RCTImage: a02ff4f1882f35574ae589556b5c94b9eee973da
-  React-RCTLinking: 70240d29450241879339d7384b0903232d30e2c6
-  React-RCTNetwork: 17a1cd202a4566c25244444644a1fadd092466db
-  React-RCTPushNotification: eec1e289dfb203ee5360a9065c4009de0c16e097
-  React-RCTSettings: 490435d0c7767d085ebc9218d6cc9f9e2018ff1c
-  React-RCTTest: 06e4d480573015d42b0acb110aeb343c16d0c595
-  React-RCTText: a2a64b9c882d9b9a8e26c27773ca305ce910f4a6
-  React-RCTVibration: d32b07b6c9e821cb784b04e1c65cee3b35099b54
+  RCTRequired: 1fa869794052e905c322945334e6a991be944b15
+  RCTTypeSafety: a64d2f488e7242e94efde2ef7ab4912d30ce82ca
+  React: 91904833b61ac3b029d6b5d01fae0507e3adea50
+  React-ART: 4a55599d17c5cca51b0522eb51ea6086d0a0be3d
+  React-callinvoker: 1c16bc94c17f90fb502a6632d27596e98d1566d0
+  React-Core: b86304125ea347c4dd1380734811d8ad78abb3fc
+  React-CoreModules: 600a12259e735a9b9c8372d5836cf466f3d7145b
+  React-cxxreact: f1d93f2ee544b68c79d69d2f502fdd25e37bd994
+  React-jsi: a6385183b4c70d69cd6574efc70e099ae014efbd
+  React-jsiexecutor: cd3c5c37c989fcdfa06b1e333d0768c5f623626d
+  React-jsinspector: 2e2e478a80924897aff1214d9b1caa38edcccc4b
+  React-RCTActionSheet: d930349167dfc09226060c0c2a592cebbb2f6cd5
+  React-RCTAnimation: 28a56166afa8c7df91055065f837f91a44f5d281
+  React-RCTBlob: db12a6574c189d60caabc3c20d249cb5c9ede079
+  React-RCTImage: 06b75cdce39f09e7ea6dfe7c2e4d823104f9ea5d
+  React-RCTLinking: 3b146e6a8cbd54157e56eaf88687e51abccd7362
+  React-RCTNetwork: 187fdab4add18e4e660b5c499ecfa125bfad66e5
+  React-RCTPushNotification: c245e0beb02c56b166b170a3c313b9063f77baa0
+  React-RCTSettings: 3bfb8a129b8a698c349cd9842072df90d0a0be51
+  React-RCTTest: 9ae64f57b1f17bf7e9007a87d9b13c255d654d55
+  React-RCTText: 89bef95815de3a6d4f61ae3d6e287f9dfcabbbd9
+  React-RCTVibration: 3ede8d3f6c16dfe5cce11175a2866b742c6ee37b
   React-TurboModuleCxx-RNW: 4da8eb44b10ab3c5bbab9fcb0a8ae415c20ea3c9
-  React-TurboModuleCxx-WinRTPort: cbe13444db8dc3af024947610c537a27cea1c1cb
-  ReactCommon: d849f99f384dafff03d56ac7e9fd173e117b1509
-  Yoga: 5ba9af3554885e152355679790ed9be0b1d01695
+  React-TurboModuleCxx-WinRTPort: 925292250d5b871d57d12be851c3fb77b371a07f
+  ReactCommon: 1f44521f0a214babcdb709a8d213adb388ebffb6
+  Yoga: 9fa16a72efe0fba876aaa6108e4590b7821dabde
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 18ca7d3b0e7db79041574a8bb6200b9e1c2d5359

--- a/RNTester/js/components/RNTesterExampleList.js
+++ b/RNTester/js/components/RNTesterExampleList.js
@@ -69,7 +69,7 @@ class RowComponent extends React.PureComponent<{
               onShowUnderlay={this.props.onShowUnderlay}
               onHideUnderlay={this.props.onHideUnderlay}
               onAccessibilityAction={this._onPress} // TODO(macOS ISS#2323203)
-              acceptsKeyboardFocus={false} // TODO(macOS ISS#2323203)
+              focusable={false} // TODO(macOS ISS#2323203)
               onPress={this._onPress}>
               <View
                 style={[
@@ -158,7 +158,7 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
                     sections={filteredSections}
                     renderItem={this._renderItem}
                     keyboardShouldPersistTaps="handled"
-                    acceptsKeyboardFocus={true} // TODO(macOS ISS#2323203)
+                    focusable={true} // TODO(macOS ISS#2323203)
                     onSelectionEntered={this._handleOnSelectionEntered} // TODO(macOS ISS#2323203)
                     enableSelectionOnKeyPress={true} // TODO(macOS ISS#2323203)
                     automaticallyAdjustContentInsets={false}

--- a/RNTester/js/examples/FocusEventsExample/FocusEventsExample.js
+++ b/RNTester/js/examples/FocusEventsExample/FocusEventsExample.js
@@ -54,7 +54,7 @@ class FocusEventExample extends React.Component<{}, State> {
           {// Only test View on MacOS, since canBecomeFirstResponder is false on all iOS, therefore we can't focus
           Platform.OS === 'macos' ? (
             <View
-              acceptsKeyboardFocus={true}
+              focusable={true}
               enableFocusRing={true}
               onFocus={() => {
                 this.setState(prevState => ({
@@ -192,7 +192,7 @@ class FocusEventExample extends React.Component<{}, State> {
                   }));
                 }}>
                 <View
-                  acceptsKeyboardFocus={true}
+                  focusable={true}
                   enableFocusRing={true}
                   onFocus={() => {
                     this.setState(prevState => ({

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -393,7 +393,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
  * Specifies whether the view participates in the key view loop as user tabs through different controls
  * This is equivalent to acceptsFirstResponder on mac OS.
  */
-@property (nonatomic, assign) BOOL acceptsKeyboardFocus;
+@property (nonatomic, assign) BOOL focusable;
 /**
  * Specifies whether focus ring should be drawn when the view has the first responder status.
  */

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1364,13 +1364,13 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 
 - (BOOL)acceptsFirstResponder
 {
-  return ([self acceptsKeyboardFocus] && [NSApp isFullKeyboardAccessEnabled]) || [super acceptsFirstResponder];
+  return ([self focusable] && [NSApp isFullKeyboardAccessEnabled]) || [super acceptsFirstResponder];
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)theEvent
 {
   if (self.onClick != nil &&
-      [self acceptsKeyboardFocus] &&
+      [self focusable] &&
       [[self window] firstResponder] == self) {
     if ([[theEvent characters] isEqualToString:@" "] || [[theEvent characters] isEqualToString:@"\r"]) {
       self.onClick(nil);

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -369,8 +369,14 @@ RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RCTView)
 // macOS properties
 RCT_CUSTOM_VIEW_PROPERTY(acceptsKeyboardFocus, BOOL, RCTView)
 {
-  if ([view respondsToSelector:@selector(setAcceptsKeyboardFocus:)]) {
-    view.acceptsKeyboardFocus = json ? [RCTConvert BOOL:json] : defaultView.acceptsKeyboardFocus;
+  if ([view respondsToSelector:@selector(setFocusable:)]) {
+    view.focusable = json ? [RCTConvert BOOL:json] : defaultView.focusable;
+  }
+}
+RCT_CUSTOM_VIEW_PROPERTY(focusable, BOOL, RCTView)
+{
+  if ([view respondsToSelector:@selector(setFocusable:)]) {
+    view.focusable = json ? [RCTConvert BOOL:json] : defaultView.focusable;
   }
 }
 RCT_CUSTOM_VIEW_PROPERTY(enableFocusRing, BOOL, RCTView)

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -416,7 +416,7 @@
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
 - (BOOL)canBecomeKeyView
 {
-  return [self acceptsKeyboardFocus];
+  return [self focusable];
 }
 
 - (CGRect)focusRingMaskBounds


### PR DESCRIPTION
<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fixes #498

This change adds support for the "focusable" property present in upstream RN, along with react-native-windows and NetUI. We need to reconcile this against the existing acceptsKeyboardFocus property. This is tricky since its usage was untyped. We follow the same strategy as react-native-windows for this.

1. Usages of acceptsKeyboardFocus will continue to work, but will yellowbox
2. Components will prefer to use focusable, and Touchables with slightly different semantics will prefer focusable semantics when present

acceptsKeyboardFocus will redbox in RNW 0.64 instead of yellowbox, but this change should allow xplat code to use focusable and not be effected by that.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Added] - Support focusable, Yellowbox on acceptsKeyboardFocus

## Test Plan

Validated setting a view to focusable is propagated, and that setting a view to acceptsKeyboardFocus works but triggers a yellowbox. More fine-grained tests for Touchable were done with the same changes in react-native-windows.

![image](https://user-images.githubusercontent.com/835219/99559389-999e4480-2979-11eb-8c32-e945e0ad9e13.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/655)