### PR TITLE
Allow exported no-op'd dev settings module in release builds

### DIFF
--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -43,7 +43,8 @@
 #define RCT_DEV 1
 #else
 // Dev Mode is now enabled or disabled at runtime via the -[RCTDevSettings isDevModeEnabled] property
-#define RCT_DEV 1
+// For now, disable debugging in release builds to avoid a bug where we can Redbox in module init
+#define RCT_DEV 0 // TODO(macOS ISS#2323203)
 #endif
 #endif
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

This disables debug tools in release builds like redboxing.

## Test Plan

This was already tested in Polyester and Devmain earlier. No more redboxing shows up in builds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/698)