### PR TITLE
Add explicit Tab support to keyboarding

### DIFF
--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -519,8 +519,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: 73d932a0c658588ceefa9a8227222a9e9afc283c
-  FBReactNativeSpec: d4c4c4e5ab07546e6245b0ca5430644856f56499
+  FBLazyVector: 33306016e21286a3ebf05b2e74758ecb51b487cb
+  FBReactNativeSpec: eba7c1b592e557c3d328af72fcd04fa5ad9dc732
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -533,32 +533,32 @@ SPEC CHECKSUMS:
   libevent: ee9265726a1fc599dea382964fa304378affaa5f
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 3400b78db3aa2f6dcdb04abbe094f0ec4feeb1bc
-  RCTTypeSafety: 3de241f8dc3247c384ed4463b631da939d553bfc
-  React: 504e788a167f1196d17c7ddc54168134f84f8e19
-  React-ART: 19d8a78315d0a8fe0147f72bf6f57ba87a08f5ca
-  React-callinvoker: 6699f2921ea89e57c1f5f652caf3602ef624186a
-  React-Core: a7aa15ffbad7d0ed845842d8922c5f4ae5470520
-  React-CoreModules: 1f350a5765cc20ca807a55e95bbf3f33607f4489
-  React-cxxreact: 474a67d035e3bbb343e12295b6f2eaea829bd195
-  React-jsi: bf1509bbf3c998c05bbe7d95c4f1855fea14bfb2
-  React-jsiexecutor: 79b1432e6b2d2e2426b0ac07d9642ff4bcb2dec1
-  React-jsinspector: ce997e3ce1393b6646b1a28f9607f5d1a7acefb1
-  React-RCTActionSheet: 3cacb41522a762b27c3eb9c44041f06f891180c8
-  React-RCTAnimation: c07ef929e68d7e9a3a36193d8c4377fae5cdb00c
-  React-RCTBlob: faa0bc4269e05d588c4d7d1b24ea666e1393c07f
-  React-RCTImage: e423bdec50aa5daab55a439ebc4639ef93ed41c1
-  React-RCTLinking: a2270c5ae7d67489a1f468aad34c9104f5904a77
-  React-RCTNetwork: f6fc3d80a280615d6707db531e38b4aee798d483
-  React-RCTPushNotification: 6ccd1004097236d487fe8d7325b35cdb3d2040ba
-  React-RCTSettings: 578a25ab83540ff0431837cffe38a1f0a49d555b
-  React-RCTTest: 4299b21226c7f0b46e50ea4a761cd6633e881913
-  React-RCTText: c732000ad9f9eaec6245f1421aecd10d61141a59
-  React-RCTVibration: 40d4d2e45acc8a7bce1df7ebb2cb0a91b0b97be7
+  RCTRequired: c1be2a438c43a3bbaae1c648944e74f09bf7b6df
+  RCTTypeSafety: 8a51d44eafbc4d6b845f4bf158973cb15017af4a
+  React: cd84a8114f257b60d426051214bb220e01f31853
+  React-ART: dc713fc5e6fc9d91111ac8dcc36f423edaf726db
+  React-callinvoker: 22c4350c8d512f0c4d28c652de164d261790eee3
+  React-Core: 301a9137b800e78e100804b201a2751eba784396
+  React-CoreModules: 1f63ebf5afc57f1182c29d071f1d0b36729d3c1e
+  React-cxxreact: 4d4c317d32055a60063d6788962df6d8e5e959a9
+  React-jsi: 5130ca982064487449da1e916815a2ab17c8b5f0
+  React-jsiexecutor: fbc8b1046ca4a8a9b5fc1e92e506a96e22600f5f
+  React-jsinspector: dbed1bb565004515d7470a54673da99cd36d6ac8
+  React-RCTActionSheet: 8d7d186c02a07c96ff8b4193c39c829003d5e401
+  React-RCTAnimation: 769775382fcb0fd801bc0e8c4ba69b112b605e97
+  React-RCTBlob: c0e2dba349e77aa3ccbc99b1c61f0f8ba53b6add
+  React-RCTImage: d1424690347182fd14183d471fb756542b9645b8
+  React-RCTLinking: f8d483d3e8e4bcc2749e67d5f68b8006dfe5eb3d
+  React-RCTNetwork: 7d4f1caaae3b87a9c3e924eeea4805a3bcaf9144
+  React-RCTPushNotification: 03dc947964f5c2a3c53389e7c386b5b8bcef2b17
+  React-RCTSettings: 6be17236bffccbcfa3a57dd961b7682998a92a11
+  React-RCTTest: 0de4043839e8b9782e9ca4c3ecaf7c6dace48027
+  React-RCTText: efcbbf74281e0c42f0c7737c8cc0f148b3cf8983
+  React-RCTVibration: 45f0a1b6780752f516bf81717cfdf901896e93a7
   React-TurboModuleCxx-RNW: 4da8eb44b10ab3c5bbab9fcb0a8ae415c20ea3c9
