### PR TITLE
Hyshin/reverting commits

### DIFF
--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - React-RCTVibration (= 0.63.32)
   - React-ART (0.63.32):
     - React-Core/ARTHeaders (= 0.63.32)
-  - React-callinvoker (0.63.32)
+  - ReactCommon/callinvoker (0.63.32)
   - React-Core (0.63.32):
     - glog
     - RCT-Folly (= 2020.01.13.00)
@@ -183,7 +183,7 @@ PODS:
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.32)
+    - ReactCommon/callinvoker (= 0.63.32)
     - React-jsinspector (= 0.63.32)
   - React-jsi (0.63.32):
     - boost-for-react-native (= 1.63.0)
@@ -269,7 +269,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.63.32)
   - React-TurboModuleCxx-RNW (0.63.32):
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.32)
+    - ReactCommon/callinvoker (= 0.63.32)
     - React-TurboModuleCxx-WinRTPort (= 0.63.32)
     - ReactCommon/turbomodule/core (= 0.63.32)
   - React-TurboModuleCxx-WinRTPort (0.63.32):
@@ -277,13 +277,13 @@ PODS:
     - React-TurboModuleCxx-WinRTPort/WinRT (= 0.63.32)
   - React-TurboModuleCxx-WinRTPort/Shared (0.63.32)
   - React-TurboModuleCxx-WinRTPort/WinRT (0.63.32):
-    - React-callinvoker (= 0.63.32)
+    - ReactCommon/callinvoker (= 0.63.32)
     - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.32)
   - ReactCommon/turbomodule/core (0.63.32):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.32)
+    - ReactCommon/callinvoker (= 0.63.32)
     - React-Core (= 0.63.32)
     - React-cxxreact (= 0.63.32)
     - React-jsi (= 0.63.32)
@@ -291,7 +291,7 @@ PODS:
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.32)
+    - ReactCommon/callinvoker (= 0.63.32)
     - React-Core (= 0.63.32)
     - React-cxxreact (= 0.63.32)
     - React-jsi (= 0.63.32)
@@ -309,7 +309,7 @@ DEPENDENCIES:
   - RCTTypeSafety (from `../Libraries/TypeSafety`)
   - React (from `../`)
   - React-ART (from `../Libraries/ART`)
-  - React-callinvoker (from `../ReactCommon/callinvoker`)
+  - ReactCommon/callinvoker (from `../ReactCommon`)
   - React-Core (from `../`)
   - React-Core/DevSupport (from `../`)
   - React-Core/RCTWebSocket (from `../`)
@@ -356,8 +356,8 @@ EXTERNAL SOURCES:
     :path: "../"
   React-ART:
     :path: "../Libraries/ART"
-  React-callinvoker:
-    :path: "../ReactCommon/callinvoker"
+  ReactCommon/callinvoker:
+    :path: "../ReactCommon"
   React-Core:
     :path: "../"
   React-CoreModules:
@@ -412,7 +412,7 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 9b9d0e720c7e0db01c4335c07293b0762db823ad
   React: 51ff14afee47ba093fc9170f763b7e5ee361c4f0
   React-ART: 105074a113c9f5c04fcf27a941951f5fbd902dfc
-  React-callinvoker: 81976a8b4c2f36e2845f918850b8b8b3977067dc
+  ReactCommon/callinvoker: 81976a8b4c2f36e2845f918850b8b8b3977067dc
   React-Core: 229cee3de04ee6f3eb9a2f1c314cafd057c2410e
   React-CoreModules: ddae027941fade9957154006bab7397a0917de1f
   React-cxxreact: fa7d783de6749ac4486dbd52bc275c0b107e3147

--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -22,6 +22,7 @@
 #import <React/RCTDataRequestHandler.h>
 #import <React/RCTFileRequestHandler.h>
 #import <React/RCTRootView.h>
+#import <ReactCommon/BridgeJSCallInvoker.h>
 
 #import <cxxreact/JSExecutor.h>
 
