### PR TITLE
verdaccio host connection refused

### DIFF
--- a/.ado/ado-start-verdaccio.sh
+++ b/.ado/ado-start-verdaccio.sh
@@ -6,6 +6,6 @@ set -ex
 THIS_DIR=$PWD
 
 COMMAND="$TMPDIR/launchVerdaccio.command"
-echo "cd ${THIS_DIR}; sudo n 10 ; verdaccio --config ./.ado/verdaccio/config.yaml &> ./.ado/verdaccio/console.log" > "$COMMAND"
+echo "cd ${THIS_DIR}; verdaccio --config ./.ado/verdaccio/config.yaml &> ./.ado/verdaccio/console.log" > "$COMMAND"
 chmod +x "$COMMAND"
 open "$COMMAND"

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -96,10 +96,6 @@ jobs:
       vmImage: $(VmImage)
       demands: ['xcode', 'sh', 'npm']
     steps:
-      - task: UseNode@1
-        inputs:
-          version: '10.x'
-
       - template: templates/react-native-macos-init.yml
         parameters:
           configuration: $(configuration)

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -14,19 +14,7 @@ steps:
       rm -rf $(Build.Repository.LocalPath)/DerivedData
     displayName: 'Clean DerivedData'
 
-  # Install the required components specified in the Brewfile file.
-  - script: 'brew update'
-    displayName: 'brew update'
-
-  - script: 'brew bundle'
-    displayName: 'brew bundle'
-
-  # Brew can't access user data for node
-  - script: sudo chown -R $(whoami) /usr/local/*
-    displayName: 'fix node permissions'
-
-  - script: brew link node@12 --overwrite --force
-    displayName: 'ensure node 12'
+  - template: apple-node-setup.yml
 
   # Task Group: XCode select proper version
   - template: apple-xcode-select.yml

--- a/.ado/templates/apple-node-setup.yml
+++ b/.ado/templates/apple-node-setup.yml
@@ -1,0 +1,13 @@
+#
+# Task Group: Brew install node version
+#
+steps:
+  - script: 'brew bundle'
+    displayName: 'brew bundle'
+
+  # Brew can't access user data for node
+  - script: sudo chown -R $(whoami) /usr/local/*
+    displayName: 'fix node permissions'
+
+  - script: brew link node@12 --overwrite --force
+    displayName: 'ensure node 12'

--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -9,6 +9,8 @@ steps:
     submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
     persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+  - template: apple-node-setup.yml
+
   # First do a build of the local package, since we point the cli at the local files, it needs to be pre-built
   - task: CmdLine@2
     displayName: yarn install (local react-native-macos)
@@ -35,12 +37,6 @@ steps:
       script: |
         npm install --global verdaccio
 
-  - task: CmdLine@2
-    displayName: Install n used by ado-start-verdaccio.sh
-    inputs:
-      script: |
-        npm install --global n
-
   - task: ShellScript@2
     displayName: Launch test npm server (verdaccio)
     inputs:
@@ -49,28 +45,28 @@ steps:
       cwd: ''
 
   - script: |
-      npm set registry http://0.0.0.0:4873
+      npm set registry http://localhost:4873
     displayName: Modify default npm config to point to local verdaccio server
 
-  # - script: |
-  #     node .ado/waitForVerdaccio.js
-  #   displayName: Wait for verdaccio server to boot
+  - script: |
+      node .ado/waitForVerdaccio.js
+    displayName: Wait for verdaccio server to boot
 
   - script: |
-      node .ado/npmAddUser.js user pass mail@nomail.com http://0.0.0.0:4873
+      node .ado/npmAddUser.js user pass mail@nomail.com http://localhost:4873
     displayName: Add npm user to verdaccio
 
   - task: CmdLine@2
     displayName: Bump package version
     inputs:
-      script: node scripts/bump-oss-version.js --ci 0.62.1000
+      script: node scripts/bump-oss-version.js --ci 0.0.1000
 
   - script: |
-      npm publish --registry http://0.0.0.0:4873
+      npm publish --registry http://localhost:4873
     displayName: Publish react-native-macos to verdaccio
 
   - script: |
-      npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://0.0.0.0:4873 --yes --access public
+      npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
     displayName: Publish react-native-macos-init to verdaccio
 
   - task: CmdLine@2

--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -49,7 +49,7 @@ steps:
       cwd: ''
 
   - script: |
-      npm set registry http://localhost:4873
+      npm set registry http://0.0.0.0:4873
     displayName: Modify default npm config to point to local verdaccio server
 
   - script: |
@@ -57,7 +57,7 @@ steps:
     displayName: Wait for verdaccio server to boot
 
   - script: |
-      node .ado/npmAddUser.js user pass mail@nomail.com http://localhost:4873
+      node .ado/npmAddUser.js user pass mail@nomail.com http://0.0.0.0:4873
     displayName: Add npm user to verdaccio
 
   - task: CmdLine@2
@@ -66,11 +66,11 @@ steps:
       script: node scripts/bump-oss-version.js --ci 0.62.1000
 
   - script: |
-      npm publish --registry http://localhost:4873
+      npm publish --registry http://0.0.0.0:4873
     displayName: Publish react-native-macos to verdaccio
 
   - script: |
-      npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
+      npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://0.0.0.0:4873 --yes --access public
     displayName: Publish react-native-macos-init to verdaccio
 
   - task: CmdLine@2

--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -52,9 +52,9 @@ steps:
       npm set registry http://0.0.0.0:4873
     displayName: Modify default npm config to point to local verdaccio server
 
-  - script: |
-      node .ado/waitForVerdaccio.js
-    displayName: Wait for verdaccio server to boot
+  # - script: |
+  #     node .ado/waitForVerdaccio.js
+  #   displayName: Wait for verdaccio server to boot
 
   - script: |
       node .ado/npmAddUser.js user pass mail@nomail.com http://0.0.0.0:4873

--- a/.ado/verdaccio/config.yaml
+++ b/.ado/verdaccio/config.yaml
@@ -2,6 +2,8 @@ storage: ./storage
 auth:
   htpasswd:
     file: ./htpasswd
+listen:
+  - 0.0.0.0:4873
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/

--- a/.ado/verdaccio/config.yaml
+++ b/.ado/verdaccio/config.yaml
@@ -2,8 +2,6 @@ storage: ./storage
 auth:
   htpasswd:
     file: ./htpasswd
-listen:
-  - 0.0.0.0:4873
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/

--- a/.ado/waitForVerdaccio.js
+++ b/.ado/waitForVerdaccio.js
@@ -7,7 +7,7 @@ const path = require('path');
 
 function queryForServerStatus() {
 
-  http.get('http://localhost:4873', res => {
+  http.get('http://0.0.0.0:4873', res => {
     console.log(`Server status: ${res.statusCode}`);
     if (res.statusCode != 200) {
       setTimeout(queryForServerStatus, 2000);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Change verdaccio server to fix connection refused problem.

## Changelog

[iOS/macOS] [Fix] - verdaccio

## Test Plan

if it passes CI then it works


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/665)