### PR TITLE
Fix missing props on secure text inputs

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
@@ -67,10 +67,20 @@
     } else {
       _backedTextInputView = [[RCTUITextField alloc] initWithFrame:self.bounds];
     }
+    _backedTextInputView.accessibilityElement = previousTextField.accessibilityElement;
+    _backedTextInputView.accessibilityHelp = previousTextField.accessibilityHelp;
+    _backedTextInputView.accessibilityIdentifier = previousTextField.accessibilityIdentifier;
+    _backedTextInputView.accessibilityLabel = previousTextField.accessibilityLabel;
+    _backedTextInputView.accessibilityRole = previousTextField.accessibilityRole;
+    _backedTextInputView.caretHidden = previousTextField.caretHidden;
+    _backedTextInputView.contextMenuHidden = previousTextField.contextMenuHidden;
+    _backedTextInputView.defaultTextAttributes = previousTextField.defaultTextAttributes;
+    _backedTextInputView.editable = previousTextField.editable;
     _backedTextInputView.placeholder = previousTextField.placeholder;
     _backedTextInputView.placeholderColor = previousTextField.placeholderColor;
     _backedTextInputView.selectionColor = previousTextField.selectionColor;
     _backedTextInputView.textAlignment = previousTextField.textAlignment;
+    _backedTextInputView.textContainerInset = previousTextField.textContainerInset;
     _backedTextInputView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _backedTextInputView.textInputDelegate = self;
     _backedTextInputView.text = previousTextField.text;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Some props don't always get transferred to the text field instance when the `secureTextEntry` prop is set because of the indeterminate order they get set on the original backing text field. We'll want to find a smarter solution to this, but for now this fixes the rest of the known missing properties.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fix missing props on secure text inputs

## Test Plan

Confirmed this fixes some of the issues we're seeing with properties not getting set when `secureTextEntry={true}`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/719)