### PR TITLE
Fix internal canary publishes

### DIFF
--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -29,6 +29,12 @@ steps:
     displayName: npm install
     inputs:
       script: npm install
+
+  - task: CmdLine@2
+    displayName: Bump canary package version
+    inputs:
+      script: node scripts/bump-oss-version.js --nightly
+    condition: eq(variables['Build.SourceBranchName'], 'master')
   
   - task: CmdLine@2
     displayName: nuget restore

--- a/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
@@ -1,6 +1,6 @@
 --- "E:\\github\\rnm-63-fresh\\ReactAndroid\\ReactAndroid.nuspec"	1969-12-31 16:00:00.000000000 -0800
 +++ "E:\\github\\rnm-63\\ReactAndroid\\ReactAndroid.nuspec"	2020-10-27 20:20:54.071789900 -0700
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,135 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
@@ -59,11 +59,6 @@
 +    <file src="build\react-ndk\all\armeabi-v7a\libv8executor.so" target="lib\droidarm"/>
 +    <file src="build\react-ndk\all\x86\libv8executor.so" target="lib\droidx86"/>
 +    <file src="build\react-ndk\all\arm64-v8a\libv8executor.so" target="lib\droidarm64"/>
-+
-+    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64"/>
-+    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm"/>
-+    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86"/>
-+    <file src="build\react-ndk\all\arm64-v8a\libyoga.so" target="lib\droidarm64"/>
 +
 +    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64"/>
 +    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm"/>


### PR DESCRIPTION
Add logic to update the version number from 1000.0.0 to 0.0.0-canary.<commit> when running the internal publish build.  -- This will then be changed to 0.0.0-canary.<commit>-microsoft.0 in a later build step.

Also removed some duplicated lines in the nuspec that was causing the nuget to not get created.