### PR TITLE
Turn off debugging tools for release builds

### DIFF
--- a/.ado/ado-start-verdaccio.sh
+++ b/.ado/ado-start-verdaccio.sh
@@ -6,6 +6,6 @@ set -ex
 THIS_DIR=$PWD
 
 COMMAND="$TMPDIR/launchVerdaccio.command"
-echo "cd ${THIS_DIR}; sudo n 10 ; verdaccio --config ./.ado/verdaccio/config.yaml &> ./.ado/verdaccio/console.log" > "$COMMAND"
+echo "cd ${THIS_DIR}; verdaccio --config ./.ado/verdaccio/config.yaml &> ./.ado/verdaccio/console.log" > "$COMMAND"
 chmod +x "$COMMAND"
 open "$COMMAND"

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -96,10 +96,6 @@ jobs:
       vmImage: $(VmImage)
       demands: ['xcode', 'sh', 'npm']
     steps:
-      - task: UseNode@1
-        inputs:
-          version: '10.x'
-
       - template: templates/react-native-macos-init.yml
         parameters:
           configuration: $(configuration)

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -14,19 +14,7 @@ steps:
       rm -rf $(Build.Repository.LocalPath)/DerivedData
     displayName: 'Clean DerivedData'
 
-  # Install the required components specified in the Brewfile file.
-  - script: 'brew update'
-    displayName: 'brew update'
-
-  - script: 'brew bundle'
-    displayName: 'brew bundle'
-
-  # Brew can't access user data for node
-  - script: sudo chown -R $(whoami) /usr/local/*
-    displayName: 'fix node permissions'
-
-  - script: brew link node@12 --overwrite --force
-    displayName: 'ensure node 12'
+  - template: apple-node-setup.yml
 
   # Task Group: XCode select proper version
   - template: apple-xcode-select.yml

--- a/.ado/templates/apple-node-setup.yml
+++ b/.ado/templates/apple-node-setup.yml
@@ -1,0 +1,13 @@
+#
+# Task Group: Brew install node version
+#
+steps:
+  - script: 'brew bundle'
+    displayName: 'brew bundle'
+
+  # Brew can't access user data for node
+  - script: sudo chown -R $(whoami) /usr/local/*
+    displayName: 'fix node permissions'
+
+  - script: brew link node@12 --overwrite --force
+    displayName: 'ensure node 12'

--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -9,6 +9,8 @@ steps:
     submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
     persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+  - template: apple-node-setup.yml
+
   # First do a build of the local package, since we point the cli at the local files, it needs to be pre-built
   - task: CmdLine@2
     displayName: yarn install (local react-native-macos)
@@ -35,12 +37,6 @@ steps:
       script: |
         npm install --global verdaccio
 
-  - task: CmdLine@2
-    displayName: Install n used by ado-start-verdaccio.sh
-    inputs:
-      script: |
-        npm install --global n
-
   - task: ShellScript@2
     displayName: Launch test npm server (verdaccio)
     inputs:
@@ -63,7 +59,7 @@ steps:
   - task: CmdLine@2
     displayName: Bump package version
     inputs:
-      script: node scripts/bump-oss-version.js --ci 0.62.1000
+      script: node scripts/bump-oss-version.js --ci 0.0.1000
 
   - script: |
       npm publish --registry http://localhost:4873

--- a/.ado/waitForVerdaccio.js
+++ b/.ado/waitForVerdaccio.js
@@ -7,7 +7,7 @@ const path = require('path');
 
 function queryForServerStatus() {
 
-  http.get('http://localhost:4873', res => {
+  http.get('http://0.0.0.0:4873', res => {
     console.log(`Server status: ${res.statusCode}`);
     if (res.statusCode != 200) {
       setTimeout(queryForServerStatus, 2000);

--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -43,7 +43,8 @@
 #define RCT_DEV 1
 #else
 // Dev Mode is now enabled or disabled at runtime via the -[RCTDevSettings isDevModeEnabled] property
-#define RCT_DEV 1
+// For now, disable debugging in release builds to avoid a bug where we can Redbox in module init
+#define RCT_DEV 0
 #endif
 #endif
 

--- a/React/DevSupport/RCTDevLoadingView.m
+++ b/React/DevSupport/RCTDevLoadingView.m
@@ -210,7 +210,7 @@ RCT_EXPORT_METHOD(hide)
 
 + (NSString *)moduleName { return nil; }
 + (void)setEnabled:(BOOL)enabled { }
-- (void)showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor { }
+- (void)showMessage:(NSString *)message color:(RCTUIColor *)color backgroundColor:(RCTUIColor *)backgroundColor { }
 - (void)showWithURL:(NSURL *)URL { }
 - (void)updateProgress:(RCTLoadingProgress *)progress { }
 - (void)hide { }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

We can hit a Redbox error in our builds in the init module phase if we error out before we can correctly set up our NSUserDefaults for disabling debugging in the RCTDevSettings module init.

To unblock downstream the fix is to disable debugging on release builds. This is temporary and will hopefully not go into master as we can get a more complete fix in there.

## Changelog

[iOS/macOS] [Fix] - Fix redboxes from showing in release builds

## Test Plan

I copied the generated release lib that contains this fix into Word and rebuilt and the scenario no longer redboxes in ship.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/664)