### PR TITLE
Remove deprecation warning for CameraRoll

### DIFF
--- a/index.js
+++ b/index.js
@@ -606,19 +606,6 @@ if (__DEV__) {
     },
   });
 
-  // $FlowFixMe This is intentional: Flow will error when attempting to access CameraRoll.
-  Object.defineProperty(module.exports, 'CameraRoll', {
-    configurable: true,
-    get() {
-      invariant(
-        false,
-        'CameraRoll has been removed from React Native. ' +
-          "It can now be installed and imported from '@react-native-community/cameraroll' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/react-native-cameraroll',
-      );
-    },
-  });
-
   // $FlowFixMe This is intentional: Flow will error when attempting to access ImageStore.
   Object.defineProperty(module.exports, 'ImageStore', {
     configurable: true,


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This removes the deprecation warning for CameraRoll. #797 removed CameraRoll outright, and this commit probably should've been bundled with that pull request. Either way, better late than never.

## Changelog

[General] [Removed] - Removed deprecation warning for CameraRoll

Probably doesn't need to be included in a detailed changelog, since it's part of removing CameraRoll in general, but the changelog entry is still here if anyone wants it.
request changes the user interface. -->
