### PR TITLE
Fix Deadlock in RCTi18nUtil (iOS)

### DIFF
--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -22,7 +22,6 @@
 /**
  * Should be used very early during app start up
  * Before the bridge is initialized
- * @return whether the app allows RTL layout, default is true
  */
 @property(atomic, readwrite, setter=allowRTL:) bool isRTLAllowed;
 

--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -18,7 +18,7 @@
 + (instancetype)sharedInstance;
 
 - (BOOL)isRTL;
-
+// [ TODO(macOS#4904077)
 /**
  * Should be used very early during app start up
  * Before the bridge is initialized
@@ -32,7 +32,6 @@
 @property(atomic, setter=forceRTL:) BOOL isRTLForced;
 
 @property(atomic, setter=swapLeftAndRightInRTL:) BOOL doLeftAndRightSwapInRTL;
-
-
+// ]TODO(macOS#4904077)
 
 @end

--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -23,15 +23,15 @@
  * Should be used very early during app start up
  * Before the bridge is initialized
  */
-@property(atomic, readwrite, setter=allowRTL:) bool isRTLAllowed;
+@property(atomic, setter=allowRTL:) BOOL isRTLAllowed;
 
 /**
  * Could be used to test RTL layout with English
  * Used for development and testing purpose
  */
-@property(atomic, readwrite, setter=forceRTL:) bool isRTLForced;
+@property(atomic, setter=forceRTL:) BOOL isRTLForced;
 
-@property(atomic, readwrite, setter=swapLeftAndRightInRTL:) bool doLeftAndRightSwapInRTL;
+@property(atomic, setter=swapLeftAndRightInRTL:) BOOL doLeftAndRightSwapInRTL;
 
 
 

--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -18,11 +18,22 @@
 + (instancetype)sharedInstance;
 
 - (BOOL)isRTL;
-- (BOOL)isRTLAllowed;
-- (void)allowRTL:(BOOL)value;
-- (BOOL)isRTLForced;
-- (void)forceRTL:(BOOL)value;
-- (BOOL)doLeftAndRightSwapInRTL;
-- (void)swapLeftAndRightInRTL:(BOOL)value;
+
+/**
+ * Should be used very early during app start up
+ * Before the bridge is initialized
+ * @return whether the app allows RTL layout, default is true
+ */
+@property(atomic, readwrite, setter=allowRTL:) bool isRTLAllowed;
+
+/**
+ * Could be used to test RTL layout with English
+ * Used for development and testing purpose
+ */
+@property(atomic, readwrite, setter=forceRTL:) bool isRTLForced;
+
+@property(atomic, readwrite, setter=swapLeftAndRightInRTL:) bool doLeftAndRightSwapInRTL;
+
+
 
 @end

--- a/React/Modules/RCTI18nUtil.m
+++ b/React/Modules/RCTI18nUtil.m
@@ -18,6 +18,7 @@
   dispatch_once(&onceToken, ^{
     sharedInstance = [self new];
     [sharedInstance swapLeftAndRightInRTL:true];
+    [sharedIntance allowRTL:true];
   });
 
   return sharedInstance;

--- a/React/Modules/RCTI18nUtil.m
+++ b/React/Modules/RCTI18nUtil.m
@@ -18,7 +18,7 @@
   dispatch_once(&onceToken, ^{
     sharedInstance = [self new];
     [sharedInstance swapLeftAndRightInRTL:true];
-    [sharedIntance allowRTL:true];
+    [sharedInstance allowRTL:true];
   });
 
   return sharedInstance;