@@ -154,7 +155,7 @@
 {
   _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
                                                              delegate:self
-                                                            jsInvoker:bridge.jsCallInvoker];
+                                                            jsInvoker:std::make_shared<facebook::react::BridgeJSCallInvoker>(bridge.reactInstance)];
   __weak __typeof(self) weakSelf = self;
   return std::make_unique<facebook::react::JSCExecutorFactory>(
     facebook::react::RCTJSIExecutorRuntimeInstaller([weakSelf, bridge](facebook::jsi::Runtime &runtime) {

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -227,6 +227,11 @@ struct RCTInstanceCallback : public InstanceCallback {
 }
 // ]TODO(OSS Candidate ISS#2710739)
 
+- (std::shared_ptr<CallInvoker>)jsCallInvoker
+{
+  return _reactInstance ? _reactInstance->getJSCallInvoker() : nullptr;
+}
+
 - (BOOL)isInspectable
 {
   return _reactInstance ? _reactInstance->isInspectable() : NO;
@@ -1473,18 +1478,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
       jsInvoker->invokeAsync(std::move(retainedFunc));
     }
   }];
-}
-
-#pragma mark - RCTBridge (RCTTurboModule)
-
-- (std::shared_ptr<CallInvoker>)jsCallInvoker
-{
-  return _reactInstance ? _reactInstance->getJSCallInvoker() : nullptr;
-}
-
-- (std::shared_ptr<CallInvoker>)decorateNativeCallInvoker:(std::shared_ptr<CallInvoker>)nativeInvoker
-{
-  return _reactInstance ? _reactInstance->getDecoratedNativeCallInvoker(nativeInvoker) : nullptr;
 }
 
 @end

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -227,11 +227,6 @@ struct RCTInstanceCallback : public InstanceCallback {
 }
 // ]TODO(OSS Candidate ISS#2710739)
 
