### PR TITLE
Update android patches for changes from last merge from core

### DIFF
--- a/android-patches/patches/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/android-patches/patches/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -53,7 +53,7 @@
    @ReactProp(name = "borderStyle")
    public void setBorderStyle(ReactViewGroup view, @Nullable String borderStyle) {
      view.setBorderStyle(borderStyle);
-@@ -285,7 +320,7 @@
+@@ -289,7 +324,7 @@
  
    @Override
    public Map<String, Integer> getCommandsMap() {
@@ -62,7 +62,7 @@
    }
  
    @Override
-@@ -301,6 +336,16 @@
+@@ -305,6 +340,16 @@
            handleSetPressed(root, args);
            break;
          }
@@ -79,7 +79,7 @@
      }
    }
  
-@@ -317,6 +362,16 @@
+@@ -321,6 +366,16 @@
            handleSetPressed(root, args);
            break;
          }

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -16,7 +16,7 @@
  
    private class ReactContextInitParams {
      private final JavaScriptExecutorFactory mJsExecutorFactory;
-@@ -915,6 +917,15 @@
+@@ -922,6 +924,15 @@
      }
    }
  
@@ -32,7 +32,7 @@
    /** Add a listener to be notified of react instance events. */
    public void addReactInstanceEventListener(ReactInstanceEventListener listener) {
      mReactInstanceEventListeners.add(listener);
-@@ -1230,7 +1241,8 @@
+@@ -1245,7 +1256,8 @@
              .setJSExecutor(jsExecutor)
              .setRegistry(nativeModuleRegistry)
              .setJSBundleLoader(jsBundleLoader)

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -1,6 +1,6 @@
 --- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\bridge\\CatalystInstance.java"	2020-10-27 20:26:16.742190400 -0700
 +++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\bridge\\CatalystInstance.java"	2020-10-13 21:28:17.283848100 -0700
-@@ -125,4 +125,11 @@
+@@ -131,4 +131,11 @@
     * hasNativeModule, and getNativeModules can also return TurboModules.
     */
    void setTurboModuleManager(JSIModule getter);

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -68,7 +68,7 @@
                                              FLog.d(
                                                  ReactConstants.TAG,
                                                  "CatalystInstanceImpl.destroy() end");
-@@ -670,6 +682,8 @@
+@@ -679,6 +691,8 @@
  
    private native long getJavaScriptContext();
  
@@ -77,7 +77,7 @@
    private void incrementPendingJSCalls() {
      int oldPendingCalls = mPendingJSCalls.getAndIncrement();
      boolean wasIdle = oldPendingCalls == 0;
-@@ -775,6 +789,7 @@
+@@ -784,6 +798,7 @@
      private @Nullable NativeModuleRegistry mRegistry;
      private @Nullable JavaScriptExecutor mJSExecutor;
      private @Nullable NativeModuleCallExceptionHandler mNativeModuleCallExceptionHandler;
@@ -85,7 +85,7 @@
  
      public Builder setReactQueueConfigurationSpec(
          ReactQueueConfigurationSpec ReactQueueConfigurationSpec) {
-@@ -802,13 +817,20 @@
+@@ -811,13 +826,20 @@
        return this;
      }
  

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -8,10 +8,10 @@
        makeNativeMethod(
            "initializeBridge", CatalystInstanceImpl::initializeBridge),
        makeNativeMethod(
-@@ -131,26 +132,39 @@
-       makeNativeMethod(
-           "jniHandleMemoryPressure",
+@@ -133,26 +134,39 @@
            CatalystInstanceImpl::handleMemoryPressure),
+       makeNativeMethod(
+           "getRuntimeExecutor", CatalystInstanceImpl::getRuntimeExecutor),           
 +      makeNativeMethod("getPointerOfInstancePointer", CatalystInstanceImpl::getPointerOfInstancePointer)
    });
  
@@ -56,7 +56,7 @@
  
    // This used to be:
    //
-@@ -169,12 +183,13 @@
+@@ -171,12 +185,13 @@
    // don't need jsModuleDescriptions any more, all the way up and down the
    // stack.
  
@@ -75,7 +75,7 @@
    instance_->initializeBridge(
        std::make_unique<JInstanceCallback>(callback, moduleMessageQueue_),
        jseh->getExecutorFactory(),
-@@ -284,6 +299,10 @@
+@@ -286,6 +301,10 @@
    instance_->handleMemoryPressure(pressureLevel);
  }
  

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
@@ -1,6 +1,6 @@
 --- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\jni\\react\\jni\\CatalystInstanceImpl.h"	2020-10-27 20:26:17.024172000 -0700
 +++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\jni\\react\\jni\\CatalystInstanceImpl.h"	2020-10-13 21:51:15.981376100 -0700
-@@ -48,17 +48,16 @@
+@@ -50,17 +50,16 @@
  
    CatalystInstanceImpl();
  
@@ -24,7 +24,7 @@
  
    void extendNativeModules(
        jni::alias_ref<jni::JCollection<
-@@ -95,6 +94,7 @@
+@@ -98,6 +97,7 @@
    void setGlobalVariable(std::string propName, std::string &&jsonValue);
    jlong getJavaScriptContext();
    void handleMemoryPressure(int pressureLevel);

--- a/android-patches/patches/OfficeRNHost/ReactCommon/cxxreact/Instance.h
+++ b/android-patches/patches/OfficeRNHost/ReactCommon/cxxreact/Instance.h
@@ -1,6 +1,6 @@
 --- "E:\\github\\rnm-63-fresh\\ReactCommon\\cxxreact\\Instance.h"	2020-10-27 20:26:17.182168000 -0700
 +++ "E:\\github\\rnm-63\\ReactCommon\\cxxreact\\Instance.h"	2020-10-13 21:56:09.532647200 -0700
-@@ -41,6 +41,8 @@
+@@ -42,6 +42,8 @@
  class RN_EXPORT Instance {
   public:
    ~Instance();

--- a/android-patches/patches/V8/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/android-patches/patches/V8/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -1,14 +1,14 @@
 --- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\jni\\react\\jni\\Android.mk"	2020-10-27 20:26:17.023172300 -0700
 +++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\jni\\react\\jni\\Android.mk"	2020-10-13 21:47:10.404176500 -0700
-@@ -70,6 +70,7 @@
- $(call import-module,jsiexecutor)
+@@ -71,6 +71,7 @@
  $(call import-module,callinvoker)
  $(call import-module,hermes)
+ $(call import-module,runtimeexecutor)
 +$(call import-module,v8jsi)
  
  include $(REACT_SRC_DIR)/turbomodule/core/jni/Android.mk
  
-@@ -81,3 +82,4 @@
+@@ -82,3 +83,4 @@
  include $(REACT_SRC_DIR)/../hermes/reactexecutor/Android.mk
  include $(REACT_SRC_DIR)/../hermes/instrumentation/Android.mk
  include $(REACT_SRC_DIR)/modules/blob/jni/Android.mk


### PR DESCRIPTION
These are patches for office's internal usage.  They need to be updated to account for the latest changes synced from react-native.