### PR TITLE
Remove unnecessary comment

### DIFF
--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -482,7 +482,7 @@ RCT_EXPORT_METHOD(addMenuItem:(NSString *)title)
 
 @implementation RCTDevSettings
 
-RCT_EXPORT_MODULE()	// TODO(macOS ISS#2323203)
+RCT_EXPORT_MODULE()
 
 - (instancetype)initWithDataSource:(id<RCTDevSettingsDataSource>)dataSource
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

This exists upstream so we don't need an explicit comment. We only didn't realize it was gone because of a bad merge from facebook's upstream into our fork.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/699)