### PR TITLE
Nuspec has two copies of version tag, and so nuget publish fails

### DIFF
--- a/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
@@ -1,12 +1,11 @@
 --- "E:\\github\\rnm-63-fresh\\ReactAndroid\\ReactAndroid.nuspec"	1969-12-31 16:00:00.000000000 -0800
 +++ "E:\\github\\rnm-63\\ReactAndroid\\ReactAndroid.nuspec"	2020-10-27 20:20:54.071789900 -0700
-@@ -0,0 +1,141 @@
+@@ -0,0 +1,140 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
 +    <id>OfficeReact.Android</id>
 +    <version>$buildNumber$</version>
-+    <version>0.63</version>
 +    <description>Contains Android Implementation of React-Native</description>
 +    <authors>Microsoft</authors>
 +    <projectUrl>https://github.com/microsoft/react-native</projectUrl>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native


Publishing of the Office Android nuget is currently failing due to a malformed nuspec file.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/689)