### PR TITLE
Fix selection highlight regression in RNTester list

### DIFF
--- a/RNTester/js/components/RNTesterExampleList.js
+++ b/RNTester/js/components/RNTesterExampleList.js
@@ -73,8 +73,8 @@ class RowComponent extends React.PureComponent<{
               onPress={this._onPress}>
               <View
                 style={[
-                  rowStyle, // TODO(macOS ISS#2323203)
                   {backgroundColor: theme.SystemBackgroundColor},
+                  rowStyle, // TODO(macOS ISS#2323203)
                 ]}>
                 <Text style={[styles.rowTitleText, {color: theme.LabelColor}]}>
                   {item.module.title}
@@ -290,19 +290,6 @@ const styles = StyleSheet.create({
     fontSize: 11,
   },
   row: {
-    ...Platform.select({
-      // [TODO(macOS ISS#2323203)
-      macos: {
-        backgroundColor: PlatformColor('controlBackgroundColor'),
-      },
-      ios: {
-        backgroundColor: PlatformColor('secondarySystemGroupedBackgroundColor'),
-      },
-      default: {
-        // ]TODO(macOS ISS#2323203)
-        backgroundColor: 'white',
-      }, // [TODO(macOS ISS#2323203)
-    }), // ]TODO(macOS ISS#2323203)
     justifyContent: 'center',
     paddingHorizontal: 15,
     paddingVertical: 8,


### PR DESCRIPTION


#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:

## Summary

Wanted to tackle https://github.com/microsoft/react-native-macos/issues/605 which was described as a regression likely when merging upstream virtualized lists changes. However, as I tested this through it turned out that it's the styling override that's to blame, not the actual functionality, which seem to work as intended. 

Fixes https://github.com/microsoft/react-native-macos/issues/605

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fix selection highlight regression in RNTester list

## Test Plan

![Screen Recording 2020-12-01 at 10 42 26](https://user-images.githubusercontent.com/5106466/100723631-4b019900-33c2-11eb-91d9-004420a5a94b.gif)

This color doesn't look great in dark mode tho. But I didn't want to diverge too much from the original RNTester. Suggestions welcome.

<img width="752" alt="image" src="https://user-images.githubusercontent.com/5106466/100723692-610f5980-33c2-11eb-9213-256156b0c4ec.png">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/660)