### PR TITLE
Enclose the app path in quotes, so that the `open` command doesn't split it if it contains spaces

### DIFF
--- a/local-cli/runMacOS/runMacOS.js
+++ b/local-cli/runMacOS/runMacOS.js
@@ -87,7 +87,7 @@ async function run(xcodeProject, scheme, args) {
   );
 
   child_process.exec(
-    'open -b ' + bundleID + ' -a ' + appPath,
+    'open -b ' + bundleID + ' -a ' + '"' + appPath + '"',
     (error, stdout, stderr) => {
       if (error) {
         logger.error('Failed to launch the app', stderr);


### PR DESCRIPTION
(This PR has already been accepted for the [`master`branch](https://github.com/microsoft/react-native-macos/pull/678))

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When running `npx react-native run-macos` (or locally `node node_modules/react-native-macos/local-cli/cli.js run-macos`) and if the target app has spaces in the name, the current call to the `open` macOS command will split the path and only keep the last part as the name in the app, which will fail:

```
...
▸ Build Succeeded
info Launching app "io.sergi.todolist" from "/Users/sergi/Library/Developer/Xcode/DerivedData/Todo_List-efowxgkzzzbxtgeghbplezporgmk/Build/Products/Debug/Todo List.app"
error Failed to launch the app, The file /Users/sergi/code/todo_list/macos/List.app does not exist.
```

This fix  surrounds the path in quotes, which is the standard way to deal with spaces in the path. It solves the issue and introduces no other effects.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fixes CLI failing to launch app if the path contains spaces

## Test Plan

This fix requires no further testing, as it only encloses a file path in quotes, keeping the exact same previous functionality, and preventing spaces from making `open` command misbehave.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/679)