--- a/React/Modules/RCTI18nUtil.m
+++ b/React/Modules/RCTI18nUtil.m
@@ -15,7 +15,7 @@
 {
   static RCTI18nUtil *sharedInstance;
   static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{git s
+  dispatch_once(&onceToken, ^{
     sharedInstance = [self new];
     [sharedInstance swapLeftAndRightInRTL:true];
   });

--- a/React/Modules/RCTI18nUtil.m
+++ b/React/Modules/RCTI18nUtil.m
@@ -15,7 +15,7 @@
 {
   static RCTI18nUtil *sharedInstance;
   static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  dispatch_once(&onceToken, ^{git s
     sharedInstance = [self new];
     [sharedInstance swapLeftAndRightInRTL:true];
   });
@@ -38,53 +38,6 @@
     return YES;
   }
   return NO;
-}
-
-/**
- * Should be used very early during app start up
- * Before the bridge is initialized
- * @return whether the app allows RTL layout, default is true
- */
-- (BOOL)isRTLAllowed
-{
-  NSNumber *value = [[NSUserDefaults standardUserDefaults] objectForKey:@"RCTI18nUtil_allowRTL"];
-  if (value == nil) {
-    return YES;
-  }
-  return [value boolValue];
-}
-
-- (void)allowRTL:(BOOL)rtlStatus
-{
-  [[NSUserDefaults standardUserDefaults] setBool:rtlStatus forKey:@"RCTI18nUtil_allowRTL"];
-  [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-/**
- * Could be used to test RTL layout with English
- * Used for development and testing purpose
- */
-- (BOOL)isRTLForced
-{
-  BOOL rtlStatus = [[NSUserDefaults standardUserDefaults] boolForKey:@"RCTI18nUtil_forceRTL"];
-  return rtlStatus;
-}
-
-- (void)forceRTL:(BOOL)rtlStatus
-{
-  [[NSUserDefaults standardUserDefaults] setBool:rtlStatus forKey:@"RCTI18nUtil_forceRTL"];
-  [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (BOOL)doLeftAndRightSwapInRTL
-{
-  return [[NSUserDefaults standardUserDefaults] boolForKey:@"RCTI18nUtil_makeRTLFlipLeftAndRightStyles"];
-}
-
-- (void)swapLeftAndRightInRTL:(BOOL)value
-{
-  [[NSUserDefaults standardUserDefaults] setBool:value forKey:@"RCTI18nUtil_makeRTLFlipLeftAndRightStyles"];
-  [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 // Check if the current device language is RTL

--- a/React/Modules/RCTI18nUtil.m
+++ b/React/Modules/RCTI18nUtil.m
@@ -18,7 +18,7 @@
   dispatch_once(&onceToken, ^{
     sharedInstance = [self new];
     [sharedInstance swapLeftAndRightInRTL:true];
-    [sharedInstance allowRTL:true];
+    [sharedInstance allowRTL:true]; // TODO(macOS#4904077)
   });
 
   return sharedInstance;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

Note: upstream PR to facebook repo is [here](https://github.com/facebook/react-native/pull/31032)

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Internally in Microsoft code, we ran into a deadlock where the main queue and the UIManager queue were both trying to access `[RCTI18nUtil sharedInstance]`, and were blocked on each other. This is similar to an earlier issue with RCTScreenScale decsribed [here](https://github.com/facebook/react-native/issues/18096).

To summarize:
1- RCTShadowView (on the UIManager queue) and RCTView (on the main queue) both try to access `[RCTI18nUtil sharedInstance]`
2- The UIManager thread gets there first, and lazily initializes the sharedInstance. Meanwhile, the main thread is waiting on a lock possessed by the UIManager thread
3- As part of the initialization, we set an NSUserDefault, which seems to require the (blocked) main thread.
4- Deadlock.

For whatever reason, this only happens on debug. I did not figure out why, but I do know based on [this comment](https://github.com/facebook/react-native/issues/18096#issuecomment-368718081), that the UIManagerQueue should never block the main queue. 

The fix is to not use NSUserDefaults, and simpy use atomic properties instead. We get the thread safety for free, and it also simplifies the code somewhat without changing the public API. The downside is values aren't persisted anymore, but I do not think that was necessary / intended.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix deadlock on RCTi18nUtil

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Ran the RTLExample in RNTester, and ensured switching to RTL still worked, and that setting forceRTL would still work after reloading the bundle.

https://user-images.githubusercontent.com/6722175/108775429-aefdae80-7526-11eb-9a89-3114f7ddc2af.mov



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/733)