### PR TITLE
Change key identifier from "Esc" -> "Escape"

### DIFF
--- a/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
+++ b/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
@@ -54,7 +54,7 @@ class KeyEventExample extends React.Component<{}, State> {
             <View
               acceptsKeyboardFocus={true}
               enableFocusRing={true}
-              validKeysDown={['g', 'Esc', 'Enter', 'ArrowLeft']}
+              validKeysDown={['g', 'Escape', 'Enter', 'ArrowLeft']}
               onKeyDown={this.onKeyDownEvent}
               validKeysUp={['c', 'd']}
               onKeyUp={this.onKeyUpEvent}>

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1716,7 +1716,7 @@ NSString* const downArrowPressKey = @"ArrowDown";
   BOOL downArrowValidityCheck = [validKeys containsObject:downArrowPressKey] && downArrowPressed;
 
   if (escapeKeyValidityCheck) {
-    keyToReturn = @"Esc";
+    keyToReturn = @"Escape";
   } else if (enterKeyValidityCheck) {
     keyToReturn = @"Enter";
   } else if (leftArrowValidityCheck) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This aligns the name to be same as in [react-native-windows](https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp#L282) and the [standard](https://www.w3.org/TR/uievents-key/#keys-ui).

## Changelog

[macOS] [Fixed] - Change key identifier from "Esc" -> "Escape"

## Test Plan

Confirmed correct key identifier is logged in the Key Event example in RNTester.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/720)