### PR TITLE
Cherry pick a few commits for 0.62-stable

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -53,8 +53,9 @@ jobs:
         inputs:
           script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(System.DefaultWorkingDirectory) -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
 
-      - script: '[ -f $(System.DefaultWorkingDirectory)/*.nupkg ]'
-        displayName: Verify that NuGet was actually created
+      # Android CI doesn't create a nuget now, but this check is failing builds. Quickest fix to unblock builds is to disable the check... but we need to find the root cause and fix it and enable this again.
+      # - script: '[ -f $(System.DefaultWorkingDirectory)/*.nupkg ]'
+      #   displayName: Verify that NuGet was actually created
 
       - task: CmdLine@2
         displayName: 'Npm pack'

--- a/.ado/templates/prep-android-nuget.yml
+++ b/.ado/templates/prep-android-nuget.yml
@@ -7,12 +7,3 @@ steps:
         $lines = Get-Content package.json | Where {$_ -match '^\s*"version":.*'} 
         $npmVersion = $lines.Trim().Split()[1].Trim('",');
         echo "##vso[task.setvariable variable=buildNumber]$npmVersion"
-
-  # Pretty yucky - but we dont want devmain to have to update versions _all_ over the place
-  - task: PowerShell@2
-    displayName: Change pom file to always use version 1000
-    inputs:
-      targetType: inline # filePath | inline
-      script: |
-        (Get-Content android\com\facebook\react\react-native\0.62.0\react-native-0.62.0.pom).replace('<version>0.62.0</version>', '<version>1000.0.0-master</version>') | Set-Content android\com\facebook\react\react-native\0.62.0\react-native-0.62.0.pom
-

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -3,14 +3,14 @@ PODS:
   - CocoaAsyncSocket (7.6.3)
   - CocoaLibEvent (1.0.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.62.15)
-  - FBReactNativeSpec (0.62.15):
+  - FBLazyVector (0.62.19)
+  - FBReactNativeSpec (0.62.19):
     - RCT-Folly (= 2018.10.22.00)