-  React-TurboModuleCxx-WinRTPort: 8085df08462066713df530f99d6bb326abc3b258
-  ReactCommon: 979769614a09644c29676105c273e66d44b8bb5d
-  Yoga: 9073a9d5c5542940ab2333dedc568f989447084f
+  React-TurboModuleCxx-WinRTPort: 723f549e1b886bae14bf16b6ef8420aef0d3f190
+  ReactCommon: 24aa1f1de935591060e0730148c0d85da7567214
+  Yoga: e009ba9e81fe6c0b4067e62295faa522982b3860
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 18ca7d3b0e7db79041574a8bb6200b9e1c2d5359

--- a/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
+++ b/RNTester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
@@ -54,7 +54,7 @@ class KeyEventExample extends React.Component<{}, State> {
             <View
               acceptsKeyboardFocus={true}
               enableFocusRing={true}
-              validKeysDown={['g', 'Escape', 'Enter', 'ArrowLeft']}
+              validKeysDown={['g', 'Tab', 'Esc', 'Enter', 'ArrowLeft']}
               onKeyDown={this.onKeyDownEvent}
               validKeysUp={['c', 'd']}
               onKeyUp={this.onKeyUpEvent}>

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1717,6 +1717,7 @@ NSString* const downArrowPressKey = @"ArrowDown";
 
   // Allow the flexibility of defining special keys in multiple ways
   BOOL enterKeyValidityCheck = [key isEqualToString:@"\r"] && ([validKeys containsObject:@"Enter"] || [validKeys containsObject:@"\r"]);
+  BOOL tabKeyValidityCheck = tabKeyPressed && ([validKeys containsObject:@"Tab"]); // tab has to be checked via a key code so we can't just use the key itself here
   BOOL escapeKeyValidityCheck = escapeKeyPressed && ([validKeys containsObject:@"Esc"] || [validKeys containsObject:@"Escape"]); // escape has to be checked via a key code so we can't just use the key itself here
   BOOL leftArrowValidityCheck = [validKeys containsObject:leftArrowPressKey] && leftArrowPressed;
   BOOL rightArrowValidityCheck = [validKeys containsObject:rightArrowPressKey] && rightArrowPressed;

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1621,6 +1621,7 @@ NSString* const downArrowPressKey = @"ArrowDown";
   BOOL rightArrowKey = NO;
   BOOL upArrowKey = NO;
   BOOL downArrowKey = NO;
+  BOOL tabKeyPressed = NO;
   BOOL escapeKeyPressed = NO;
   NSString *key = event.charactersIgnoringModifiers;
   unichar const code = [key characterAtIndex:0];
@@ -1636,9 +1637,16 @@ NSString* const downArrowPressKey = @"ArrowDown";
     downArrowKey = YES;
   }
   
