### PR TITLE
Xcode12.5 support in 0.62-stable

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -796,7 +796,7 @@ struct RCTInstanceCallback : public InstanceCallback {
 #endif
 }
 
-- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules
+- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
                                withDispatchGroup:(dispatch_group_t)dispatchGroup
                                 lazilyDiscovered:(BOOL)lazilyDiscovered
 {

--- a/ReactCommon/fabric/graphics/platform/ios/Color.cpp
+++ b/ReactCommon/fabric/graphics/platform/ios/Color.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Color.h"
+#include <cassert>
 
 namespace facebook {
 namespace react {

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
@@ -304,7 +304,7 @@ static Class getFallbackClassFromName(const char *name)
             @"%@ has no setter or ivar for its bridge, which is not "
              "permitted. You must either @synthesize the bridge property, "
              "or provide your own setter method.",
-            RCTBridgeModuleNameForClass(strongModule));
+            RCTBridgeModuleNameForClass([strongModule class]));
       }
     }
 


### PR DESCRIPTION


#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [X] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Add Xcode 12.5 support for 0.62-stable. It's my understanding that this different than from what's needed for other versions and we can take those fixes in separately.

`git cherry-pick 8721ee0a6b10e5bc8a5a95809aaa7b25dd5a6043`

## Changelog

[Apple] [Bug] - Xcode 12.5 support

## Test Plan

The change was already tested upstream so this is just a cherry-pick.