### PR TITLE
Updates to (recently added) keyboarding events + add ability to have split buttons on macOS

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -23,6 +23,11 @@ const invariant = require('invariant');
 import type {PressEvent, KeyEvent} from '../Types/CoreEventTypes';
 import type {FocusEvent, BlurEvent} from './TextInput/TextInput'; // TODO(OSS Candidate ISS#2710739)
 import type {ColorValue} from '../StyleSheet/StyleSheetTypes';
+import type {
+  AccessibilityActionEvent,
+  AccessibilityActionInfo,
+  AccessibilityRole,
+} from './View/ViewAccessibility';
 
 type ButtonProps = $ReadOnly<{|
   /**
@@ -93,6 +98,20 @@ type ButtonProps = $ReadOnly<{|
    * Hint text to display blindness accessibility features
    */
   accessibilityHint?: ?string, // TODO(OSS Candidate ISS#2710739)
+
+  // TODO(OSS Candidate ISS#2710739)
+  /**
+   * Custom accessibility role -- otherwise we use button
+   */
+  accessibilityRole?: ?AccessibilityRole,
+
+  // TODO(OSS Candidate ISS#2710739)
+  /**
+   * Accessibility action handlers
+   */
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  
   /**
    * If true, disable all interactions for this component.
    */
@@ -171,6 +190,9 @@ class Button extends React.Component<ButtonProps> {
     const {
       accessibilityLabel,
       accessibilityHint, // TODO(OSS Candidate ISS#2710739)
+      accessibilityRole, // TODO(OSS Candidate ISS#2710739)
+      accessibilityActions, // TODO(OSS Candidate ISS#2710739)
+      onAccessibilityAction, // TODO(OSS Candidate ISS#2710739)
       color,
       onPress,
       touchSoundDisabled,
@@ -220,8 +242,10 @@ class Button extends React.Component<ButtonProps> {
       <Touchable
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint} // TODO(OSS Candidate ISS#2710739)
-        accessibilityRole="button"
+        accessibilityRole={accessibilityRole || "button"} // TODO(OSS Candidate ISS#2710739)
         accessibilityState={accessibilityState}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
         hasTVPreferredFocus={hasTVPreferredFocus}
         nextFocusDown={nextFocusDown}
         nextFocusForward={nextFocusForward}

--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -111,7 +111,7 @@ type ButtonProps = $ReadOnly<{|
    */
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
-  
+
   /**
    * If true, disable all interactions for this component.
    */
@@ -242,7 +242,7 @@ class Button extends React.Component<ButtonProps> {
       <Touchable
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint} // TODO(OSS Candidate ISS#2710739)
-        accessibilityRole={accessibilityRole || "button"} // TODO(OSS Candidate ISS#2710739)
+        accessibilityRole={accessibilityRole || 'button'} // TODO(OSS Candidate ISS#2710739)
         accessibilityState={accessibilityState}
         accessibilityActions={accessibilityActions}
         onAccessibilityAction={onAccessibilityAction}

--- a/Libraries/Components/View/ReactNativeViewViewConfig.js
+++ b/Libraries/Components/View/ReactNativeViewViewConfig.js
@@ -45,18 +45,6 @@ const ReactNativeViewConfig = {
         captured: 'onFocusCapture',
       },
     },
-    topKeyUp: {
-      phasedRegistrationNames: {
-        bubbled: 'onKeyUp',
-        captured: 'onKeyUpCapture',
-      },
-    },
-    topKeyDown: {
-      phasedRegistrationNames: {
-        bubbled: 'onKeyDown',
-        captured: 'onKeyDownCapture',
-      },
-    },
     topKeyPress: {
       phasedRegistrationNames: {
         bubbled: 'onKeyPress',
@@ -117,6 +105,12 @@ const ReactNativeViewConfig = {
     },
     topMagicTap: {
       registrationName: 'onMagicTap',
+    },
+    topKeyUp: {
+      registrationName: 'onKeyUp',
+    },
+    topKeyDown: {
+      registrationName: 'onKeyDown',
     },
     // Events for react-native-gesture-handler (T45765076)
     // Remove once this library can handle JS View Configs

--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -45,7 +45,9 @@ export type AccessibilityRole =
   | 'tab'
   | 'tablist'
   | 'timer'
-  | 'toolbar';
+  | 'toolbar'
+  | 'popupbutton'
+  | 'menubutton';
 
 // the info associated with an accessibility action
 export type AccessibilityActionInfo = $ReadOnly<{

--- a/RNTester/js/examples/AccessibilityShowMenu/AccessibilityShowMenu.js
+++ b/RNTester/js/examples/AccessibilityShowMenu/AccessibilityShowMenu.js
@@ -17,31 +17,33 @@ const {Button, Text, View} = ReactNative;
 
 class AccessibilityShowMenu extends React.Component {
   onClick: () => void = () => {
-    console.log('received click event\n',);
+    console.log('received click event\n');
   };
 
-  onAccessibilityAction: (e) => void = (e) => {
+  onAccessibilityAction: e => void = e => {
     if (e.nativeEvent.actionName === 'showMenu') {
-        console.log('received accessibility show event\n');
+      console.log('received accessibility show event\n');
     }
   };
 
   render() {
     return (
       <View>
-        <Text>Accessibility Show Menu action is dispatched when the OS triggers it</Text>
+        <Text>
+          Accessibility Show Menu action is dispatched when the OS triggers it
+        </Text>
         <View>
           {Platform.OS === 'macos' ? (
-              <Button
-                title={'Test button'}
-                onPress={this.onClick}
-                accessibilityRole={'menubutton'}
-                accessibilityActions={[
-                    { name: 'showMenu' }
-                  ]}
-                accessibilityHint={'For more options, press Control-Option-Shift-M'}
-                onAccessibilityAction={this.onAccessibilityAction}
-              />
+            <Button
+              title={'Test button'}
+              onPress={this.onClick}
+              accessibilityRole={'menubutton'}
+              accessibilityActions={[{name: 'showMenu'}]}
+              accessibilityHint={
+                'For more options, press Control-Option-Shift-M'
+              }
+              onAccessibilityAction={this.onAccessibilityAction}
+            />
           ) : null}
         </View>
       </View>
@@ -50,7 +52,8 @@ class AccessibilityShowMenu extends React.Component {
 }
 
 exports.title = 'Accessibiltiy Show Menu action';
-exports.description = 'Examples that show how Accessibility Show Menu action can be used.';
+exports.description =
+  'Examples that show how Accessibility Show Menu action can be used.';
 exports.examples = [
   {
     title: 'AccessibilityShowMenu',

--- a/RNTester/js/examples/AccessibilityShowMenu/AccessibilityShowMenu.js
+++ b/RNTester/js/examples/AccessibilityShowMenu/AccessibilityShowMenu.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict'; // TODO(OSS Candidate ISS#2710739)
+
+const React = require('react');
+const ReactNative = require('react-native');
+import {Platform} from 'react-native';
+const {Button, Text, View} = ReactNative;
+
+class AccessibilityShowMenu extends React.Component {
+  onClick: () => void = () => {
+    console.log('received click event\n',);
+  };
+
+  onAccessibilityAction: (e) => void = (e) => {
+    if (e.nativeEvent.actionName === 'showMenu') {
+        console.log('received accessibility show event\n');
+    }
+  };
+
+  render() {
+    return (
+      <View>
+        <Text>Accessibility Show Menu action is dispatched when the OS triggers it</Text>
+        <View>
+          {Platform.OS === 'macos' ? (
+              <Button
+                title={'Test button'}
+                onPress={this.onClick}
+                accessibilityRole={'menubutton'}
+                accessibilityActions={[
+                    { name: 'showMenu' }
+                  ]}
+                accessibilityHint={'For more options, press Control-Option-Shift-M'}
+                onAccessibilityAction={this.onAccessibilityAction}
+              />
+          ) : null}
+        </View>
+      </View>
+    );
+  }
+}
+
+exports.title = 'Accessibiltiy Show Menu action';
+exports.description = 'Examples that show how Accessibility Show Menu action can be used.';
+exports.examples = [
+  {
+    title: 'AccessibilityShowMenu',
+    render: function(): React.Element<any> {
+      return <AccessibilityShowMenu />;
+    },
+  },
+];

--- a/RNTester/js/examples/AccessibilityShowMenu/AccessibilityShowMenu.js
+++ b/RNTester/js/examples/AccessibilityShowMenu/AccessibilityShowMenu.js
@@ -12,15 +12,17 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-import {Platform} from 'react-native';
 const {Button, Text, View} = ReactNative;
 
-class AccessibilityShowMenu extends React.Component {
+import {Platform} from 'react-native';
+import type {AccessibilityActionEvent} from 'react-native/Libraries/Components/View/ViewAccessibility';
+
+class AccessibilityShowMenu extends React.Component<{}> {
   onClick: () => void = () => {
     console.log('received click event\n');
   };
 
-  onAccessibilityAction: e => void = e => {
+  onAccessibilityAction: (e: AccessibilityActionEvent) => void = e => {
     if (e.nativeEvent.actionName === 'showMenu') {
       console.log('received accessibility show event\n');
     }

--- a/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
+++ b/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
@@ -33,7 +33,7 @@ class KeyEventExample extends React.Component<{}, State> {
     this.setState({characters: e.nativeEvent.key});
     this.setState(prevState => ({
       eventStream:
-        prevState.eventStream + prevState.characters + '\nKey Down: ',
+        prevState.eventStream + '\nKey Down: ' + prevState.characters,
     }));
   };
 
@@ -41,7 +41,7 @@ class KeyEventExample extends React.Component<{}, State> {
     console.log('received key up event\n', e.nativeEvent.key);
     this.setState({characters: e.nativeEvent.key});
     this.setState(prevState => ({
-      eventStream: prevState.eventStream + prevState.characters + '\nKey Up: ',
+      eventStream: prevState.eventStream + '\nKey Up: ' + prevState.characters,
     }));
   };
 

--- a/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
+++ b/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
@@ -54,13 +54,13 @@ class KeyEventExample extends React.Component<{}, State> {
             <View
               acceptsKeyboardFocus={true}
               enableFocusRing={true}
-              validKeysDown={['a', 'b', 'rightArrow']}
+              validKeysDown={['a', 'b', 'x', 'rightArrow']}
               onKeyDown={this.onKeyDownEvent}
               validKeysUp={['c', 'd', 'leftArrow']}
               onKeyUp={this.onKeyUpEvent}>
               <Button
                 title={'Test button'}
-                validKeysDown={['g', 'h', 'i']}
+                validKeysDown={['g', 'h', 'i', 'x']}
                 onKeyDown={this.onKeyDownEvent}
                 validKeysUp={['j', 'k', 'l']}
                 onKeyUp={this.onKeyUpEvent}

--- a/RNTester/js/utils/RNTesterList.ios.js
+++ b/RNTester/js/utils/RNTesterList.ios.js
@@ -57,6 +57,11 @@ const ComponentExamples: Array<RNTesterExample> = [
     supportsTVOS: false,
   }, // ]TODO(OSS Candidate ISS#2710739)
   {
+    key: 'AccessibilityShowMenu',
+    module: require('../examples/AccessibilityShowMenu/AccessibilityShowMenu'),
+    supportsTVOS: false,
+  }, // ]TODO(OSS Candidate ISS#2710739)
+  {
     key: 'ImageExample',
     module: require('../examples/Image/ImageExample'),
     supportsTVOS: true,

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1358,6 +1358,8 @@ RCT_ENUM_CONVERTER(
       @"disclosure": NSAccessibilityDisclosureTriangleRole,
       @"group": NSAccessibilityGroupRole,
       @"list": NSAccessibilityListRole,
+      @"popupbutton": NSAccessibilityPopUpButtonRole,
+      @"menubutton": NSAccessibilityMenuButtonRole,
     };
   });
 

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -137,8 +137,8 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, copy) RCTDirectEventBlock onDrop;
 
 // Keyboarding events
-@property (nonatomic, copy) RCTBubblingEventBlock onKeyDown;
-@property (nonatomic, copy) RCTBubblingEventBlock onKeyUp;
+@property (nonatomic, copy) RCTDirectEventBlock onKeyDown;
+@property (nonatomic, copy) RCTDirectEventBlock onKeyUp;
 @property (nonatomic, copy) NSArray<NSString*> *validKeysDown;
 @property (nonatomic, copy) NSArray<NSString*> *validKeysUp;
 #endif // ]TODO(macOS ISS#2323203)

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -435,11 +435,32 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     if (_onAccessibilityAction != nil && accessibilityActionsNameMap[@"decrement"]) {
       isAllowed = YES;
     }
+#if TARGET_OS_OSX // TODO(macOS ISS#2323203)
+  } else if (selector == @selector(accessibilityPerformShowMenu)) {
+    if (_onAccessibilityAction != nil && accessibilityActionsNameMap[@"showMenu"]) {
+      isAllowed = YES;
+    }
+#endif
   } else {
     isAllowed = YES;
   }
   return isAllowed;
 }
+
+// This override currently serves as a workaround to avoid the generic "action 1"
+// description for show menu
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (NSString *)accessibilityActionDescription:(NSString *)action {
+	NSString *actionDescription = nil;
+	if ([action isEqualToString:NSAccessibilityPressAction] || [action isEqualToString:NSAccessibilityShowMenuAction]) {
+		actionDescription = NSAccessibilityActionDescription(action);
+	} else {
+		actionDescription = [super accessibilityActionDescription:action];
+	}
+	return actionDescription;
+}
+#pragma clang dianostic pop
 
 - (BOOL)isAccessibilityEnabled {
   BOOL isAccessibilityEnabled = YES;
@@ -672,6 +693,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 - (BOOL)accessibilityPerformDecrement
 {
   return [self performAccessibilityAction:@"decrement"];
+}
+#endif // ]TODO(macOS ISS#2323203)
+
+#if TARGET_OS_OSX // TODO(macOS ISS#2323203)
+- (BOOL)accessibilityPerformShowMenu
+{
+  return [self performAccessibilityAction:@"showMenu"];
 }
 #endif // ]TODO(macOS ISS#2323203)
 

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1685,7 +1685,7 @@ const NSString *downArrowPressKey = @"downArrow";
 
   RCTViewKeyboardEvent *keyboardEvent = [self keyboardEvent:event downPress:YES];
   if (keyboardEvent != nil) {
-    [_eventDispatcher sendEvent:[self keyboardEvent:event downPress:YES]];
+    [_eventDispatcher sendEvent:keyboardEvent];
   } else {
     [super keyDown:event];
   }
@@ -1701,7 +1701,7 @@ const NSString *downArrowPressKey = @"downArrow";
   if (keyboardEvent != nil) {
     [_eventDispatcher sendEvent:keyboardEvent];
   } else {
-    [super keyDown:event];
+    [super keyUp:event];
   }
 }
 #endif // TARGET_OS_OSX

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -112,8 +112,6 @@ RCT_EXPORT_MODULE()
     @"change",
     @"focus",
     @"blur",
-    @"keyDown",
-    @"keyUp",
     @"submitEditing",
     @"endEditing",
     @"keyPress",
@@ -465,8 +463,8 @@ RCT_EXPORT_VIEW_PROPERTY(onMouseLeave, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDragEnter, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDragLeave, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDrop, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onKeyDown, RCTBubblingEventBlock) // macOS keyboard events
-RCT_EXPORT_VIEW_PROPERTY(onKeyUp, RCTBubblingEventBlock) // macOS keyboard events
+RCT_EXPORT_VIEW_PROPERTY(onKeyDown, RCTDirectEventBlock) // macOS keyboard events
+RCT_EXPORT_VIEW_PROPERTY(onKeyUp, RCTDirectEventBlock) // macOS keyboard events
 RCT_CUSTOM_VIEW_PROPERTY(validKeysDown, NSArray<NSString*>, RCTView)
 {
   if ([view respondsToSelector:@selector(setValidKeysDown:)]) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

* Switch key down and key up to direct events. Because views need to specify what events they're interested in, they should probably only receive those events (and nothing else). But because these were added as bubbling events, views can receive events they never asked for, since these events "bubbled" (to their ancestors, from the RN side, not the native\OS side -- which makes sense on say, Win32, where there's no such specification on what events views are interested in, but not so much on the Mac)
* Fix wrong keyUp -> keyDown redirection in RCTView
* Minor fixes in keyboard events example to test the above
* Add custom accessibility role override + actions on button. Plumb to underlying touchable.
* Add new accessibility roles (menu button, pop up button)
* Add new custom split button example that demonstrates possible usage of the above

## Test Plan

* Tested various keys on the button (g, h, i, x, j, k, l) and the enclosing view (a, b, c, d, x, left arrow, right arrow). Ensured there are no "duplicate" events
* Tested VO with the custom split button example -- checked role, accessibility hint, press (VO+space), and show menu (VO+shift+m) actions
* The above, this time with accessibility inspector instead
* Ensured no new warnings in RNTester