### PR TITLE
Add high contrast API to AccessibilityInfo

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
@@ -53,6 +53,13 @@ const AccessibilityInfo = {
   },
 
   /**
+   * macOS only
+   */
+  isHighContrastEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  /**
    * iOS only
    */
   isInvertColorsEnabled: function(): Promise<boolean> {

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -86,6 +86,13 @@ const AccessibilityInfo = {
   },
 
   /**
+   * macOS only
+   */
+  isHighContrastEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  /**
    * Query whether inverted colors are currently enabled.
    *
    * Returns a promise which resolves to a boolean.

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
@@ -18,6 +18,7 @@ const RCTDeviceEventEmitter = require('../../EventEmitter/RCTDeviceEventEmitter'
 import NativeAccessibilityManager from './NativeAccessibilityManager';
 
 const CHANGE_EVENT_NAME = {
+  highContrastChanged: 'highContrastChanged',
   invertColorsChanged: 'invertColorsChanged',
   reduceMotionChanged: 'reduceMotionChanged',
   reduceTransparencyChanged: 'reduceTransparencyChanged',
@@ -26,6 +27,7 @@ const CHANGE_EVENT_NAME = {
 
 type ChangeEventName = $Keys<{
   change: string,
+  highContrastChanged: string,
   invertColorsChanged: string,
   reduceMotionChanged: string,
   reduceTransparencyChanged: string,
@@ -56,6 +58,22 @@ const AccessibilityInfo = {
    */
   isGrayscaleEnabled: function(): Promise<boolean> {
     return Promise.resolve(false);
+  },
+
+  /**
+   * Query whether high contrast is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when invert color is enabled and `false` otherwise.
+   */
+  isHighContrastEnabled: function(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (NativeAccessibilityManager) {
+        NativeAccessibilityManager.getCurrentHighContrastState(resolve, reject);
+      } else {
+        reject(reject);
+      }
+    });
   },
 
   /**

--- a/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
+++ b/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
@@ -22,6 +22,12 @@ export interface Spec extends TurboModule {
     onSuccess: (isGrayscaleEnabled: boolean) => void,
     onError: (error: Object) => void,
   ) => void;
+  // [TODO(macOS ISS#2323203)
+  +getCurrentHighContrastState: (
+    onSuccess: (isHighContrastEnabled: boolean) => void,
+    onError: (error: Object) => void,
+  ) => void;
+  // ]TODO(macOS ISS#2323203)
   +getCurrentInvertColorsState: (
     onSuccess: (isInvertColorsEnabled: boolean) => void,
     onError: (error: Object) => void,

--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -740,6 +740,16 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
 
   componentDidMount() {
     AccessibilityInfo.addEventListener(
+      'highContrastChanged',
+      this._handleHighContrastToggled,
+    );
+    AccessibilityInfo.isHighContrastEnabled().done(isEnabled => {
+      this.setState({
+        highContrastEnabled: isEnabled,
+      });
+    });
+
+    AccessibilityInfo.addEventListener(
       'invertColorsChanged',
       this._handleInvertColorsToggled,
     );
@@ -772,6 +782,10 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
 
   componentWillUnmount() {
     AccessibilityInfo.removeEventListener(
+      'highContrastChanged',
+      this._handleHighContrastToggled,
+    );
+    AccessibilityInfo.removeEventListener(
       'invertColorsChanged',
       this._handleInvertColorsToggled,
     );
@@ -784,6 +798,12 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
       this._handleReduceTransparencyToggled,
     );
   }
+
+  _handleHighContrastToggled = isEnabled => {
+    this.setState({
+      highContrastEnabled: isEnabled,
+    });
+  };
 
   _handleInvertColorsToggled = isEnabled => {
     this.setState({
@@ -806,6 +826,12 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
   render() {
     return (
       <View>
+        <View>
+          <Text>
+            High contrast is{' '}
+            {this.state.highContrastEnabled ? 'enabled' : 'disabled'}.
+          </Text>
+        </View>
         <View>
           <Text>
             Invert colors is{' '}

--- a/React/CoreModules/RCTAccessibilityManager.h
+++ b/React/CoreModules/RCTAccessibilityManager.h
@@ -21,6 +21,7 @@ extern NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification; /
 
 @property (nonatomic, assign) BOOL isBoldTextEnabled;
 @property (nonatomic, assign) BOOL isGrayscaleEnabled;
+@property (nonatomic, assign) BOOL isHighContrastEnabled; // TODO(macOS ISS#2323203)
 @property (nonatomic, assign) BOOL isInvertColorsEnabled;
 @property (nonatomic, assign) BOOL isReduceMotionEnabled;
 @property (nonatomic, assign) BOOL isReduceTransparencyEnabled;

--- a/React/CoreModules/RCTAccessibilityManager.h
+++ b/React/CoreModules/RCTAccessibilityManager.h
@@ -21,7 +21,7 @@ extern NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification; /
 
 @property (nonatomic, assign) BOOL isBoldTextEnabled;
 @property (nonatomic, assign) BOOL isGrayscaleEnabled;
-@property (nonatomic, assign) BOOL isHighContrastEnabled; // TODO(macOS ISS#2323203)
+@property (nonatomic, assign) BOOL isHighContrastEnabled; // TODO(macOS ISS#2323203) - maps to shouldIncreaseContrast on macOS
 @property (nonatomic, assign) BOOL isInvertColorsEnabled;
 @property (nonatomic, assign) BOOL isReduceMotionEnabled;
 @property (nonatomic, assign) BOOL isReduceTransparencyEnabled;

--- a/React/Modules/MacOS/RCTAccessibilityManager.m
+++ b/React/Modules/MacOS/RCTAccessibilityManager.m
@@ -23,12 +23,12 @@ RCT_EXPORT_MODULE()
 
 static void *AccessibilityVoiceOverChangeContext = &AccessibilityVoiceOverChangeContext;
 
-+ (BOOL)requiresMainQueueSetup 
++ (BOOL)requiresMainQueueSetup
 {
   return NO;
 }
 
-- (instancetype)init 
+- (instancetype)init
 {
   if (self = [super init]) {
     [[NSWorkspace sharedWorkspace] addObserver:self
@@ -39,11 +39,11 @@ static void *AccessibilityVoiceOverChangeContext = &AccessibilityVoiceOverChange
                                              selector:@selector(accessibilityDisplayOptionsChange:)
                                                  name:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification
                                                object:nil];
+    _isHighContrastEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
     _isInvertColorsEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldInvertColors];
     _isReduceMotionEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion];
     _isReduceTransparencyEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceTransparency];
     _isVoiceOverEnabled = [[NSWorkspace sharedWorkspace] isVoiceOverEnabled];
-    
   }
   return self;
 }
@@ -53,7 +53,7 @@ static void *AccessibilityVoiceOverChangeContext = &AccessibilityVoiceOverChange
   [[NSWorkspace sharedWorkspace] removeObserver:self
                                      forKeyPath:@"voiceOverEnabled"
                                         context:AccessibilityVoiceOverChangeContext];
-  [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self]; 
+  [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
 }
 
 RCT_EXPORT_METHOD(announceForAccessibility:(NSString *)announcement)
@@ -65,6 +65,12 @@ RCT_EXPORT_METHOD(announceForAccessibility:(NSString *)announcement)
                                                       NSAccessibilityPriorityKey : @(NSAccessibilityPriorityHigh)
                                                     }
                                                 );
+}
+
+RCT_EXPORT_METHOD(getCurrentHighContrastState:(RCTResponseSenderBlock)callback
+                  error:(__unused RCTResponseSenderBlock)error)
+{
+  callback(@[@(_isHighContrastEnabled)]);
 }
 
 RCT_EXPORT_METHOD(getCurrentInvertColorsState:(RCTResponseSenderBlock)callback
@@ -124,9 +130,16 @@ RCT_EXPORT_METHOD(setAccessibilityFocus:(nonnull NSNumber *)reactTag)
 
 - (void)accessibilityDisplayOptionsChange:(NSNotification *)notification
 {
+  BOOL newHighContrastEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
   BOOL newInvertColorsEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldInvertColors];
   BOOL newReduceMotionEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion];
   BOOL newReduceTransparencyEnabled = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceTransparency];
+
+  if (_isHighContrastEnabled != newHighContrastEnabled) {
+    _isHighContrastEnabled = newHighContrastEnabled;
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"highContrastChanged"
+                                                body:@(_isHighContrastEnabled)];
+  }
   if (_isInvertColorsEnabled != newInvertColorsEnabled) {
     _isInvertColorsEnabled = newInvertColorsEnabled;
     [_bridge.eventDispatcher sendDeviceEventWithName:@"invertColorsChanged"

--- a/React/Modules/MacOS/RCTAccessibilityManager.m
+++ b/React/Modules/MacOS/RCTAccessibilityManager.m
@@ -25,7 +25,7 @@ static void *AccessibilityVoiceOverChangeContext = &AccessibilityVoiceOverChange
 
 + (BOOL)requiresMainQueueSetup
 {
-  return NO;
+  return YES;
 }
 
 - (instancetype)init

--- a/React/Modules/MacOS/RCTAccessibilityManager.m
+++ b/React/Modules/MacOS/RCTAccessibilityManager.m
@@ -53,7 +53,6 @@ static void *AccessibilityVoiceOverChangeContext = &AccessibilityVoiceOverChange
   [[NSWorkspace sharedWorkspace] removeObserver:self
                                      forKeyPath:@"voiceOverEnabled"
                                         context:AccessibilityVoiceOverChangeContext];
-  [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
 }
 
 RCT_EXPORT_METHOD(announceForAccessibility:(NSString *)announcement)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This adds the `isHighContrastEnabled()` method and `highContrastChanged` event to the `AccessibilityInfo` module. This matches the existing API conventions we have in React Native macOS for other accessibility features. React Native Windows has a [similar API](https://github.com/microsoft/react-native-windows/blob/master/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx#L45-L59) with its `AppTheme` module, but that module doesn't exist for other React Native platforms and this is more appropriate in `AccessibilityInfo`.

## Changelog

[macOS] [Added] - Add high contrast API to AccessibilityInfo

## Test Plan

Tested in RNTester. Observed live updates when changing the **Increase contrast** setting under System Preferences.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/742)