### PR TITLE
PR CI should run on all stable branches

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -7,7 +7,7 @@ pr:
   branches:
     include:
       - master
-      - 0.59-stable
+      - '*-stable'
   paths:
     exclude:
       - '*.md'

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -10,7 +10,7 @@ pr:
   branches:
     include:
       - master
-      - 0.59-stable
+      - '*-stable'
   paths:
     exclude:
       - '*.md'

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -10,7 +10,7 @@ pr:
   branches:
     include:
       - master
-      - '*-stable'
+      - 0.59-stable
   paths:
     exclude:
       - '*.md'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Currently the CI loop isn't running on submissions to the 0.63-stable branch.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/717)