### PR TITLE
Fix ability to call focus()/blur() on any view

### DIFF
--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -124,6 +124,24 @@ RCT_EXPORT_MODULE()
   ];
 }
 
+#if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+RCT_EXPORT_METHOD(focus : (nonnull NSNumber *)viewTag)
+{
+  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+    RCTUIView *view = viewRegistry[viewTag];
+    [view reactFocus];
+  }];
+}
+
+RCT_EXPORT_METHOD(blur : (nonnull NSNumber *)viewTag)
+{
+  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+    RCTUIView *view = viewRegistry[viewTag];
+    [view reactBlur];
+  }];
+}
+#endif // ]TODO(macOS ISS#2323203)
+
 #pragma mark - View properties
 
 #if TARGET_OS_TV


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes a regression from when we upgraded to 0.63 where we could no longer call `focus()` or `blur()` on any `View` (including `Text`). This regression was due to a change that dispatches these as commands (to be compatible with Fabric) instead of directly using `UIManager` to change focus. Only the `TextInput` supported these commands.

## Changelog

[macOS] [Fixed] - Fix ability to call focus()/blur() on any view

## Test Plan

Confirmed calling `focus()` and `blur()` on `View` and `Text` components now work again.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/738)