-    - RCTRequired (= 0.62.15)
-    - RCTTypeSafety (= 0.62.15)
-    - React-Core (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
+    - RCTRequired (= 0.62.19)
+    - RCTTypeSafety (= 0.62.19)
+    - React-Core (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
   - Flipper (0.30.2):
     - Flipper-Folly (~> 2.1)
     - Flipper-RSocket (~> 1.0)
@@ -81,272 +81,272 @@ PODS:
     - DoubleConversion
     - glog
     - libevent
-  - RCTRequired (0.62.15)
-  - RCTTypeSafety (0.62.15):
-    - FBLazyVector (= 0.62.15)
+  - RCTRequired (0.62.19)
+  - RCTTypeSafety (0.62.19):
+    - FBLazyVector (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTRequired (= 0.62.15)
-    - React-Core (= 0.62.15)
-  - React (0.62.15):
-    - React-Core (= 0.62.15)
-    - React-Core/DevSupport (= 0.62.15)
-    - React-Core/RCTWebSocket (= 0.62.15)
-    - React-RCTActionSheet (= 0.62.15)
-    - React-RCTAnimation (= 0.62.15)
-    - React-RCTBlob (= 0.62.15)
-    - React-RCTImage (= 0.62.15)
-    - React-RCTLinking (= 0.62.15)
-    - React-RCTNetwork (= 0.62.15)
-    - React-RCTSettings (= 0.62.15)
-    - React-RCTText (= 0.62.15)
-    - React-RCTVibration (= 0.62.15)
-  - React-ART (0.62.15):
-    - React-Core/ARTHeaders (= 0.62.15)
-  - React-Core (0.62.15):
+    - RCTRequired (= 0.62.19)
+    - React-Core (= 0.62.19)
+  - React (0.62.19):
+    - React-Core (= 0.62.19)
+    - React-Core/DevSupport (= 0.62.19)
+    - React-Core/RCTWebSocket (= 0.62.19)
+    - React-RCTActionSheet (= 0.62.19)
+    - React-RCTAnimation (= 0.62.19)
+    - React-RCTBlob (= 0.62.19)
+    - React-RCTImage (= 0.62.19)
+    - React-RCTLinking (= 0.62.19)
+    - React-RCTNetwork (= 0.62.19)
+    - React-RCTSettings (= 0.62.19)
+    - React-RCTText (= 0.62.19)
+    - React-RCTVibration (= 0.62.19)
+  - React-ART (0.62.19):
+    - React-Core/ARTHeaders (= 0.62.19)
+  - React-Core (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.15)
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-Core/Default (= 0.62.19)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/ARTHeaders (0.62.15):
-    - glog
-    - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
-    - Yoga
-  - React-Core/CoreModulesHeaders (0.62.15):
+  - React-Core/ARTHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/Default (0.62.15):
+  - React-Core/CoreModulesHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-Core/Default
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/DevSupport (0.62.15):
+  - React-Core/Default (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.15)
-    - React-Core/RCTWebSocket (= 0.62.15)
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
-    - React-jsinspector (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/Hermes (0.62.15):
+  - React-Core/DevSupport (0.62.19):
+    - glog
+    - RCT-Folly (= 2018.10.22.00)
+    - React-Core/Default (= 0.62.19)
+    - React-Core/RCTWebSocket (= 0.62.19)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
+    - React-jsinspector (= 0.62.19)
+    - Yoga
+  - React-Core/Hermes (0.62.19):
     - glog
     - hermes (~> 0.4.1)
     - RCT-Folly (= 2018.10.22.00)
     - RCT-Folly/Futures
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTActionSheetHeaders (0.62.15):
+  - React-Core/RCTActionSheetHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.62.15):
+  - React-Core/RCTAnimationHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.62.15):
+  - React-Core/RCTBlobHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTImageHeaders (0.62.15):
+  - React-Core/RCTImageHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.62.15):
+  - React-Core/RCTLinkingHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.62.15):
+  - React-Core/RCTNetworkHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.62.15):
+  - React-Core/RCTPushNotificationHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.62.15):
+  - React-Core/RCTSettingsHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTTextHeaders (0.62.15):
+  - React-Core/RCTTextHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.62.15):
+  - React-Core/RCTVibrationHeaders (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-Core/RCTWebSocket (0.62.15):
+  - React-Core/RCTWebSocket (0.62.19):
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/Default (= 0.62.15)
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-jsiexecutor (= 0.62.15)
+    - React-Core/Default (= 0.62.19)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-jsiexecutor (= 0.62.19)
     - Yoga
-  - React-CoreModules (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
+  - React-CoreModules (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.15)
-    - React-Core/CoreModulesHeaders (= 0.62.15)
-    - React-RCTImage (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-cxxreact (0.62.15):
+    - RCTTypeSafety (= 0.62.19)
+    - React-Core/CoreModulesHeaders (= 0.62.19)
+    - React-RCTImage (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-cxxreact (0.62.19):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-jsinspector (= 0.62.15)
-  - React-jsi (0.62.15):
+    - React-jsinspector (= 0.62.19)
+  - React-jsi (0.62.19):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-jsi/Default (= 0.62.15)
-  - React-jsi/Default (0.62.15):
+    - React-jsi/Default (= 0.62.19)
+  - React-jsi/Default (0.62.19):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-  - React-jsiexecutor (0.62.15):
+  - React-jsiexecutor (0.62.19):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-  - React-jsinspector (0.62.15)
-  - React-RCTActionSheet (0.62.15):
-    - React-Core/RCTActionSheetHeaders (= 0.62.15)
-  - React-RCTAnimation (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+  - React-jsinspector (0.62.19)
+  - React-RCTActionSheet (0.62.19):
+    - React-Core/RCTActionSheetHeaders (= 0.62.19)
+  - React-RCTAnimation (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.15)
-    - React-Core/RCTAnimationHeaders (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-RCTBlob (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
+    - RCTTypeSafety (= 0.62.19)
+    - React-Core/RCTAnimationHeaders (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-RCTBlob (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/RCTBlobHeaders (= 0.62.15)
-    - React-Core/RCTWebSocket (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - React-RCTNetwork (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-RCTImage (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
+    - React-Core/RCTBlobHeaders (= 0.62.19)
+    - React-Core/RCTWebSocket (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - React-RCTNetwork (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-RCTImage (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.15)
-    - React-Core/RCTImageHeaders (= 0.62.15)
-    - React-RCTNetwork (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-RCTLinking (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
-    - React-Core/RCTLinkingHeaders (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-RCTNetwork (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
+    - RCTTypeSafety (= 0.62.19)
+    - React-Core/RCTImageHeaders (= 0.62.19)
+    - React-RCTNetwork (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-RCTLinking (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
+    - React-Core/RCTLinkingHeaders (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-RCTNetwork (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.15)
-    - React-Core/RCTNetworkHeaders (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-RCTPushNotification (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
-    - RCTTypeSafety (= 0.62.15)
-    - React-Core/RCTPushNotificationHeaders (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-RCTSettings (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
+    - RCTTypeSafety (= 0.62.19)
+    - React-Core/RCTNetworkHeaders (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-RCTPushNotification (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
+    - RCTTypeSafety (= 0.62.19)
+    - React-Core/RCTPushNotificationHeaders (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-RCTSettings (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - RCTTypeSafety (= 0.62.15)
-    - React-Core/RCTSettingsHeaders (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - React-RCTTest (0.62.15):
-    - React-Core (= 0.62.15)
-    - React-CoreModules (= 0.62.15)
-  - React-RCTText (0.62.15):
-    - React-Core/RCTTextHeaders (= 0.62.15)
-  - React-RCTVibration (0.62.15):
-    - FBReactNativeSpec (= 0.62.15)
+    - RCTTypeSafety (= 0.62.19)
+    - React-Core/RCTSettingsHeaders (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - React-RCTTest (0.62.19):
+    - React-Core (= 0.62.19)
+    - React-CoreModules (= 0.62.19)
+  - React-RCTText (0.62.19):
+    - React-Core/RCTTextHeaders (= 0.62.19)
+  - React-RCTVibration (0.62.19):
+    - FBReactNativeSpec (= 0.62.19)
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core/RCTVibrationHeaders (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
-  - ReactCommon/callinvoker (0.62.15):
+    - React-Core/RCTVibrationHeaders (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
+  - ReactCommon/callinvoker (0.62.19):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-cxxreact (= 0.62.15)
-  - ReactCommon/turbomodule/core (0.62.15):
+    - React-cxxreact (= 0.62.19)
+  - ReactCommon/turbomodule/core (0.62.19):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core (= 0.62.15)
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - ReactCommon/callinvoker (= 0.62.15)
-  - ReactCommon/turbomodule/samples (0.62.15):
+    - React-Core (= 0.62.19)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - ReactCommon/callinvoker (= 0.62.19)
+  - ReactCommon/turbomodule/samples (0.62.19):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2018.10.22.00)
-    - React-Core (= 0.62.15)
-    - React-cxxreact (= 0.62.15)
-    - React-jsi (= 0.62.15)
-    - ReactCommon/callinvoker (= 0.62.15)
-    - ReactCommon/turbomodule/core (= 0.62.15)
+    - React-Core (= 0.62.19)
+    - React-cxxreact (= 0.62.19)
+    - React-jsi (= 0.62.19)
+    - ReactCommon/callinvoker (= 0.62.19)
+    - ReactCommon/turbomodule/core (= 0.62.19)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -477,8 +477,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 681b789128e5512811c81706e9b361209f40d21e
-  FBLazyVector: bc3eca783f136fd77f4c3b0523dda105b9859187
-  FBReactNativeSpec: f69ed05ef684e5be380c633d852b7c045b84533e
+  FBLazyVector: 2148067223fff0e0f8fbd80a6b0c934ffb7725a8
+  FBReactNativeSpec: 4651ecfeba87402f1ddb06782d6be89628c9a156
   Flipper: 10b225e352595f521be0e5badddd90e241336e89
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -491,31 +491,31 @@ SPEC CHECKSUMS:
   libevent: ee9265726a1fc599dea382964fa304378affaa5f
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 71ece0166f9c96c1ec9279eeb0317baf533c020f
-  RCTRequired: 8953bfefb26ff73e5d45e05f089b97193267deaf
-  RCTTypeSafety: 23fae052ca4a6708dc2ad3a31f7e3a4152a1b566
-  React: 7aaea546a755d0572f1ac60e49d017dd5962010b
-  React-ART: 40a3896d5d538edc1694ea658178685622105d76
-  React-Core: 85f68cf6bbc891751c2856e30e20e76fd9262438
-  React-CoreModules: 8e6c827bd718110e3978d5d892066b945d07a939
-  React-cxxreact: 6fd5fc345d1163574e61be29220d09199d936724
-  React-jsi: 4750ec29707649d512ac9cefa9e2e803dcb5bd45
-  React-jsiexecutor: ea128410408a90fa8c34e50727bf35d33f0afb47
-  React-jsinspector: b993b6199075a64cebb22503db21c1b03e7bab2c
-  React-RCTActionSheet: b55fe1713c2d3c994fa9f3eb5a0c6b864869751a
-  React-RCTAnimation: a6dd7efa9f0e049d1ea2ad7a73843b237547378d
-  React-RCTBlob: ac98a56c716baef9ac6e982f3e1eeb9329a9f6d0
-  React-RCTImage: 3b89c744fa718dace801f8989ff5054e13f52df4
-  React-RCTLinking: b643d4eb870c22b6ee654d7cfc21ff9c3e7c6219
-  React-RCTNetwork: 9cada148a7cbfed9175427bbd68ef5616af97aa4
-  React-RCTPushNotification: 29d049a50f7c885402b7eb66447ac89fa6ee6819
-  React-RCTSettings: 76e5e6f6b2a0bad6f7fbcd3a493cf6f752cb8794
-  React-RCTTest: d519420ee10c87f46a8b1b74d1e20a33a9ac1328
-  React-RCTText: b779378b6a01d2a4025dc0e32ea381af15741700
-  React-RCTVibration: 168ba1c81e7bec7dac242775d8930225d8d142cb
-  ReactCommon: 6e88045a7cc5568578eaa692aa3dc472108b0c4b
-  Yoga: 201b34f6ba83e49b98f5c3e2f612309aec3cfa89
+  RCTRequired: 918911330763c153719cc97d230fd9d68fef4293
+  RCTTypeSafety: 5c2458c8b7986d139316674c3d8574213fa8b03f
+  React: 14b21d89802f6deb3c58438b820a259f0ad19663
+  React-ART: b011af588c64073177c77ebaaba8bed4540da3d7
+  React-Core: b77665beecb3d2a4106f49e5689f40d1a9cdf48a
+  React-CoreModules: 65926e4c1f9db334435f7d8b2bc5b9c05393bfd2
+  React-cxxreact: e96cd68b9b1113c1738aa43c667f9b958b946aae
+  React-jsi: 9d639b6e1b7358ebf5e5794a27599b20a1bd5848
+  React-jsiexecutor: 9647f8a2e7a239ddbe28b358b33bcfff383c8898
+  React-jsinspector: e33ea205855278ad8a4bdef517749ac97e9acfbc
+  React-RCTActionSheet: 5f8275f010e786a9e55fba6a28bf4210c9ade83c
+  React-RCTAnimation: 2bf688fb4c2c8c719098902783e31dbd8a023ed5
+  React-RCTBlob: 5b88201c29e1dc93c5605c7f6056feae2ea25be7
+  React-RCTImage: c032e6bb560d7107521ca7117a64ed3371a66aa1
+  React-RCTLinking: fb9ba55af2995d8024c38a113a0f93fe4d29ed1a
+  React-RCTNetwork: 4000f11a6806f1863bfa7600d77ad623c55d7d9d
+  React-RCTPushNotification: 8461343c6c53d8614074ac2340780f5305b80fd8
+  React-RCTSettings: 07c25b9a0e21ca6003639421c1502dc527a9f8f6
+  React-RCTTest: 912ac34abccf794c640303ee8f27745b2d89277b
+  React-RCTText: 7785349fd7bd8486f314ae55869aedb0d0ecf43b
+  React-RCTVibration: 389fe18e19c8baff80d7243580398d37f50c18c4
+  ReactCommon: c8428c9a8fdd14228f9f190883832aaeeba7911e
+  Yoga: fa1f25acd1b133b22869a154cacb2e690b166e2f
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 8a50297c26ad9d948d1614b33e20d755094cb377
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.0

--- a/RNTester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTester-macOS Release.xcscheme
+++ b/RNTester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTester-macOS Release.xcscheme
@@ -101,12 +101,21 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F15345A233AB2C4006DFE44"
+            BuildableName = "RNTester-macOS.app"
+            BlueprintName = "RNTester-macOS"
+            ReferencedContainer = "container:RNTesterPods.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
             BlueprintIdentifier = "18FC77851EF4770B002B3F17"
             BuildableName = "RNTester-macOS.app"
             BlueprintName = "RNTester-macOS"
             ReferencedContainer = "container:RNTester.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "CI_USE_PACKAGER"

--- a/React/Base/RCTRedBoxSetEnabled.m
+++ b/React/Base/RCTRedBoxSetEnabled.m
@@ -7,7 +7,7 @@
 
 #import "RCTRedBoxSetEnabled.h"
 
-#if RCT_DEV
+#if RCT_DEV && DEBUG // TODO(macOS ISS#2323203) RCT_DEV is always on in the react-native-macos fork, so to not default to redboxing in release builds, trigger the initial value off of the scheme as well
 static BOOL redBoxEnabled = YES;
 #else
 static BOOL redBoxEnabled = NO;

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "babel-eslint": "10.0.1",
     "clang-format": "^1.2.4",
     "coveralls": "^3.0.2",
-    "detox": "14.5.1",
+    "detox": "16.7.2",
     "eslint": "5.1.0",
     "eslint-config-fb-strict": "24.3.0",
     "eslint-config-fbjs": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,10 +2093,10 @@ big-integer@^1.6.7:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.36.tgz#78631076265d4ae3555c04f85e7d9d2f3a071a36"
   integrity sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==
 
-bluebird@3.5.x:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
-  integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
+bluebird@^3.5.4:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bplist-creator@0.0.7:
   version "0.0.7"
@@ -2837,16 +2837,17 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detox@14.5.1:
-  version "14.5.1"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-14.5.1.tgz#dd3cbdb4f26aaf461774303eb825f2f0fc8e8260"
-  integrity sha512-ZFt9LOHRXTxX1HVefysCnF5tLQQRQvr+w4KSXxkdJUa+9afr9/avZyz5kR0elasC2aU6/pnuzUiOJmCCyy7f6w==
+detox@16.7.2:
+  version "16.7.2"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-16.7.2.tgz#531c98416adf52d4ba95601b669969acadafb970"
+  integrity sha512-+837eRgk4xOewXmeF5H6vOTn0RbKUFIyCi5UsTXEhvplsMk+KrrqfKik2j8fvubJkByry7HqIN/JF9jKe+meIQ==
   dependencies:
     "@babel/core" "^7.4.5"
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"
     chalk "^2.4.2"
     child-process-promise "^2.2.0"
+    find-up "^4.1.0"
     fs-extra "^4.0.2"
     funpermaproxy "^1.0.1"
     get-port "^2.1.0"
@@ -2857,7 +2858,7 @@ detox@14.5.1:
     sanitize-filename "^1.6.1"
     shell-utils "^1.0.9"
     tail "^2.0.0"
-    telnet-client "0.15.3"
+    telnet-client "1.2.8"
     tempfile "^2.0.0"
     which "^1.3.1"
     ws "^3.3.1"
@@ -7220,12 +7221,12 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-telnet-client@0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/telnet-client/-/telnet-client-0.15.3.tgz#99ec754e4acf6fa51dc69898f574df3c2550712e"
-  integrity sha512-GSfdzQV0BKIYsmeXq7bJFJ2wHeJud6icaIxCUf6QCGQUD6R0BBGbT1+yLDhq67JRdgRpwyPwUbV7JxFeRrZomQ==
+telnet-client@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/telnet-client/-/telnet-client-1.2.8.tgz#946c0dadc8daa3f19bb40a3e898cb870403a4ca4"
+  integrity sha512-W+w4k3QAmULVNhBVT2Fei369kGZCh/TH25M7caJAXW+hLxwoQRuw0di3cX4l0S9fgH3Mvq7u+IFMoBDpEw/eIg==
   dependencies:
-    bluebird "3.5.x"
+    bluebird "^3.5.4"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Pull in several important fixes to ensure 0.62-stable continues working.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Update detox to a later version that is compatible with Xcode 12 (cherry picked from #670)
[General] [Fixed] - Disable redboxes on release builds (cherry picked from #671)
[Android] [Fixed] - Fix Android CI (cherry picked from #674) 

## Test Plan

RNTester test app still works.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/676)