### PR TITLE
Give RCTDevLoadingView a more macOS look

### DIFF
--- a/React/CoreModules/RCTDevLoadingView.mm
+++ b/React/CoreModules/RCTDevLoadingView.mm
@@ -107,7 +107,7 @@ RCT_EXPORT_MODULE()
       self->_label.textAlignment = NSTextAlignmentCenter;
 #elif TARGET_OS_OSX // [TODO(macOS ISS#2323203)
       NSRect screenFrame = [NSScreen mainScreen].visibleFrame;
-      self->_window = [[NSPanel alloc] initWithContentRect:NSMakeRect(screenFrame.origin.x + round((screenFrame.size.width - 375) / 2), screenFrame.size.height - 19 - 1, 375, 19)
+      self->_window = [[NSPanel alloc] initWithContentRect:NSMakeRect(screenFrame.origin.x + round((screenFrame.size.width - 375) / 2), screenFrame.size.height - 20, 375, 19)
                                                  styleMask:NSWindowStyleMaskBorderless
                                                    backing:NSBackingStoreBuffered
                                                      defer:YES];

--- a/React/CoreModules/RCTDevLoadingView.mm
+++ b/React/CoreModules/RCTDevLoadingView.mm
@@ -107,17 +107,20 @@ RCT_EXPORT_MODULE()
       self->_label.textAlignment = NSTextAlignmentCenter;
 #elif TARGET_OS_OSX // [TODO(macOS ISS#2323203)
       NSRect screenFrame = [NSScreen mainScreen].visibleFrame;
-      self->_window = [[NSPanel alloc] initWithContentRect:NSMakeRect(screenFrame.origin.x + round((screenFrame.size.width - 375) / 2), screenFrame.size.height - 22, 375, 22)
+      self->_window = [[NSPanel alloc] initWithContentRect:NSMakeRect(screenFrame.origin.x + round((screenFrame.size.width - 375) / 2), screenFrame.size.height - 19 - 1, 375, 19)
                                                  styleMask:NSWindowStyleMaskBorderless
                                                    backing:NSBackingStoreBuffered
                                                      defer:YES];
       self->_window.releasedWhenClosed = NO;
+      self->_window.backgroundColor = [NSColor clearColor];
 
       NSTextField *label = [[NSTextField alloc] initWithFrame:self->_window.contentView.bounds];
       label.alignment = NSTextAlignmentCenter;
       label.bezeled = NO;
       label.editable = NO;
       label.selectable = NO;
+      label.wantsLayer = YES;
+      label.layer.cornerRadius = label.frame.size.height / 3;
       self->_label = label;
       [[self->_window contentView] addSubview:label];
 #endif // ]TODO(macOS ISS#2323203)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

I thought that the dev loading indicator having rounder corners would look more macOS-like than the one being a rectangle, so here it is. Also moved it 1pt down, so it have a visual distinction from the menu bar. This is purely aesthetic and I understand that it's not worth landing in the core :) It seems nicer though.

||RCTDevLoadingView|
| -- | -- |
|before|<img width="441" alt="Screen Shot 2020-12-05 at 00 55 34" src="https://user-images.githubusercontent.com/5106466/101226766-d36b8c80-3695-11eb-9afb-ff906b6d41de.png">|
|after|<img width="436" alt="Screen Shot 2020-12-05 at 00 51 59" src="https://user-images.githubusercontent.com/5106466/101226762-d23a5f80-3695-11eb-9169-4721dfb401ff.png">|

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Changed] - Give RCTDevLoadingView a more macOS look

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/667)