### PR TITLE
Revert RCT_DEV to enabled in release builds to test downstream unblock

### DIFF
--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -43,8 +43,7 @@
 #define RCT_DEV 1
 #else
 // Dev Mode is now enabled or disabled at runtime via the -[RCTDevSettings isDevModeEnabled] property
-// For now, disable debugging in release builds to avoid a bug where we can Redbox in module init
-#define RCT_DEV 0
+#define RCT_DEV 1
 #endif
 #endif
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Undo this for now to unblock other changes getting into devmain. This is likely causing the DevSettings turbo module to not get found in release builds which is breaking.

## Test Plan

Can verify once a nuget is produced

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-macos/pull/694)