-  // detect Escape key presses via the key code
-  if (event.keyCode == 53) {
-    escapeKeyPressed = YES;
+  // detect special key presses via the key code
+  switch (event.keyCode) {
+    case 48: // Tab
+      tabKeyPressed = YES;
+      break;
+    case 53: // Escape
+      escapeKeyPressed = YES;
+      break;
+    default:
+      break;
   }
 
   // detect modifier flags
@@ -1663,7 +1671,7 @@ NSString* const downArrowPressKey = @"ArrowDown";
   RCTViewKeyboardEvent *keyboardEvent = nil;
   // only post events for keys we care about
   if (downPress) {
-    NSString *keyToReturn = [self keyIsValid:key left:leftArrowKey right:rightArrowKey up:upArrowKey down:downArrowKey escapeKey:escapeKeyPressed validKeys:[self validKeysDown]];
+    NSString *keyToReturn = [self keyIsValid:key left:leftArrowKey right:rightArrowKey up:upArrowKey down:downArrowKey tabKey:tabKeyPressed escapeKey:escapeKeyPressed validKeys:[self validKeysDown]];
     if (keyToReturn != nil) {
       keyboardEvent = [RCTViewKeyboardEvent keyDownEventWithReactTag:self.reactTag
                                                          capsLockKey:capsLockKey
@@ -1681,7 +1689,7 @@ NSString* const downArrowPressKey = @"ArrowDown";
                                                                  key:keyToReturn];
     }
   } else {
-    NSString *keyToReturn = [self keyIsValid:key left:leftArrowKey right:rightArrowKey up:upArrowKey down:downArrowKey escapeKey:escapeKeyPressed validKeys:[self validKeysUp]];
+    NSString *keyToReturn = [self keyIsValid:key left:leftArrowKey right:rightArrowKey up:upArrowKey down:downArrowKey tabKey:tabKeyPressed escapeKey:escapeKeyPressed validKeys:[self validKeysUp]];
     if (keyToReturn != nil) {
       keyboardEvent = [RCTViewKeyboardEvent keyUpEventWithReactTag:self.reactTag
                                                        capsLockKey:capsLockKey
@@ -1704,7 +1712,7 @@ NSString* const downArrowPressKey = @"ArrowDown";
 
 // check if the user typed key matches a key we need to send an event for
 // translate key codes over to JS compatible keys
-- (NSString*)keyIsValid:(NSString*)key left:(BOOL)leftArrowPressed right:(BOOL)rightArrowPressed up:(BOOL)upArrowPressed down:(BOOL)downArrowPressed escapeKey:(BOOL)escapeKeyPressed validKeys:(NSArray<NSString*>*)validKeys {
+- (NSString*)keyIsValid:(NSString*)key left:(BOOL)leftArrowPressed right:(BOOL)rightArrowPressed up:(BOOL)upArrowPressed down:(BOOL)downArrowPressed tabKey:(BOOL)tabKeyPressed escapeKey:(BOOL)escapeKeyPressed validKeys:(NSArray<NSString*>*)validKeys {
   NSString *keyToReturn = key;
 
   // Allow the flexibility of defining special keys in multiple ways
@@ -1715,7 +1723,9 @@ NSString* const downArrowPressKey = @"ArrowDown";
   BOOL upArrowValidityCheck = [validKeys containsObject:upArrowPressKey] && upArrowPressed;
   BOOL downArrowValidityCheck = [validKeys containsObject:downArrowPressKey] && downArrowPressed;
 
-  if (escapeKeyValidityCheck) {
+if (tabKeyValidityCheck) {
+    keyToReturn = @"Tab";
+  } else if (escapeKeyValidityCheck) {
     keyToReturn = @"Escape";
   } else if (enterKeyValidityCheck) {
     keyToReturn = @"Enter";


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Tab is an interesting character to receive a keyboard event for. Tab alone provides an OS event of character @"	" (the width of a tab). However, when paired with the shift modifier key, the Tab event character becomes an empty string modified by the shift bar.

This is likely due to the multiple purposes of the tab key given that tab is used by the OS to traverse between many accessible views.

The easiest fix here is to slot the Tab key along with Escape as a special character that we need to explicitly check the key code for. This also aligns with the [W3 standard](https://www.w3.org/TR/uievents-key/#keys-ui) section 3.3 Whitespace.

After this gets into master I'll make PR's checking it into the 0.62-stable and 0.63-stable branches.

## Changelog

[macOS] [Bug] - Tab keyboard support

## Test Plan

Added tab to the keyboard events test app. Both tab and shift tab can now propagate to our JS when listening for tab events.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/723)