### PR TITLE
Complete basic layout animation support

### DIFF
--- a/React/Modules/RCTLayoutAnimation.m
+++ b/React/Modules/RCTLayoutAnimation.m
@@ -164,6 +164,7 @@ static NSString *CAMediaTimingFunctionNameFromRCTAnimationType(RCTAnimationType 
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
       context.duration = duration;
       context.timingFunction = timingFunction;
+      context.allowsImplicitAnimation = YES;
       
       if (animations != nil) {
         animations();


### PR DESCRIPTION
# Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

(Kinda) Fixes #277 

I decided to take a look at the `LayoutAnimation` implementation and found that it was 99% of the way there already — only needing a single line change in order to opt into implicit CAAnimations. It was so close to working previously that I'm inclined to believe that this was intentional, but without any comments explaining why and the file's history being kind of a mess, I'm submitting this PR so that we can hopefully at the very least get the reasoning documented.

The MacOS implementation of LayoutAnimation uses the closest analog to UIView's animateWithDuration API (what RN on iOS uses) but unfortunately the MacOS API doesn't provide any mechanisms to provide a spring timing function like iOS does. Adding support for the spring timing functions will likely require a rewrite with a lower level animation API.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[MacOS] [Added] - Completed basic LayoutAnimation support

## Test Plan

| Before | After |
|---|---|
| ![2020-12-26 19 20 54](https://user-images.githubusercontent.com/1398555/103161415-933c8d00-47af-11eb-83c8-08a08524a8f6.gif) | ![2020-12-26 19 20 59](https://user-images.githubusercontent.com/1398555/103161420-96d01400-47af-11eb-8769-dd7c4a04e310.gif) |



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/681)