### PR TITLE
Ensuring that the same version of folly is built as well as packaged

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -140,7 +140,7 @@ jobs:
       - task: CmdLine@2
         displayName: gradlew installArchives
         inputs:
-          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
+          script: REACT_NATIVE_DEPENDENCIES=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
 
       - template: templates\prep-android-nuget.yml
 


### PR DESCRIPTION
This commit (https://github.com/microsoft/react-native-macos/commit/b2afdfdc8dbb8286417d599255fc8f4049d9729b#diff-8cc88adda4da183aafc286681a96e285509fd92919e0549a163c376f2ee12994) has updated the Android publish task to build with downloaded folly sources. But, the changes to package the downloaded folly headers is not yet available in RN62-stable. Which resulted in ABI mismatch when consuming the RN62 nuget package. 

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Devmain SDX features are crashing due to ABI mismatches when using Folly datastructures.

## Changelog

Devmain SDX features are crashing due to ABI mismatches when using Folly datastructures.

This commit (https://github.com/microsoft/react-native-macos/commit/b2afdfdc8dbb8286417d599255fc8f4049d9729b#diff-8cc88adda4da183aafc286681a96e285509fd92919e0549a163c376f2ee12994) has updated the Android publish task to build with downloaded folly sources. But, the changes to package the downloaded folly headers is not yet available in RN62-stable. Which resulted in ABI mismatch when consuming the RN62 nuget package. 

[CATEGORY] [TYPE] - Message

## Test Plan

Devmain applications shouldn't crash

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/690)