### PR TITLE
Fixing bug in Commenting icon disappering on removing tintColor property

### DIFF
--- a/.ado/templates/apple-droid-node-patching.yml
+++ b/.ado/templates/apple-droid-node-patching.yml
@@ -5,4 +5,4 @@ steps:
   - task: CmdLine@2
     displayName: Apply Android specific patches for Office consumption
     inputs:
-      script: node $(System.DefaultWorkingDirectory)/android-patches/bundle/bundle.js patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}
+      script: node $(System.DefaultWorkingDirectory)/android-patches/bundle/bundle.js patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus ImageColor --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}

--- a/android-patches/patches/ImageColor/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/android-patches/patches/ImageColor/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -1,0 +1,52 @@
+--- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\uimanager\\ViewManagersPropertyCache.java"	2020-10-27 20:26:16.901168200 -0700
++++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\uimanager\\ViewManagersPropertyCache.java"	2021-03-09 18:12:54.215475900 -0800
+@@ -214,6 +214,29 @@
+     }
+   }
+ 
++  private static class NullableColorPropSetter extends PropSetter {
++
++    private final int mDefaultValue;
++
++    public NullableColorPropSetter(ReactProp prop, Method setter) {
++      this(prop, setter, 0);
++    }
++
++    public NullableColorPropSetter(ReactProp prop, Method setter, int defaultValue) {
++      super(prop, "mixed", setter);
++      mDefaultValue = defaultValue;
++    }
++
++    @Override
++    protected Object getValueOrDefault(Object value, Context context) {
++      if (value == null) {
++        return null;
++      }
++
++      return ColorPropConverter.getColor(value, context);
++    }
++  }
++
+   private static class BooleanPropSetter extends PropSetter {
+ 
+     private final boolean mDefaultValue;
+@@ -407,6 +430,9 @@
+       if ("Color".equals(annotation.customType())) {
+         return new ColorPropSetter(annotation, method, annotation.defaultInt());
+       }
++      if ("NullableColor".equals(annotation.customType())) {
++        return new NullableColorPropSetter(annotation, method, annotation.defaultInt());
++      }
+       return new IntPropSetter(annotation, method, annotation.defaultInt());
+     } else if (propTypeClass == float.class) {
+       return new FloatPropSetter(annotation, method, annotation.defaultFloat());
+@@ -420,6 +446,9 @@
+       if ("Color".equals(annotation.customType())) {
+         return new ColorPropSetter(annotation, method);
+       }
++      if ("NullableColor".equals(annotation.customType())) {
++        return new NullableColorPropSetter(annotation, method, annotation.defaultInt());
++      }
+       return new BoxedIntPropSetter(annotation, method);
+     } else if (propTypeClass == ReadableArray.class) {
+       return new ArrayPropSetter(annotation, method);

--- a/android-patches/patches/ImageColor/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/android-patches/patches/ImageColor/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -1,0 +1,29 @@
+--- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\views\\image\\ReactImageManager.java"	2020-10-27 20:26:16.952166400 -0700
++++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\views\\image\\ReactImageManager.java"	2021-03-09 18:13:37.555129800 -0800
+@@ -145,7 +145,7 @@
+     view.setLoadingIndicatorSource(source);
+   }
+ 
+-  @ReactProp(name = "borderColor", customType = "Color")
++  @ReactProp(name = "borderColor", customType = "NullableColor")
+   public void setBorderColor(ReactImageView view, @Nullable Integer borderColor) {
+     if (borderColor == null) {
+       view.setBorderColor(Color.TRANSPARENT);
+@@ -154,7 +154,7 @@
+     }
+   }
+ 
+-  @ReactProp(name = "overlayColor", customType = "Color")
++  @ReactProp(name = "overlayColor", customType = "NullableColor")
+   public void setOverlayColor(ReactImageView view, @Nullable Integer overlayColor) {
+     if (overlayColor == null) {
+       view.setOverlayColor(Color.TRANSPARENT);
+@@ -209,7 +209,7 @@
+     }
+   }
+ 
+-  @ReactProp(name = "tintColor", customType = "Color")
++  @ReactProp(name = "tintColor", customType = "NullableColor")
+   public void setTintColor(ReactImageView view, @Nullable Integer tintColor) {
+     if (tintColor == null) {
+       view.clearColorFilter();


### PR DESCRIPTION
This fix will avoid flattening null to '0' when resetting color properties of Image.

I create this [PR](https://github.com/facebook/react-native/pull/31114/) to upstream this change. But later realized there is another active [PR](https://github.com/facebook/react-native/pull/29830) for this issue with similar fix.

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

This fix will avoid flattening null to '0' when resetting color properties of Image.

## Changelog

This fix will avoid flattening null to '0' when resetting color properties of Image.

[CATEGORY] [TYPE] - Message

## Test Plan

Tested.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-macos/pull/745)