-- (std::shared_ptr<CallInvoker>)jsCallInvoker
-{
-  return _reactInstance ? _reactInstance->getJSCallInvoker() : nullptr;
-}
-
 - (BOOL)isInspectable
 {
   return _reactInstance ? _reactInstance->isInspectable() : NO;
@@ -1473,10 +1468,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
   __weak __typeof(self) weakSelf = self;
   [self _runAfterLoad:^{
     __strong __typeof(self) strongSelf = weakSelf;
-
-    if (std::shared_ptr<CallInvoker> jsInvoker = strongSelf.jsCallInvoker) {
-      jsInvoker->invokeAsync(std::move(retainedFunc));
+    if (strongSelf->_reactInstance == nullptr) {
+      return;
     }
+    strongSelf->_reactInstance->invokeAsync(std::move(retainedFunc));
   }];
 }
 

--- a/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <ReactCommon/CallInvokerHolder.h>
+#include <ReactCommon/MessageQueueThreadCallInvoker.h>
 #include <cxxreact/CxxNativeModule.h>
 #include <cxxreact/Instance.h>
 #include <cxxreact/JSBigString.h>
@@ -287,8 +288,8 @@ void CatalystInstanceImpl::handleMemoryPressure(int pressureLevel) {
 jni::alias_ref<CallInvokerHolder::javaobject>
 CatalystInstanceImpl::getJSCallInvokerHolder() {
   if (!jsCallInvokerHolder_) {
-    jsCallInvokerHolder_ = jni::make_global(
-        CallInvokerHolder::newObjectCxxArgs(instance_->getJSCallInvoker()));
+    jsCallInvokerHolder_ = jni::make_global(CallInvokerHolder::newObjectCxxArgs(
+        std::make_shared<BridgeJSCallInvoker>(instance_)));
   }
 
   return jsCallInvokerHolder_;
@@ -297,30 +298,10 @@ CatalystInstanceImpl::getJSCallInvokerHolder() {
 jni::alias_ref<CallInvokerHolder::javaobject>
 CatalystInstanceImpl::getNativeCallInvokerHolder() {
   if (!nativeCallInvokerHolder_) {
-    class NativeThreadCallInvoker : public CallInvoker {
-     private:
-      std::shared_ptr<JMessageQueueThread> messageQueueThread_;
-
-     public:
-      NativeThreadCallInvoker(
-          std::shared_ptr<JMessageQueueThread> messageQueueThread)
-          : messageQueueThread_(messageQueueThread) {}
-      void invokeAsync(std::function<void()> &&work) override {
-        messageQueueThread_->runOnQueue(std::move(work));
-      }
-      void invokeSync(std::function<void()> &&work) override {
-        messageQueueThread_->runOnQueueSync(std::move(work));
-      }
-    };
-
-    std::shared_ptr<CallInvoker> nativeInvoker =
-        std::make_shared<NativeThreadCallInvoker>(moduleMessageQueue_);
-
-    std::shared_ptr<CallInvoker> decoratedNativeInvoker =
-        instance_->getDecoratedNativeCallInvoker(nativeInvoker);
-
-    nativeCallInvokerHolder_ = jni::make_global(
-        CallInvokerHolder::newObjectCxxArgs(decoratedNativeInvoker));
+    nativeCallInvokerHolder_ =
+        jni::make_global(CallInvokerHolder::newObjectCxxArgs(
+            std::make_shared<MessageQueueThreadCallInvoker>(
+                moduleMessageQueue_)));
   }
 
   return nativeCallInvokerHolder_;

--- a/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
+++ b/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include <ReactCommon/BridgeJSCallInvoker.h>
 #include <ReactCommon/CallInvokerHolder.h>
 #include <fbjni/fbjni.h>
 

--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -36,8 +36,17 @@ Pod::Spec.new do |s|
                                "USE_HEADERMAP" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" }
 
+  s.subspec "callinvoker" do |ss|
+    ss.source_files = "callinvoker/**/*.{cpp,h}"
+
+    ss.dependency "React-cxxreact", version
+    ss.dependency "DoubleConversion"
+    ss.dependency "Folly", folly_version
+    ss.dependency "glog"
+  end
+
   s.subspec "turbomodule" do |ss|
-    ss.dependency "React-callinvoker", version
+    ss.dependency "ReactCommon/callinvoker", version
     ss.dependency "React-Core", version
     ss.dependency "React-cxxreact", version
     ss.dependency "React-jsi", version

--- a/ReactCommon/callinvoker/Android.mk
+++ b/ReactCommon/callinvoker/Android.mk
@@ -15,6 +15,8 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 
 LOCAL_CFLAGS += -fexceptions -frtti -std=c++14 -Wall
 
+LOCAL_STATIC_LIBRARIES = libreactnative
+
 # Name of this module.
 LOCAL_MODULE := callinvoker
 

--- a/ReactCommon/callinvoker/BUCK
+++ b/ReactCommon/callinvoker/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "rn_xplat_cxx_library", "subdir_glob")
+load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "react_native_xplat_target", "rn_xplat_cxx_library", "subdir_glob")
 
 rn_xplat_cxx_library(
     name = "callinvoker",
@@ -25,5 +25,8 @@ rn_xplat_cxx_library(
     ],
     visibility = [
         "PUBLIC",
+    ],
+    deps = [
+        react_native_xplat_target("cxxreact:bridge"),
     ],
 )

--- a/ReactCommon/callinvoker/ReactCommon/BridgeJSCallInvoker.cpp
+++ b/ReactCommon/callinvoker/ReactCommon/BridgeJSCallInvoker.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <ReactCommon/BridgeJSCallInvoker.h>
+#include <cxxreact/Instance.h>
+
+namespace facebook {
+namespace react {
+
+BridgeJSCallInvoker::BridgeJSCallInvoker(std::weak_ptr<Instance> reactInstance)
+    : reactInstance_(reactInstance) {}
+
+void BridgeJSCallInvoker::invokeAsync(std::function<void()> &&func) {
+  auto instance = reactInstance_.lock();
+  if (instance == nullptr) {
+    return;
+  }
+  instance->invokeAsync(std::move(func));
+}
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/callinvoker/ReactCommon/BridgeJSCallInvoker.h
+++ b/ReactCommon/callinvoker/ReactCommon/BridgeJSCallInvoker.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <ReactCommon/CallInvoker.h>
+
+namespace facebook {
+namespace react {
+
+class Instance;
+
+/**
+ * A native-to-JS call invoker that uses the bridge ('Instance').
+ * It guarantees that any calls from any thread are queued on the right JS
+ * thread.
+ *
+ * For now, this is a thin-wrapper around existing bridge. Eventually,
+ * it should be consolidated with Fabric implementation so there's only one
+ * API to call JS from native, whether synchronously or asynchronously.
+ * Also, this class should not depend on `Instance` in the future.
+ */
+class BridgeJSCallInvoker : public CallInvoker {
+ public:
+  BridgeJSCallInvoker(std::weak_ptr<Instance> reactInstance);
+
+  void invokeAsync(std::function<void()> &&func) override;
+  // TODO: add sync support
+
+ private:
+  std::weak_ptr<Instance> reactInstance_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/callinvoker/ReactCommon/MessageQueueThreadCallInvoker.cpp
+++ b/ReactCommon/callinvoker/ReactCommon/MessageQueueThreadCallInvoker.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MessageQueueThreadCallInvoker.h"
+
+namespace facebook {
+namespace react {
+
+MessageQueueThreadCallInvoker::MessageQueueThreadCallInvoker(
+    std::shared_ptr<MessageQueueThread> moduleMessageQueue)
+    : moduleMessageQueue_(moduleMessageQueue) {}
+
+void MessageQueueThreadCallInvoker::invokeAsync(std::function<void()> &&func) {
+  moduleMessageQueue_->runOnQueue(std::move(func));
+}
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/callinvoker/ReactCommon/MessageQueueThreadCallInvoker.h
+++ b/ReactCommon/callinvoker/ReactCommon/MessageQueueThreadCallInvoker.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <ReactCommon/CallInvoker.h>
+#include <cxxreact/MessageQueueThread.h>
+
+namespace facebook {
+namespace react {
+
+/**
+ * Used to schedule async calls on the NativeModuels thread.
+ */
+class MessageQueueThreadCallInvoker : public CallInvoker {
+ public:
+  MessageQueueThreadCallInvoker(
+      std::shared_ptr<MessageQueueThread> moduleMessageQueue);
+
+  void invokeAsync(std::function<void()> &&func) override;
+  // TODO: add sync support
+
+ private:
+  std::shared_ptr<MessageQueueThread> moduleMessageQueue_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/cxxreact/Android.mk
+++ b/ReactCommon/cxxreact/Android.mk
@@ -19,14 +19,13 @@ LOCAL_CFLAGS := \
 
 LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
 
-LOCAL_STATIC_LIBRARIES := boost jsi callinvoker
+LOCAL_STATIC_LIBRARIES := boost jsi
 LOCAL_SHARED_LIBRARIES := jsinspector libfolly_json glog
 
 include $(BUILD_STATIC_LIBRARY)
 
 $(call import-module,fb)
 $(call import-module,folly)
-$(call import-module,callinvoker)
 $(call import-module,jsc)
 $(call import-module,glog)
 $(call import-module,jsi)

--- a/ReactCommon/cxxreact/BUCK
+++ b/ReactCommon/cxxreact/BUCK
@@ -148,7 +148,6 @@ rn_xplat_cxx_library(
         "//xplat/folly:headers_only",
         "//xplat/folly:memory",
         "//xplat/folly:molly",
-        react_native_xplat_target("callinvoker:callinvoker"),
         react_native_xplat_target("jsinspector:jsinspector"),
         react_native_xplat_target("microprofiler:microprofiler"),
         "//xplat/folly:optional",

--- a/ReactCommon/cxxreact/Instance.cpp
+++ b/ReactCommon/cxxreact/Instance.cpp
@@ -47,15 +47,8 @@ void Instance::initializeBridge(
   callback_ = std::move(callback);
   moduleRegistry_ = std::move(moduleRegistry);
   jsQueue->runOnQueueSync([this, &jsef, jsQueue]() mutable {
-    nativeToJsBridge_ = std::make_shared<NativeToJsBridge>(
+    nativeToJsBridge_ = std::make_unique<NativeToJsBridge>(
         jsef.get(), moduleRegistry_, jsQueue, callback_);
-
-    /**
-     * After NativeToJsBridge is created, the jsi::Runtime should exist.
-     * Also, the JS message queue thread exists. So, it's safe to
-     * schedule all queued up js Calls.
-     */
-    jsCallInvoker_->setNativeToJsBridgeAndFlushCalls(nativeToJsBridge_);
 
     std::lock_guard<std::mutex> lock(m_syncMutex);
     m_syncReady = true;
@@ -223,66 +216,12 @@ void Instance::handleMemoryPressure(int pressureLevel) {
   nativeToJsBridge_->handleMemoryPressure(pressureLevel);
 }
 
-std::shared_ptr<CallInvoker> Instance::getJSCallInvoker() {
-  return std::static_pointer_cast<CallInvoker>(jsCallInvoker_);
-}
-
-std::shared_ptr<CallInvoker> Instance::getDecoratedNativeCallInvoker(
-    std::shared_ptr<CallInvoker> nativeInvoker) {
-  return nativeToJsBridge_->getDecoratedNativeCallInvoker(nativeInvoker);
-}
-
-void Instance::JSCallInvoker::setNativeToJsBridgeAndFlushCalls(
-    std::weak_ptr<NativeToJsBridge> nativeToJsBridge) {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
-  m_shouldBuffer = false;
-  m_nativeToJsBridge = nativeToJsBridge;
-  while (m_workBuffer.size() > 0) {
-    scheduleAsync(std::move(m_workBuffer.front()));
-    m_workBuffer.pop_front();
-  }
-}
-
-void Instance::JSCallInvoker::invokeSync(std::function<void()> &&work) {
-  // TODO: Replace JS Callinvoker with RuntimeExecutor.
-  throw std::runtime_error(
-      "Synchronous native -> JS calls are currently not supported.");
-}
-
-void Instance::JSCallInvoker::invokeAsync(std::function<void()> &&work) {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
-  /**
-   * Why is is necessary to queue up async work?
-   *
-   * 1. TurboModuleManager must be created synchronously after the Instance,
-   *    before we load the source code. This is when the NativeModule system
-   *    is initialized. RCTDevLoadingView shows bundle download progress.
-   * 2. TurboModuleManager requires a JS CallInvoker.
-   * 3. The JS CallInvoker requires the NativeToJsBridge, which is created on
-   *    the JS thread in Instance::initializeBridge.
-   *
-   * Therefore, although we don't call invokeAsync before the JS bundle is
-   * executed, this buffering is implemented anyways to ensure that work
-   * isn't discarded.
-   */
-  if (m_shouldBuffer) {
-    m_workBuffer.push_back(std::move(work));
-    return;
-  }
-
-  scheduleAsync(std::move(work));
-}
-
-void Instance::JSCallInvoker::scheduleAsync(std::function<void()> &&work) {
-  if (auto strongNativeToJsBridge = m_nativeToJsBridge.lock()) {
-    strongNativeToJsBridge->runOnExecutorQueue(
-        [work = std::move(work)](JSExecutor *executor) {
-          work();
-          executor->flush();
-        });
-  }
+void Instance::invokeAsync(std::function<void()> &&func) {
+  nativeToJsBridge_->runOnExecutorQueue(
+      [func = std::move(func)](JSExecutor *executor) {
+        func();
+        executor->flush();
+      });
 }
 
 } // namespace react

--- a/ReactCommon/cxxreact/Instance.h
+++ b/ReactCommon/cxxreact/Instance.h
@@ -8,9 +8,7 @@
 #pragma once
 
 #include <condition_variable>
-#include <list>
 #include <memory>
-#include <mutex>
 
 #include <cxxreact/NativeToJsBridge.h>
 
@@ -88,44 +86,7 @@ class RN_EXPORT Instance {
 
   void handleMemoryPressure(int pressureLevel);
 
-  /**
-   * JS CallInvoker is used by TurboModules to schedule work on the JS thread.
-   *
-   * Why is the bridge creating JS CallInvoker?
-   *
-   * - After every Native -> JS call in the TurboModule system, the bridge
-   *   needs to flush all queued NativeModule method calls. The bridge must
-   *   also dispatch onBatchComplete if the queue of NativeModule method calls
-   *   was not empty.
-   */
-  std::shared_ptr<CallInvoker> getJSCallInvoker();
-
-  /**
-   * Native CallInvoker is used by TurboModules to schedule work on the
-   * NativeModule thread(s).
-   *
-   * Why is the bridge decorating native CallInvoker?
-   *
-   * - The bridge must be informed of all TurboModule async method calls. Why?
-   *   When all queued NativeModule method calls are flushed by a call from
-   *   Native -> JS, if that queue was non-zero in size, JsToNativeBridge
-   *   dispatches onBatchComplete. When we turn our NativeModules to
-   *   TurboModuels, there will be less and less pending NativeModule method
-   *   calls, so onBatchComplete will not fire as often. Therefore, the bridge
-   *   needs to know how many TurboModule async method calls have been completed
-   *   since the last time the bridge was flushed. If this number is non-zero,
-   *   we fire onBatchComplete.
-   *
-   * Why can't we just create and return a new native CallInvoker?
-   *
-   * - On Android, we have one NativeModule thread. That thread is created and
-   *   managed outisde of NativeToJsBridge. On iOS, we have one MethodQueue per
-   *   module. Those MethodQueues are also created and managed outside of
-   *   NativeToJsBridge. Therefore, we need to pass in a CallInvoker that
-   *   schedules work on the respective thread.
-   */
-  std::shared_ptr<CallInvoker> getDecoratedNativeCallInvoker(
-      std::shared_ptr<CallInvoker> nativeInvoker);
+  void invokeAsync(std::function<void()> &&func);
 
  private:
   void callNativeModules(folly::dynamic &&calls, bool isEndOfBatch);
@@ -139,31 +100,12 @@ class RN_EXPORT Instance {
       std::string startupScriptSourceURL);
 
   std::shared_ptr<InstanceCallback> callback_;
-  std::shared_ptr<NativeToJsBridge> nativeToJsBridge_;
+  std::unique_ptr<NativeToJsBridge> nativeToJsBridge_;
   std::shared_ptr<ModuleRegistry> moduleRegistry_;
 
   std::mutex m_syncMutex;
   std::condition_variable m_syncCV;
   bool m_syncReady = false;
-
-  class JSCallInvoker : public CallInvoker {
-   private:
-    std::weak_ptr<NativeToJsBridge> m_nativeToJsBridge;
-    std::mutex m_mutex;
-    bool m_shouldBuffer = true;
-    std::list<std::function<void()>> m_workBuffer;
-
-    void scheduleAsync(std::function<void()> &&work);
-
-   public:
-    void setNativeToJsBridgeAndFlushCalls(
-        std::weak_ptr<NativeToJsBridge> nativeToJsBridge);
-    void invokeAsync(std::function<void()> &&work) override;
-    void invokeSync(std::function<void()> &&work) override;
-  };
-
-  std::shared_ptr<JSCallInvoker> jsCallInvoker_ =
-      std::make_shared<JSCallInvoker>();
 };
 
 } // namespace react

--- a/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -7,7 +7,6 @@
 
 #include "NativeToJsBridge.h"
 
-#include <ReactCommon/CallInvoker.h>
 #include <folly/MoveWrapper.h>
 #include <folly/json.h>
 #include <glog/logging.h>
@@ -43,7 +42,7 @@ class JsToNativeBridge : public react::ExecutorDelegate {
   }
 
   bool isBatchActive() {
-    return m_batchHadNativeModuleOrTurboModuleCalls;
+    return m_batchHadNativeModuleCalls;
   }
 
   void callNativeModules(
@@ -52,8 +51,7 @@ class JsToNativeBridge : public react::ExecutorDelegate {
       bool isEndOfBatch) override {
     CHECK(m_registry || calls.empty())
         << "native module calls cannot be completed with no native modules";
-    m_batchHadNativeModuleOrTurboModuleCalls =
-        m_batchHadNativeModuleOrTurboModuleCalls || !calls.empty();
+    m_batchHadNativeModuleCalls = m_batchHadNativeModuleCalls || !calls.empty();
 
     // An exception anywhere in here stops processing of the batch.  This
     // was the behavior of the Android bridge, and since exception handling
@@ -67,9 +65,9 @@ class JsToNativeBridge : public react::ExecutorDelegate {
       // decrementPendingJSCalls will be called sync. Be aware that the bridge
       // may still be processing native calls when the bridge idle signaler
       // fires.
-      if (m_batchHadNativeModuleOrTurboModuleCalls) {
+      if (m_batchHadNativeModuleCalls) {
         m_callback->onBatchComplete();
-        m_batchHadNativeModuleOrTurboModuleCalls = false;
+        m_batchHadNativeModuleCalls = false;
       }
       m_callback->decrementPendingJSCalls();
     }
@@ -84,17 +82,13 @@ class JsToNativeBridge : public react::ExecutorDelegate {
         moduleId, methodId, std::move(args));
   }
 
-  void recordTurboModuleAsyncMethodCall() {
-    m_batchHadNativeModuleOrTurboModuleCalls = true;
-  }
-
  private:
   // These methods are always invoked from an Executor.  The NativeToJsBridge
   // keeps a reference to the executor, and when destroy() is called, the
   // executor is destroyed synchronously on its queue.
   std::shared_ptr<ModuleRegistry> m_registry;
   std::shared_ptr<InstanceCallback> m_callback;
-  bool m_batchHadNativeModuleOrTurboModuleCalls = false;
+  bool m_batchHadNativeModuleCalls = false;
 };
 
 NativeToJsBridge::NativeToJsBridge(
@@ -295,35 +289,6 @@ void NativeToJsBridge::runOnExecutorQueue(
         // 3. we just confirmed that the executor hasn't been unregistered above
         task(m_executor.get());
       });
-}
-
-std::shared_ptr<CallInvoker> NativeToJsBridge::getDecoratedNativeCallInvoker(
-    std::shared_ptr<CallInvoker> nativeInvoker) {
-  class NativeCallInvoker : public CallInvoker {
-   private:
-    std::weak_ptr<JsToNativeBridge> m_jsToNativeBridge;
-    std::shared_ptr<CallInvoker> m_nativeInvoker;
-
-   public:
-    NativeCallInvoker(
-        std::weak_ptr<JsToNativeBridge> jsToNativeBridge,
-        std::shared_ptr<CallInvoker> nativeInvoker)
-        : m_jsToNativeBridge(jsToNativeBridge),
-          m_nativeInvoker(nativeInvoker) {}
-
-    void invokeAsync(std::function<void()> &&func) override {
-      if (auto strongJsToNativeBridge = m_jsToNativeBridge.lock()) {
-        strongJsToNativeBridge->recordTurboModuleAsyncMethodCall();
-      }
-      m_nativeInvoker->invokeAsync(std::move(func));
-    }
-
-    void invokeSync(std::function<void()> &&func) override {
-      m_nativeInvoker->invokeSync(std::move(func));
-    }
-  };
-
-  return std::make_shared<NativeCallInvoker>(m_delegate, nativeInvoker);
 }
 
 } // namespace react

--- a/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -12,7 +12,6 @@
 #include <map>
 #include <vector>
 
-#include <ReactCommon/CallInvoker.h>
 #include <cxxreact/JSExecutor.h>
 
 namespace folly {
@@ -93,13 +92,6 @@ class NativeToJsBridge {
   void destroy();
 
   void runOnExecutorQueue(std::function<void(JSExecutor *)> task);
-
-  /**
-   * Native CallInvoker is used by TurboModules to schedule work on the
-   * NativeModule thread(s).
-   */
-  std::shared_ptr<CallInvoker> getDecoratedNativeCallInvoker(
-      std::shared_ptr<CallInvoker> nativeInvoker);
 
  private:
   // This is used to avoid a race condition where a proxyCallback gets queued

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -40,5 +40,4 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
   s.dependency "React-jsinspector", version
-  s.dependency "React-callinvoker", version
 end

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
@@ -215,13 +215,9 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 
 @end
 
-/**
- * These methods are all implemented by RCTCxxBridge, which subclasses RCTBridge. Hence, they must only be used in
- * contexts where the concrete class of an RCTBridge instance is RCTCxxBridge. This happens, for example, when
- * [RCTCxxBridgeDelegate jsExecutorFactoryForBridge:(RCTBridge *)] is invoked by RCTCxxBridge.
- *
- * TODO: Consolidate this extension with the one in RCTSurfacePresenter.
- */
+// TODO: Consolidate this extension with the one in RCTSurfacePresenter.
 @interface RCTBridge ()
-- (std::shared_ptr<facebook::react::CallInvoker>)jsCallInvoker;
+
+- (std::weak_ptr<facebook::react::Instance>)reactInstance;
+
 @end

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
@@ -222,8 +222,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
  *
  * TODO: Consolidate this extension with the one in RCTSurfacePresenter.
  */
-@interface RCTBridge (RCTTurboModule)
+@interface RCTBridge ()
 - (std::shared_ptr<facebook::react::CallInvoker>)jsCallInvoker;
-- (std::shared_ptr<facebook::react::CallInvoker>)decorateNativeCallInvoker:
-    (std::shared_ptr<facebook::react::CallInvoker>)nativeInvoker;
 @end

--- a/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec
+++ b/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
 
   s.dependency "RCT-Folly", folly_version
-  s.dependency "React-callinvoker", version
+  s.dependency "ReactCommon/callinvoker", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-TurboModuleCxx-WinRTPort", version
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -44,7 +44,7 @@ def use_react_native! (options={})
   pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
   pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
   pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector"
-  pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
+  pod 'ReactCommon/callinvoker', :path => "#{prefix}/ReactCommon"
   pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon"
   pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
 


### PR DESCRIPTION
revert a3f0ef4 and 9b94a54 but still running into pod install failures

[!] CocoaPods could not find compatible versions for pod "Folly":
  In Podfile:
    ReactCommon/callinvoker (from `../ReactCommon`) was resolved to 0.63.33, which depends on
      Folly (= 2020.01.13.00)

None of your spec sources contain a spec satisfying the dependency: `Folly (= 2020.01.13.00)`.

