### PR TITLE
Match handleOpenURLNotification event payload with iOS

### DIFF
--- a/Libraries/LinkingIOS/macos/RCTLinkingManager.mm
+++ b/Libraries/LinkingIOS/macos/RCTLinkingManager.mm
@@ -82,7 +82,7 @@ RCT_EXPORT_MODULE()
     NSWindow *lastWindow = [[NSApp windows] lastObject];
     [lastWindow makeKeyAndOrderFront:nil];
 
-    [self sendEventWithName:@"url" body:notification.userInfo[@"url"]];
+    [self sendEventWithName:@"url" body:notification.userInfo];
 }
 
 RCT_EXPORT_METHOD(openURL:(NSURL *)URL


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Payloads when handling Linking url events differ between iOS implementation and macOS causing issues with third party libraries like react-navigation. This updates to match the existing react-native url event payload shape.

## Changelog

[macOS] [Fixed] - Fixed discrepancy between Linking url event payloads between iOS and macOS

## Test Plan

1. Setup url scheme for iOS and macOS apps
2. Add event listener via Linking.addEventListener('url', handler)
3. Launch apps via url
4. The url event payload should be the same
