### PR TITLE
Merge from upstream through 2020-06-07

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -86,4 +86,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.125.0
+^0.126.1

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -89,4 +89,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.125.0
+^0.126.1

--- a/.flowconfig.macos
+++ b/.flowconfig.macos
@@ -89,4 +89,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.125.0
+^0.126.1

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @preventMunge
  */
 
 'use strict';

--- a/Libraries/BatchedBridge/MessageQueue.js
+++ b/Libraries/BatchedBridge/MessageQueue.js
@@ -112,13 +112,6 @@ class MessageQueue {
     return this.flushedQueue();
   }
 
-  // Deprecated. T61834641: Remove me once native clients have updated
-  callFunctionReturnResultAndFlushedQueue(
-    module: string,
-    method: string,
-    args: any[],
-  ): void {}
-
   invokeCallbackAndReturnFlushedQueue(
     cbID: number,
     args: any[],

--- a/Libraries/Blob/NativeBlobModule.js
+++ b/Libraries/Blob/NativeBlobModule.js
@@ -23,4 +23,38 @@ export interface Spec extends TurboModule {
   +release: (blobId: string) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('BlobModule'): ?Spec);
+const NativeModule = TurboModuleRegistry.get<Spec>('BlobModule');
+
+let constants = null;
+let NativeBlobModule = null;
+
+if (NativeModule != null) {
+  NativeBlobModule = {
+    getConstants(): {|BLOB_URI_SCHEME: ?string, BLOB_URI_HOST: ?string|} {
+      if (constants == null) {
+        constants = NativeModule.getConstants();
+      }
+      return constants;
+    },
+    addNetworkingHandler(): void {
+      NativeModule.addNetworkingHandler();
+    },
+    addWebSocketHandler(id: number): void {
+      NativeModule.addWebSocketHandler(id);
+    },
+    removeWebSocketHandler(id: number): void {
+      NativeModule.removeWebSocketHandler(id);
+    },
+    sendOverSocket(blob: Object, socketID: number): void {
+      NativeModule.sendOverSocket(blob, socketID);
+    },
+    createFromParts(parts: Array<Object>, withId: string): void {
+      NativeModule.createFromParts(parts, withId);
+    },
+    release(blobId: string): void {
+      NativeModule.release(blobId);
+    },
+  };
+}
+
+export default (NativeBlobModule: ?Spec);

--- a/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid.js
+++ b/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid.js
@@ -31,6 +31,40 @@ export interface Spec extends TurboModule {
   +setHidden: (hidden: boolean) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'StatusBarManager',
-): Spec);
+const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('StatusBarManager');
+let constants = null;
+
+const NativeStatusBarManager = {
+  getConstants(): {|
+    +HEIGHT: number,
+    +DEFAULT_BACKGROUND_COLOR?: number,
+  |} {
+    if (constants == null) {
+      constants = NativeModule.getConstants();
+    }
+    return constants;
+  },
+
+  setColor(color: number, animated: boolean): void {
+    NativeModule.setColor(color, animated);
+  },
+
+  setTranslucent(translucent: boolean): void {
+    NativeModule.setTranslucent(translucent);
+  },
+
+  /**
+   *  - statusBarStyles can be:
+   *    - 'default'
+   *    - 'dark-content'
+   */
+  setStyle(statusBarStyle?: ?string): void {
+    NativeModule.setStyle(statusBarStyle);
+  },
+
+  setHidden(hidden: boolean): void {
+    NativeModule.setHidden(hidden);
+  },
+};
+
+export default NativeStatusBarManager;

--- a/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
+++ b/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
@@ -38,6 +38,53 @@ export interface Spec extends TurboModule {
   +setHidden: (hidden: boolean, withAnimation: string) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'StatusBarManager',
-): Spec);
+const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('StatusBarManager');
+let constants = null;
+
+const NativeStatusBarManager = {
+  getConstants(): {|
+    +HEIGHT: number,
+    +DEFAULT_BACKGROUND_COLOR?: number,
+  |} {
+    if (constants == null) {
+      constants = NativeModule.getConstants();
+    }
+    return constants;
+  },
+
+  // TODO(T47754272) Can we remove this method?
+  getHeight(callback: (result: {|height: number|}) => void): void {
+    NativeModule.getHeight(callback);
+  },
+
+  setNetworkActivityIndicatorVisible(visible: boolean): void {
+    NativeModule.setNetworkActivityIndicatorVisible(visible);
+  },
+
+  addListener(eventType: string): void {
+    NativeModule.addListener(eventType);
+  },
+
+  removeListeners(count: number): void {
+    NativeModule.removeListeners(count);
+  },
+
+  /**
+   *  - statusBarStyles can be:
+   *    - 'default'
+   *    - 'dark-content'
+   *    - 'light-content'
+   */
+  setStyle(statusBarStyle?: ?string, animated: boolean): void {
+    NativeModule.setStyle(statusBarStyle, animated);
+  },
+
+  /**
+   *  - withAnimation can be: 'none' | 'fade' | 'slide'
+   */
+  setHidden(hidden: boolean, withAnimation: string): void {
+    NativeModule.setHidden(hidden, withAnimation);
+  },
+};
+
+export default NativeStatusBarManager;

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1133,8 +1133,7 @@ function InternalTextInput(props: Props): React.Node {
     const style = [props.style];
     const autoCapitalize = props.autoCapitalize || 'sentences';
     let children = props.children;
-    let childCount = 0;
-    React.Children.forEach(children, () => ++childCount);
+    const childCount = React.Children.count(children);
     invariant(
       !(props.value && childCount),
       'Cannot specify both value and children.',

--- a/Libraries/Components/ToastAndroid/ToastAndroid.android.js
+++ b/Libraries/Components/ToastAndroid/ToastAndroid.android.js
@@ -32,14 +32,16 @@ import NativeToastAndroid from './NativeToastAndroid';
  * ```
  */
 
+const ToastAndroidConstants = NativeToastAndroid.getConstants();
+
 const ToastAndroid = {
   // Toast duration constants
-  SHORT: (NativeToastAndroid.getConstants().SHORT: number),
-  LONG: (NativeToastAndroid.getConstants().LONG: number),
+  SHORT: (ToastAndroidConstants.SHORT: number),
+  LONG: (ToastAndroidConstants.LONG: number),
   // Toast gravity constants
-  TOP: (NativeToastAndroid.getConstants().TOP: number),
-  BOTTOM: (NativeToastAndroid.getConstants().BOTTOM: number),
-  CENTER: (NativeToastAndroid.getConstants().CENTER: number),
+  TOP: (ToastAndroidConstants.TOP: number),
+  BOTTOM: (ToastAndroidConstants.BOTTOM: number),
+  CENTER: (ToastAndroidConstants.CENTER: number),
 
   show: function(message: string, duration: number): void {
     NativeToastAndroid.show(message, duration);

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -279,18 +279,6 @@ type AndroidViewProps = $ReadOnly<{|
   renderToHardwareTextureAndroid?: ?boolean,
 
   /**
-   * Views that are only used to layout their children or otherwise don't draw
-   * anything may be automatically removed from the native hierarchy as an
-   * optimization. Set this property to `false` to disable this optimization and
-   * ensure that this `View` exists in the native view hierarchy.
-   *
-   * @platform android
-   *
-   * See https://reactnative.dev/docs/view.html#collapsable
-   */
-  collapsable?: ?boolean,
-
-  /**
    * Whether this `View` needs to rendered offscreen and composited with an
    * alpha in order to preserve 100% correct colors and blending behavior.
    *
@@ -507,6 +495,19 @@ export type ViewProps = $ReadOnly<{|
    *
    */
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+
+  /**
+   * Views that are only used to layout their children or otherwise don't draw
+   * anything may be automatically removed from the native hierarchy as an
+   * optimization. Set this property to `false` to disable this optimization and
+   * ensure that this `View` exists in the native view hierarchy.
+   *
+   * @platform android
+   * In Fabric, this prop is used in ios as well.
+   *
+   * See https://reactnative.dev/docs/view.html#collapsable
+   */
+  collapsable?: ?boolean,
 
   /**
    * Used to locate this view in end-to-end tests.

--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -11,7 +11,6 @@
 'use strict';
 
 import type {ExtendedError} from './Devtools/parseErrorStack';
-import * as LogBoxData from '../LogBox/Data/LogBoxData';
 import type {ExceptionData} from './NativeExceptionsManager';
 
 class SyntheticError extends Error {
@@ -104,7 +103,8 @@ function reportException(
       console.error(data.message);
     }
 
-    if (isHandledByLogBox) {
+    if (__DEV__ && isHandledByLogBox) {
+      const LogBoxData = require('../LogBox/Data/LogBoxData');
       LogBoxData.addException({
         ...data,
         isComponentError: !!e.isComponentError,

--- a/Libraries/Inspector/InspectorOverlay.js
+++ b/Libraries/Inspector/InspectorOverlay.js
@@ -56,6 +56,7 @@ class InspectorOverlay extends React.Component<Props> {
       <View
         onStartShouldSetResponder={this.shouldSetResponser}
         onResponderMove={this.findViewForTouchEvent}
+        nativeID="inspectorOverlay"
         style={[styles.inspector, {height: Dimensions.get('window').height}]}>
         {content}
       </View>

--- a/Libraries/LogBox/LogBox.js
+++ b/Libraries/LogBox/LogBox.js
@@ -12,8 +12,6 @@
 
 import Platform from '../Utilities/Platform';
 import RCTLog from '../Utilities/RCTLog';
-import * as LogBoxData from './Data/LogBoxData';
-import {parseLogBoxLog, parseInterpolation} from './Data/parseLogBoxLog';
 
 import type {IgnorePattern} from './Data/LogBoxData';
 
@@ -23,6 +21,9 @@ let LogBox;
  * LogBox displays logs in the app.
  */
 if (__DEV__) {
+  const LogBoxData = require('./Data/LogBoxData');
+  const {parseLogBoxLog, parseInterpolation} = require('./Data/parseLogBoxLog');
+
   // LogBox needs to insert itself early,
   // in order to access the component stacks appended by React DevTools.
   const {error, warn} = console;

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const AppContainer = require('../ReactNative/AppContainer');
+const {RootTagContext} = require('../ReactNative/RootTag');
 const I18nManager = require('../ReactNative/I18nManager');
 const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
 import NativeModalManager from './NativeModalManager';
@@ -21,6 +22,7 @@ const ScrollView = require('../Components/ScrollView/ScrollView');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const View = require('../Components/View/View');
 
+import type {RootTag} from '../ReactNative/RootTag';
 import type {ViewProps} from '../Components/View/ViewPropTypes';
 import type {DirectEventHandler} from '../Types/CodegenTypes';
 import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
@@ -156,9 +158,7 @@ class Modal extends React.Component<Props> {
     hardwareAccelerated: false,
   };
 
-  static contextTypes: any | {|rootTag: React$PropType$Primitive<number>|} = {
-    rootTag: PropTypes.number,
-  };
+  static contextType: React.Context<RootTag> = RootTagContext;
 
   _identifier: number;
   _eventSubscription: ?EmitterSubscription;
@@ -224,9 +224,7 @@ class Modal extends React.Component<Props> {
     }
 
     const innerChildren = __DEV__ ? (
-      <AppContainer rootTag={this.context.rootTag}>
-        {this.props.children}
-      </AppContainer>
+      <AppContainer rootTag={this.context}>{this.props.children}</AppContainer>
     ) : (
       this.props.children
     );

--- a/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
@@ -75,6 +75,11 @@
 
 - (void)restoreDefaultValues
 {
+  if (_managedByFabric) {
+    // Restoring to default values causes render of inconsistent state
+    // to the user because it isn't synchonised with Fabric's UIManager.
+    return;
+  }
   // Restore the default value for all props that were modified by this node.
   for (NSString *key in _propsDictionary.allKeys) {
     _propsDictionary[key] = [NSNull null];

--- a/Libraries/NativeModules/specs/NativeSourceCode.js
+++ b/Libraries/NativeModules/specs/NativeSourceCode.js
@@ -19,4 +19,19 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('SourceCode'): Spec);
+const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('SourceCode');
+let constants = null;
+
+const NativeSourceCode = {
+  getConstants(): {|
+    scriptURL: string,
+  |} {
+    if (constants == null) {
+      constants = NativeModule.getConstants();
+    }
+
+    return constants;
+  },
+};
+
+export default NativeSourceCode;

--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -91,7 +91,7 @@ export type PressEvent = ResponderSyntheticEvent<
     button?: ?number, // TODO(macOS GH#774)
     changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
     ctrlKey?: ?boolean, // TODO(macOS GH#774)
-    force: number,
+    force?: number,
     identifier: number,
     locationX: number,
     locationY: number,

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -43,7 +43,18 @@ export interface Spec extends TurboModule {
 }
 
 const NativeModule: Spec = TurboModuleRegistry.getEnforcing<Spec>('DeviceInfo');
+let constants = null;
 
-const NativeDeviceInfo = NativeModule;
+const NativeDeviceInfo = {
+  getConstants(): {|
+    +Dimensions: DimensionsPayload,
+    +isIPhoneX_deprecated?: boolean,
+  |} {
+    if (constants == null) {
+      constants = NativeModule.getConstants();
+    }
+    return constants;
+  },
+};
 
 export default NativeDeviceInfo;

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -251,6 +251,7 @@ PODS:
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-callinvoker (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - React-jsinspector (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - React-runtimeexecutor (= 1000.0.0)
@@ -523,8 +524,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 2b45d0f8e156a5b02354c8a4062de64d41ccb4e0
-  FBLazyVector: 612364849df0026a8fdea446ac929d32f9f0a423
-  FBReactNativeSpec: 30d621de10913f14a0a5905ce088ea18b85c2dbb
+  FBLazyVector: 473624d6d8a95dddea531181b5fe074296b849d4
+  FBReactNativeSpec: aa5face1bbc5054a321b7a71a7a9f63fb9b9ed7f
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -535,34 +536,34 @@ SPEC CHECKSUMS:
   glog: 789873d01e4b200777d0a09bc23d548446758699
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 55d0039b24e192081ec0b2257f7bd9f42e382fb7
-  RCTRequired: 6d90ba4846a58d45539e8118ebf7a06d2db379cc
-  RCTTypeSafety: 9e0a77a9f2c4e0688c985ec1243307d6777805ab
-  React: 7070d4f9baf939baedfcd1358acdaf0a259b023d
-  React-ART: 531f0b78884eecc02b0088330e1b820ca7ef186f
-  React-callinvoker: 94940d7aa248934637b2a6020aab6c1de893e5c7
-  React-Core: 84250af569c182909120182e89914ae17be2b6ed
-  React-CoreModules: 2c51a966aa8dfb075c85caee7fdc0f1a02062f8a
-  React-cxxreact: f5a570f0eeea78b7eabf322dc01ed7c54b092320
-  React-jsi: f63877d063edf2a614d67f454ea68825953079ff
-  React-jsiexecutor: ba971320209048169e0d9e7b0d1d25758e266a2f
-  React-jsinspector: 9a3e9449f88a9abe091b13f6b8a214dd26465b26
-  React-perflogger: 0fad4dd40022e77107f74a593204945d78b52876
-  React-RCTActionSheet: 5890411c18dcd860bd792882fb20b81f22f25bc4
-  React-RCTAnimation: ae52c02def54ee24f7522088bffbe33874265ca8
-  React-RCTBlob: 6bfe0eab854c0ea95dea90a9f2d9b555502503e0
-  React-RCTImage: 16232a23bdb07d5a06705f95b3b40ee28ba3054c
-  React-RCTLinking: 3d4dcd2e7f15dd11bb18861bdf7b4781f76d4d64
-  React-RCTNetwork: 0cbd4b96fcf726438f9814631e447cfe4db714c9
-  React-RCTPushNotification: 61f472384037a2d15fa3c76e069ccde9979c8a89
-  React-RCTSettings: a9952a40a7d89e4f3aec025185f197e58a1a22a2
-  React-RCTTest: b86c663b9dc6b0dccd6b37a794b6a7d8c164c4f3
-  React-RCTText: ee61e09fc11975b5669bcddc36549ee848ad3b83
-  React-RCTVibration: 37bb78ecacc0cfeb619b3b46a436b31246b8fcb1
-  React-runtimeexecutor: a0adc3b14832a771a58bdee656a775a096be3d7a
+  RCTRequired: c2b55a638af545470baa7e1953525cbdd249f071
+  RCTTypeSafety: 6f8075941c3b0a18fe2dc4b343aea938d0bad5e2
+  React: 8ebf7e7f105fbcea86199badd55a6bb67a5b8afa
+  React-ART: a75138364a2681f5189fe24af2a645a4f9069353
+  React-callinvoker: 497cecd63f6e72c269c808e8529b36e31816175f
+  React-Core: 21186234ce1a0dfdd68bb885f36953f03f6ad595
+  React-CoreModules: 20deecbc9727971b94d8b7e36addba9ee5b3df7b
+  React-cxxreact: 78dadb6f1c308aac81c14cc5fa55eee1bf4e509a
+  React-jsi: 04aa49b53eb6627f22a208b7a453b7c695c23f13
+  React-jsiexecutor: 68b861e21c43a19980374229f98003860e389eb7
+  React-jsinspector: b75196b3c0ed12a6608798366cd627fd93d8aef5
+  React-perflogger: 1e95f386e69d2531429be35018b9e3a7e7319f0d
+  React-RCTActionSheet: 2f5024fba47f6bbae7cd7035bcfe3a2a9ceab828
+  React-RCTAnimation: c5daba3acc6601ed49befc73314f3a4a3dffac7e
+  React-RCTBlob: e88442441bf43cb1733faf5ee0369cb77ef9a9c5
+  React-RCTImage: 0d6613af0b99b24bb2f10d951c36d682b15ba90f
+  React-RCTLinking: b47cd2eda4ad15424f1ad02f4eb9ff027f212f6c
+  React-RCTNetwork: 1bdb44306b36686fcdf51fb353cd5bea1910c9dc
+  React-RCTPushNotification: 0d9ef4d1acc93d00828de47763834ef9f7e825c7
+  React-RCTSettings: 606a93f1f422bb1e33e8178715edcbeb00ef0e29
+  React-RCTTest: 61a59b3db0d728bd3f2e4c477aa39f5308f58d3d
+  React-RCTText: 377bcb96f1626badf03d4e7cb08efc1e49ca8654
+  React-RCTVibration: a68e8de67fd7d6fe24f027965291dff20a7e1ecf
+  React-runtimeexecutor: b5c501cbb838fb190272567117469ba89ca4095c
   React-TurboModuleCxx-RNW: 18bb71af41fe34c8b12a56bef60aae7ee32b0817
-  React-TurboModuleCxx-WinRTPort: c5ee8d0f7fd49453996a980a8646afb251339acb
-  ReactCommon: 37c88457c9e4896daaa6a7aa699f9d54ae5e148e
-  Yoga: 8838387cf620983b4e0e6e6c0486c6041b3faee3
+  React-TurboModuleCxx-WinRTPort: bbf5afaa8aa712919a56b270bee8a83a74d7c6f5
+  ReactCommon: d4fccf43589bf37d7e3b94c32ce3722a0889d98c
+  Yoga: 4fec242f984a794825ad52bc24af3c0c91da2d7d
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 7d43a928a9b9ad27329da110adbfadd923a39ba8

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -523,8 +523,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 2b45d0f8e156a5b02354c8a4062de64d41ccb4e0
-  FBLazyVector: dac58e415545ed3aaa631054fe0447782a933865
-  FBReactNativeSpec: d25a00a4a4d0392ed51a01fcdc33b3445bae2957
+  FBLazyVector: 612364849df0026a8fdea446ac929d32f9f0a423
+  FBReactNativeSpec: 30d621de10913f14a0a5905ce088ea18b85c2dbb
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -535,34 +535,34 @@ SPEC CHECKSUMS:
   glog: 789873d01e4b200777d0a09bc23d548446758699
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCT-Folly: 55d0039b24e192081ec0b2257f7bd9f42e382fb7
-  RCTRequired: 212ed857d2e02aa7a950e2e9fd1e0e14bf36dac9
-  RCTTypeSafety: cc7500b093bff4f94b61c64033c26f9c9b613ed6
-  React: 1fbebfa33be059ef6f440ac79e568d7cc2f881db
-  React-ART: fda22d56018ca90ce94d0775f756acc88f700041
-  React-callinvoker: 6b4291b2f7baa371074a21bc01c1ae3469159f26
-  React-Core: 7587308afd5f755599465e6c8e0d111fe7294370
-  React-CoreModules: 2845f7f2e5487b7146b8fcfb28603e7aba8c73dd
-  React-cxxreact: b79fc1d424cdedac912585efd2fb8481c963185b
-  React-jsi: 4ff577747833dbf79aadf814d0a7103b70566ba7
-  React-jsiexecutor: 64210b838560d2aaf1ed69f514894961cf43f684
-  React-jsinspector: 3fd9965e147de74ce261fdb58fef297b2973b84e
-  React-perflogger: 097bc54ba46a5733759303edb807834888c694de
-  React-RCTActionSheet: d0520c2146f744d28915281af40b8421c549a648
-  React-RCTAnimation: 87c74e6bdb902190345b90df4878a018dd62d3f3
-  React-RCTBlob: 1ed3cccb9eba04212a0779493902b4673605f79f
-  React-RCTImage: 1df1bc4d3f172c43c053d881befd4e189b58930e
-  React-RCTLinking: 35ce87cc530d4c9945d7c4f457a3d370f0c22361
-  React-RCTNetwork: 450019d7b09925c10210be67268870761abc560a
-  React-RCTPushNotification: 3638092f4cc05336049fe360d45dfc64e1f662b4
-  React-RCTSettings: 90fbb7c75497e6a68a60fd3d155cec3aa9ec3905
-  React-RCTTest: 703fefa06f06aeeb412b2b4912c7104517bdf0a7
-  React-RCTText: 34cd0c240c00bfe8b942c5a3038169754a902200
-  React-RCTVibration: 2d2b494b2d8795b8382545bf31a686cc39056bc7
-  React-runtimeexecutor: 56de50ce596344a7d1fbc697149b844183e9ff9b
+  RCTRequired: 6d90ba4846a58d45539e8118ebf7a06d2db379cc
+  RCTTypeSafety: 9e0a77a9f2c4e0688c985ec1243307d6777805ab
+  React: 7070d4f9baf939baedfcd1358acdaf0a259b023d
+  React-ART: 531f0b78884eecc02b0088330e1b820ca7ef186f
+  React-callinvoker: 94940d7aa248934637b2a6020aab6c1de893e5c7
+  React-Core: 84250af569c182909120182e89914ae17be2b6ed
+  React-CoreModules: 2c51a966aa8dfb075c85caee7fdc0f1a02062f8a
+  React-cxxreact: f5a570f0eeea78b7eabf322dc01ed7c54b092320
+  React-jsi: f63877d063edf2a614d67f454ea68825953079ff
+  React-jsiexecutor: ba971320209048169e0d9e7b0d1d25758e266a2f
+  React-jsinspector: 9a3e9449f88a9abe091b13f6b8a214dd26465b26
+  React-perflogger: 0fad4dd40022e77107f74a593204945d78b52876
+  React-RCTActionSheet: 5890411c18dcd860bd792882fb20b81f22f25bc4
+  React-RCTAnimation: ae52c02def54ee24f7522088bffbe33874265ca8
+  React-RCTBlob: 6bfe0eab854c0ea95dea90a9f2d9b555502503e0
+  React-RCTImage: 16232a23bdb07d5a06705f95b3b40ee28ba3054c
+  React-RCTLinking: 3d4dcd2e7f15dd11bb18861bdf7b4781f76d4d64
+  React-RCTNetwork: 0cbd4b96fcf726438f9814631e447cfe4db714c9
+  React-RCTPushNotification: 61f472384037a2d15fa3c76e069ccde9979c8a89
+  React-RCTSettings: a9952a40a7d89e4f3aec025185f197e58a1a22a2
+  React-RCTTest: b86c663b9dc6b0dccd6b37a794b6a7d8c164c4f3
+  React-RCTText: ee61e09fc11975b5669bcddc36549ee848ad3b83
+  React-RCTVibration: 37bb78ecacc0cfeb619b3b46a436b31246b8fcb1
+  React-runtimeexecutor: a0adc3b14832a771a58bdee656a775a096be3d7a
   React-TurboModuleCxx-RNW: 18bb71af41fe34c8b12a56bef60aae7ee32b0817
-  React-TurboModuleCxx-WinRTPort: 892e11a61325fcab19632767b4e4d0fb6979ae33
-  ReactCommon: 574163ae6b6797f54c228ad305bc7a52afa1cef9
-  Yoga: ba8ee169a50208f5ab580225e339f8d7f6a46e22
+  React-TurboModuleCxx-WinRTPort: c5ee8d0f7fd49453996a980a8646afb251339acb
+  ReactCommon: 37c88457c9e4896daaa6a7aa699f9d54ae5e148e
+  Yoga: 8838387cf620983b4e0e6e6c0486c6041b3faee3
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 7d43a928a9b9ad27329da110adbfadd923a39ba8

--- a/RNTester/RNTester-macOS/AppDelegate.mm
+++ b/RNTester/RNTester-macOS/AppDelegate.mm
@@ -115,7 +115,10 @@ NSString *kBundleNameJS = @"RNTesterApp";
       }
       __typeof(self) strongSelf = weakSelf;
       if (strongSelf) {
-        [strongSelf->_turboModuleManager installJSBindingWithRuntime:&runtime];
+        facebook::react::RuntimeExecutor syncRuntimeExecutor = [&](std::function<void(facebook::jsi::Runtime &runtime_)> &&callback) {
+          callback(runtime);
+        };
+        [strongSelf->_turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
       }
     })
   );

--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -178,7 +178,10 @@
       }
       __typeof(self) strongSelf = weakSelf;
       if (strongSelf) {
-        [strongSelf->_turboModuleManager installJSBindingWithRuntime:&runtime];
+        facebook::react::RuntimeExecutor syncRuntimeExecutor = [&](std::function<void(facebook::jsi::Runtime &runtime_)> &&callback) {
+          callback(runtime);
+        };
+        [strongSelf->_turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
       }
     })
   );

--- a/RNTester/RNTesterUnitTests/RCTBundleURLProviderTests.m
+++ b/RNTester/RNTesterUnitTests/RCTBundleURLProviderTests.m
@@ -20,12 +20,24 @@ static NSURL *mainBundleURL()
 
 static NSURL *localhostBundleURL()
 {
-  return [NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:8081/%@.bundle?platform=%@&dev=true&minify=false&app=com.apple.dt.xctest.tool", testFile, kRCTPlatformName]]; // TODO(macOS ISS#3536887)
+  return [NSURL
+      URLWithString:
+          [NSString
+              stringWithFormat:
+                  @"http://localhost:8081/%@.bundle?platform=%@&dev=true&minify=false&modulesOnly=false&runMdoule=true&app=com.apple.dt.xctest.tool",
+                  testFile,
+                  kRCTPlatformName]]; // TODO(macOS GH#774)
 }
 
 static NSURL *ipBundleURL()
 {
-  return [NSURL URLWithString:[NSString stringWithFormat:@"http://192.168.1.1:8081/%@.bundle?platform=%@&dev=true&minify=false&app=com.apple.dt.xctest.tool", testFile, kRCTPlatformName]]; // TODO(macOS ISS#3536887)
+  return [NSURL
+      URLWithString:
+          [NSString
+              stringWithFormat:
+                  @"http://192.168.1.1:8081/%@.bundle?platform=%@&dev=true&minify=false&modulesOnly=false&runMdoule=true&app=com.apple.dt.xctest.tool",
+                  testFile,
+                  kRCTPlatformName]]; // TODO(macOS GH#774)
 }
 
 @implementation NSBundle (RCTBundleURLProviderTests)
@@ -50,16 +62,14 @@ static NSURL *ipBundleURL()
 {
   [super setUp];
 
-  RCTSwapInstanceMethods([NSBundle class],
-                         @selector(URLForResource:withExtension:),
-                          @selector(RCT_URLForResource:withExtension:));
+  RCTSwapInstanceMethods(
+      [NSBundle class], @selector(URLForResource:withExtension:), @selector(RCT_URLForResource:withExtension:));
 }
 
 - (void)tearDown
 {
-  RCTSwapInstanceMethods([NSBundle class],
-                         @selector(URLForResource:withExtension:),
-                         @selector(RCT_URLForResource:withExtension:));
+  RCTSwapInstanceMethods(
+      [NSBundle class], @selector(URLForResource:withExtension:), @selector(RCT_URLForResource:withExtension:));
 
   [super tearDown];
 }

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -167,7 +167,7 @@ function ForceTouchExample() {
           style={styles.wrapper}
           testID="pressable_3dtouch_button"
           onStartShouldSetResponder={() => true}
-          onResponderMove={event => setForce(event.nativeEvent.force)}
+          onResponderMove={event => setForce(event.nativeEvent?.force || 1)}
           onResponderRelease={event => setForce(0)}>
           <Text style={styles.button}>Press Me</Text>
         </View>

--- a/React/Base/RCTBundleURLProvider.h
+++ b/React/Base/RCTBundleURLProvider.h
@@ -48,6 +48,11 @@ extern NSString *const kRCTPlatformName; // TODO(macOS GH#774)
 - (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot fallbackURLProvider:(NSURL * (^)(void))fallbackURLProvider;
 
 /**
+ * Returns the jsBundleURL for a given split bundle entrypoint in development
+ */
+- (NSURL *)jsBundleURLForSplitBundleRoot:(NSString *)bundleRoot;
+
+/**
  * Returns the jsBundleURL for a given bundle entrypoint and
  * the fallback offline JS bundle if the packager is not running.
  * if resourceName or extension are nil, "main" and "jsbundle" will be
@@ -91,14 +96,29 @@ extern NSString *const kRCTPlatformName; // TODO(macOS GH#774)
 + (instancetype)sharedSettings;
 
 /**
- Given a hostname for the packager and a bundle root, returns the URL to the js bundle. Generally you should use the
- instance method -jsBundleURLForBundleRoot:fallbackResource: which includes logic to guess if the packager is running
- and fall back to a pre-packaged bundle if it is not.
+ * Given a hostname for the packager and a bundle root, returns the URL to the js bundle. Generally you should use the
+ * instance method -jsBundleURLForBundleRoot:fallbackResource: which includes logic to guess if the packager is running
+ * and fall back to a pre-packaged bundle if it is not.
+ *
+ * The options here mirror some of Metro's Bundling Options:
+ * - enableDev: Whether to keep or remove `__DEV__` blocks from the bundle.
+ * - enableMinification: Enables or disables minification. Usually production bundles are minified and development
+ *     bundles are not.
+ * - modulesOnly: When true, will only send module definitions without polyfills and without the require-runtime.
+ * - runModule: When true, will run the main module after defining all modules. This is used in the main bundle but not
+ *     in split bundles.
  */
 + (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
                        packagerHost:(NSString *)packagerHost
                           enableDev:(BOOL)enableDev
                  enableMinification:(BOOL)enableMinification;
+
++ (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                       packagerHost:(NSString *)packagerHost
+                          enableDev:(BOOL)enableDev
+                 enableMinification:(BOOL)enableMinification
+                        modulesOnly:(BOOL)modulesOnly
+                          runModule:(BOOL)runModule;
 
 /**
  * Given a hostname for the packager and a resource path (including "/"), return the URL to the resource.

--- a/React/Base/RCTBundleURLProvider.m
+++ b/React/Base/RCTBundleURLProvider.m
@@ -151,6 +151,16 @@ static NSURL *serverRootWithHostPort(NSString *hostPort)
   }
 }
 
+- (NSURL *)jsBundleURLForSplitBundleRoot:(NSString *)bundleRoot
+{
+  return [RCTBundleURLProvider jsBundleURLForBundleRoot:bundleRoot
+                                           packagerHost:[self packagerServerHost]
+                                              enableDev:[self enableDev]
+                                     enableMinification:[self enableMinification]
+                                            modulesOnly:YES
+                                              runModule:NO];
+}
+
 - (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
                    fallbackResource:(NSString *)resourceName
                   fallbackExtension:(NSString *)extension
@@ -192,13 +202,31 @@ static NSURL *serverRootWithHostPort(NSString *hostPort)
                        packagerHost:(NSString *)packagerHost
                           enableDev:(BOOL)enableDev
                  enableMinification:(BOOL)enableMinification
+
+{
+  return [self jsBundleURLForBundleRoot:bundleRoot
+                           packagerHost:packagerHost
+                              enableDev:enableDev
+                     enableMinification:enableMinification
+                            modulesOnly:NO
+                              runModule:YES];
+}
+
++ (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                       packagerHost:(NSString *)packagerHost
+                          enableDev:(BOOL)enableDev
+                 enableMinification:(BOOL)enableMinification
+                        modulesOnly:(BOOL)modulesOnly
+                          runModule:(BOOL)runModule
 {
   NSString *path = [NSString stringWithFormat:@"/%@.bundle", bundleRoot];
   // When we support only iOS 8 and above, use queryItems for a better API.
-  NSString *query = [NSString stringWithFormat:@"platform=%@&dev=%@&minify=%@",
+  NSString *query = [NSString stringWithFormat:@"platform=%@&dev=%@&minify=%@&modulesOnly=%@&runMdoule=%@",
                                                kRCTPlatformName, // TODO(macOS GH#774)
                                                enableDev ? @"true" : @"false",
-                                               enableMinification ? @"true" : @"false"];
+                                               enableMinification ? @"true" : @"false",
+                                               modulesOnly ? @"true" : @"false",
+                                               runModule ? @"true" : @"false"];
   NSString *bundleID = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey];
   if (bundleID) {
     query = [NSString stringWithFormat:@"%@&app=%@", query, bundleID];

--- a/React/Base/RCTModuleData.h
+++ b/React/Base/RCTModuleData.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #import <React/RCTInvalidating.h>
+#import "RCTDefines.h"
 
 @protocol RCTBridgeMethod;
 @protocol RCTBridgeModule;
@@ -94,3 +95,6 @@ typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
 @property (nonatomic, assign, readonly) BOOL implementsPartialBatchDidFlush;
 
 @end
+
+RCT_EXTERN void RCTSetIsMainQueueExecutionOfConstantsToExportDisabled(BOOL val);
+RCT_EXTERN BOOL RCTIsMainQueueExecutionOfConstantsToExportDisabled();

--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -29,6 +29,17 @@ int32_t getUniqueId()
   return counter++;
 }
 }
+static BOOL isMainQueueExecutionOfConstantToExportDisabled = NO;
+
+void RCTSetIsMainQueueExecutionOfConstantsToExportDisabled(BOOL val)
+{
+  isMainQueueExecutionOfConstantToExportDisabled = val;
+}
+
+BOOL RCTIsMainQueueExecutionOfConstantsToExportDisabled()
+{
+  return isMainQueueExecutionOfConstantToExportDisabled;
+}
 
 @implementation RCTModuleData {
   NSDictionary<NSString *, id> *_constantsToExport;
@@ -389,7 +400,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
      *    require.
      */
     BridgeNativeModulePerfLogger::moduleJSRequireEndingStart([moduleName UTF8String]);
-    if (_requiresMainQueueSetup) {
+
+    if (!RCTIsMainQueueExecutionOfConstantsToExportDisabled() && _requiresMainQueueSetup) {
       if (!RCTIsMainQueue()) {
         RCTLogWarn(@"Required dispatch_sync to load constants for %@. This may lead to deadlocks", _moduleClass);
       }
@@ -400,6 +412,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
     } else {
       _constantsToExport = [_instance constantsToExport] ?: @{};
     }
+
     RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
   } else {
     /**

--- a/React/CoreModules/RCTAppState.mm
+++ b/React/CoreModules/RCTAppState.mm
@@ -67,9 +67,14 @@ RCT_EXPORT_MODULE()
 
 - (facebook::react::ModuleConstants<JS::NativeAppState::Constants>)getConstants
 {
-  return facebook::react::typedConstants<JS::NativeAppState::Constants>({
-      .initialAppState = RCTCurrentAppState(),
+  __block facebook::react::ModuleConstants<JS::NativeAppState::Constants> constants;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    constants = facebook::react::typedConstants<JS::NativeAppState::Constants>({
+        .initialAppState = RCTCurrentAppState(),
+    });
   });
+
+  return constants;
 }
 
 #pragma mark - Lifecycle

--- a/React/CoreModules/RCTDeviceInfo.mm
+++ b/React/CoreModules/RCTDeviceInfo.mm
@@ -138,18 +138,23 @@ NSDictionary *RCTExportedDimensions(RCTPlatformView *rootView)
 
 - (NSDictionary<NSString *, id> *)getConstants
 {
-  return @{
+  __block NSDictionary<NSString *, id> *constants;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    constants = @{
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
-    @"Dimensions" : RCTExportedDimensions(_bridge),
+      @"Dimensions" : RCTExportedDimensions(self->_bridge),
 #else // [TODO(macOS GH#774)
-    @"Dimensions": RCTExportedDimensions(nil),
+      @"Dimensions": RCTExportedDimensions(nil),
 #endif // ]TODO(macOS GH#774)
-    // Note:
-    // This prop is deprecated and will be removed in a future release.
-    // Please use this only for a quick and temporary solution.
-    // Use <SafeAreaView> instead.
-    @"isIPhoneX_deprecated" : @(RCTIsIPhoneX()),
-  };
+      // Note:
+      // This prop is deprecated and will be removed in a future release.
+      // Please use this only for a quick and temporary solution.
+      // Use <SafeAreaView> instead.
+      @"isIPhoneX_deprecated" : @(RCTIsIPhoneX()),
+    };
+  });
+
+  return constants;
 }
 
 - (void)didReceiveNewContentSizeMultiplier

--- a/React/CoreModules/RCTPlatform.mm
+++ b/React/CoreModules/RCTPlatform.mm
@@ -58,22 +58,27 @@ RCT_EXPORT_MODULE(PlatformConstants)
 
 - (ModuleConstants<JS::NativePlatformConstantsIOS::Constants>)getConstants
 {
-  UIDevice *device = [UIDevice currentDevice];
-  auto versions = RCTGetReactNativeVersion();
-  return typedConstants<JS::NativePlatformConstantsIOS::Constants>({
-      .forceTouchAvailable = RCTForceTouchAvailable() ? true : false,
-      .osVersion = [device systemVersion],
-      .systemName = [device systemName],
-      .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
-      .isTesting = RCTRunningInTestEnvironment() ? true : false,
-      .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsReactNativeVersion::Builder(
-          {.minor = [versions[@"minor"] doubleValue],
-           .major = [versions[@"major"] doubleValue],
-           .patch = [versions[@"patch"] doubleValue],
-           .prerelease = [versions[@"prerelease"] isKindOfClass:[NSNull class]]
-               ? folly::Optional<double>{}
-               : [versions[@"prerelease"] doubleValue]}),
+  __block ModuleConstants<JS::NativePlatformConstantsIOS::Constants> constants;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    UIDevice *device = [UIDevice currentDevice];
+    auto versions = RCTGetReactNativeVersion();
+    constants = typedConstants<JS::NativePlatformConstantsIOS::Constants>({
+        .forceTouchAvailable = RCTForceTouchAvailable() ? true : false,
+        .osVersion = [device systemVersion],
+        .systemName = [device systemName],
+        .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
+        .isTesting = RCTRunningInTestEnvironment() ? true : false,
+        .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsReactNativeVersion::Builder(
+            {.minor = [versions[@"minor"] doubleValue],
+             .major = [versions[@"major"] doubleValue],
+             .patch = [versions[@"patch"] doubleValue],
+             .prerelease = [versions[@"prerelease"] isKindOfClass:[NSNull class]]
+                 ? folly::Optional<double>{}
+                 : [versions[@"prerelease"] doubleValue]}),
+    });
   });
+
+  return constants;
 }
 
 - (std::shared_ptr<TurboModule>)getTurboModule:(const ObjCTurboModule::InitParams &)params

--- a/React/CoreModules/RCTStatusBarManager.mm
+++ b/React/CoreModules/RCTStatusBarManager.mm
@@ -185,10 +185,15 @@ RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
 
 - (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)getConstants
 {
-  return facebook::react::typedConstants<JS::NativeStatusBarManagerIOS::Constants>({
-      .HEIGHT = RCTSharedApplication().statusBarFrame.size.height,
-      .DEFAULT_BACKGROUND_COLOR = folly::none,
+  __block facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants> constants;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    constants = facebook::react::typedConstants<JS::NativeStatusBarManagerIOS::Constants>({
+        .HEIGHT = RCTSharedApplication().statusBarFrame.size.height,
+        .DEFAULT_BACKGROUND_COLOR = folly::none,
+    });
   });
+
+  return constants;
 }
 
 - (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)constantsToExport

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -280,7 +280,7 @@ struct RCTInstanceCallback : public InstanceCallback {
 {
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-#endif // TODO9macOS GH#774)
+#endif // TODO(macOS GH#774)
 }
 
 + (void)runRunLoop

--- a/React/Fabric/RCTScheduler.mm
+++ b/React/Fabric/RCTScheduler.mm
@@ -114,7 +114,7 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
 
     if (_layoutAnimationsEnabled) {
       _layoutAnimationDelegateProxy = std::make_shared<LayoutAnimationDelegateProxy>((__bridge void *)self);
-      _animationDriver = std::make_unique<LayoutAnimationDriver>(_layoutAnimationDelegateProxy.get());
+      _animationDriver = std::make_shared<LayoutAnimationDriver>(_layoutAnimationDelegateProxy.get());
       _uiRunLoopObserver =
           toolbox.mainRunLoopObserverFactory(RunLoopObserver::Activity::BeforeWaiting, _layoutAnimationDelegateProxy);
       _uiRunLoopObserver->setDelegate(_layoutAnimationDelegateProxy.get());
@@ -152,12 +152,7 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
 
   auto props = convertIdToFollyDynamic(initialProps);
   _scheduler->startSurface(
-      surfaceId,
-      RCTStringFromNSString(moduleName),
-      props,
-      layoutConstraints,
-      layoutContext,
-      (_animationDriver ? _animationDriver.get() : nullptr));
+      surfaceId, RCTStringFromNSString(moduleName), props, layoutConstraints, layoutContext, _animationDriver);
   _scheduler->renderTemplateToSurface(
       surfaceId, props.getDefault("navigationConfig").getDefault("initialUITemplate", "").getString());
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -655,9 +655,9 @@ public class ReactInstanceManager {
     }
   }
 
-  /** Temporary: due to T62192299, log sources of destroy calls. TODO T62192299: delete */
+  /** Temporary: due to T67035147, log sources of destroy calls. TODO T67035147: delete */
   private void logOnDestroy() {
-    FLog.e(
+    FLog.d(
         TAG,
         "ReactInstanceManager.destroy called",
         new RuntimeException("ReactInstanceManager.destroy called"));
@@ -669,7 +669,6 @@ public class ReactInstanceManager {
     UiThreadUtil.assertOnUiThread();
     PrinterHolder.getPrinter().logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: Destroy");
 
-    // TODO T62192299: remove when investigation is complete
     logOnDestroy();
 
     if (mHasStartedDestroying) {
@@ -1134,8 +1133,7 @@ public class ReactInstanceManager {
   }
 
   private void attachRootViewToInstance(final ReactRoot reactRoot) {
-    // TODO: downgrade back to FLog.d once T62192299 is resolved.
-    FLog.e(ReactConstants.TAG, "ReactInstanceManager.attachRootViewToInstance()");
+    FLog.d(ReactConstants.TAG, "ReactInstanceManager.attachRootViewToInstance()");
     Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "attachRootViewToInstance");
 
     @Nullable
@@ -1281,38 +1279,14 @@ public class ReactInstanceManager {
 
     reactContext.initializeWithInstance(catalystInstance);
 
-    if (ReactFeatureFlags.enableTurboModuleDebugLogs) {
-      // TODO(T46487253): Remove after task is closed
-      FLog.e(
-          ReactConstants.TAG,
-          "ReactInstanceManager.createReactContext: mJSIModulePackage "
-              + (mJSIModulePackage != null ? "not null" : "null"));
-    }
-
     if (mJSIModulePackage != null) {
       catalystInstance.addJSIModules(
           mJSIModulePackage.getJSIModules(
               reactContext, catalystInstance.getJavaScriptContextHolder()));
 
-      if (ReactFeatureFlags.enableTurboModuleDebugLogs) {
-        // TODO(T46487253): Remove after task is closed
-        FLog.e(
-            ReactConstants.TAG,
-            "ReactInstanceManager.createReactContext: ReactFeatureFlags.useTurboModules == "
-                + (ReactFeatureFlags.useTurboModules == false ? "false" : "true"));
-      }
-
       if (ReactFeatureFlags.useTurboModules) {
         JSIModule turboModuleManager =
             catalystInstance.getJSIModule(JSIModuleType.TurboModuleManager);
-
-        if (ReactFeatureFlags.enableTurboModuleDebugLogs) {
-          // TODO(T46487253): Remove after task is closed
-          FLog.e(
-              ReactConstants.TAG,
-              "ReactInstanceManager.createReactContext: TurboModuleManager "
-                  + (turboModuleManager == null ? "not created" : "created"));
-        }
 
         catalystInstance.setTurboModuleManager(turboModuleManager);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -523,8 +523,6 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
       mShouldLogContentAppeared = true;
 
-      // TODO T62192299: remove this
-      FLog.e(TAG, "runApplication: call AppRegistry.runApplication");
       catalystInstance.getJSModule(AppRegistry.class).runApplication(jsAppModuleName, appParams);
     } finally {
       Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -582,16 +582,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
   public NativeModule getNativeModule(String moduleName) {
     if (getTurboModuleRegistry() != null) {
       TurboModule turboModule = getTurboModuleRegistry().getModule(moduleName);
-
-      if (ReactFeatureFlags.enableTurboModuleDebugLogs) {
-        // TODO(T46487253): Remove after task is closed
-        FLog.e(
-            ReactConstants.TAG,
-            "CatalystInstanceImpl.getNativeModule: TurboModule "
-                + moduleName
-                + (turboModule == null ? " not" : "")
-                + " found");
-      }
       if (turboModule != null) {
         return (NativeModule) turboModule;
       }
@@ -724,9 +714,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
   }
 
   private void onNativeException(Exception e) {
-    // TODO T62192299: remove this after investigation
-    FLog.e(ReactConstants.TAG, "CatalystInstanceImpl caught native exception", e);
-
     mNativeModuleCallExceptionHandler.handleException(e);
     mReactQueueConfiguration
         .getUIQueueThread()

--- a/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -23,9 +23,6 @@ public class ReactFeatureFlags {
    */
   public static volatile boolean useTurboModules = false;
 
-  /** Should we output debug logs to debug the TurboModule infra? */
-  public static volatile boolean enableTurboModuleDebugLogs = false;
-
   /*
    * This feature flag enables logs for Fabric
    */
@@ -89,4 +86,7 @@ public class ReactFeatureFlags {
 
   /** Feature flag to configure initialization of Fabric surfaces. */
   public static boolean enableFabricStartSurfaceWithLayoutMetrics = true;
+
+  /** Feature flag to have FabricUIManager teardown stop all active surfaces. */
+  public static boolean enableFabricStopAllSurfacesOnTeardown = false;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -9,7 +9,6 @@ package com.facebook.react.devsupport;
 
 import android.view.View;
 import androidx.annotation.Nullable;
-import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.DefaultNativeModuleCallExceptionHandler;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -158,9 +157,6 @@ public class DisabledDevSupportManager implements DevSupportManager {
 
   @Override
   public void handleException(Exception e) {
-    // TODO T62192299: remove this after investigation
-    FLog.e("DisabledDevSupportManager", "Caught exception", e);
-
     mDefaultNativeModuleCallExceptionHandler.handleException(e);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
@@ -13,6 +13,7 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.NativeMap;
+import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.fabric.events.EventBeatManager;
 import com.facebook.react.uimanager.PixelUtil;
@@ -35,6 +36,7 @@ public class Binding {
 
   private native void installFabricUIManager(
       long jsContextNativePointer,
+      RuntimeExecutor runtimeExecutor,
       Object uiManager,
       EventBeatManager eventBeatManager,
       MessageQueueThread jsMessageQueueThread,
@@ -72,8 +74,10 @@ public class Binding {
 
   public native void driveCxxAnimations();
 
+  // TODO (T67721598) Remove the jsContext param once we've migrated to using RuntimeExecutor
   public void register(
       @NonNull JavaScriptContextHolder jsContext,
+      @NonNull RuntimeExecutor runtimeExecutor,
       @NonNull FabricUIManager fabricUIManager,
       @NonNull EventBeatManager eventBeatManager,
       @NonNull MessageQueueThread jsMessageQueueThread,
@@ -82,6 +86,7 @@ public class Binding {
     fabricUIManager.setBinding(this);
     installFabricUIManager(
         jsContext.get(),
+        runtimeExecutor,
         fabricUIManager,
         eventBeatManager,
         jsMessageQueueThread,

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricJSIModuleProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricJSIModuleProvider.java
@@ -74,8 +74,10 @@ public class FabricJSIModuleProvider implements JSIModuleProvider<UIManager> {
             .getCatalystInstance()
             .getReactQueueConfiguration()
             .getJSQueueThread();
+
     binding.register(
         mJSContext,
+        mReactApplicationContext.getCatalystInstance().getRuntimeExecutor(),
         uiManager,
         eventBeatManager,
         jsMessageQueueThread,

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.h
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.h
@@ -10,6 +10,7 @@
 #include <fbjni/fbjni.h>
 #include <react/animations/LayoutAnimationDriver.h>
 #include <react/jni/JMessageQueueThread.h>
+#include <react/jni/JRuntimeExecutor.h>
 #include <react/jni/ReadableNativeMap.h>
 #include <react/scheduler/Scheduler.h>
 #include <react/scheduler/SchedulerDelegate.h>
@@ -50,6 +51,7 @@ class Binding : public jni::HybridClass<Binding>,
 
   void installFabricUIManager(
       jlong jsContextNativePointer,
+      jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutorHolder,
       jni::alias_ref<jobject> javaUIManager,
       EventBeatManager *eventBeatManager,
       jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
@@ -110,7 +112,7 @@ class Binding : public jni::HybridClass<Binding>,
   virtual void onAnimationStarted() override;
   virtual void onAllAnimationsComplete() override;
   LayoutAnimationDriver *getAnimationDriver();
-  std::unique_ptr<LayoutAnimationDriver> animationDriver_;
+  std::shared_ptr<LayoutAnimationDriver> animationDriver_;
 
   std::shared_ptr<Scheduler> scheduler_;
   std::mutex schedulerMutex_;

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/BatchMountItem.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/BatchMountItem.java
@@ -26,13 +26,14 @@ import com.facebook.systrace.Systrace;
 @DoNotStrip
 public class BatchMountItem implements MountItem {
 
+  private final int mRootTag;
   @NonNull private final MountItem[] mMountItems;
 
   private final int mSize;
 
   private final int mCommitNumber;
 
-  public BatchMountItem(MountItem[] items, int size, int commitNumber) {
+  public BatchMountItem(int rootTag, MountItem[] items, int size, int commitNumber) {
     if (items == null) {
       throw new NullPointerException();
     }
@@ -40,6 +41,7 @@ public class BatchMountItem implements MountItem {
       throw new IllegalArgumentException(
           "Invalid size received by parameter size: " + size + " items.size = " + items.length);
     }
+    mRootTag = rootTag;
     mMountItems = items;
     mSize = size;
     mCommitNumber = commitNumber;
@@ -66,6 +68,10 @@ public class BatchMountItem implements MountItem {
     }
 
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+  }
+
+  public int getRootTag() {
+    return mRootTag;
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
@@ -16,6 +16,7 @@ import android.media.MediaMetadataRetriever;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images;
@@ -47,6 +48,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 // TODO #6015104: rename to something less iOSish
@@ -68,21 +70,32 @@ public class CameraRollManager extends NativeCameraRollManagerSpec {
   private static final String ASSET_TYPE_VIDEOS = "Videos";
   private static final String ASSET_TYPE_ALL = "All";
 
-  private static final String[] PROJECTION = {
-    Images.Media._ID,
-    Images.Media.MIME_TYPE,
-    Images.Media.BUCKET_DISPLAY_NAME,
-    Images.Media.DATE_TAKEN,
-    MediaStore.MediaColumns.WIDTH,
-    MediaStore.MediaColumns.HEIGHT,
-    Images.Media.LONGITUDE,
-    Images.Media.LATITUDE,
-    MediaStore.MediaColumns.DATA
-  };
-
   private static final String SELECTION_BUCKET = Images.Media.BUCKET_DISPLAY_NAME + " = ?";
   private static final String SELECTION_DATE_TAKEN = Images.Media.DATE_TAKEN + " < ?";
   private static final String SELECTION_MEDIA_SIZE = Images.Media.SIZE + " < ?";
+
+  private static final int IMAGES_MEDIA_LATITUDE_LONGITUDE_DEPRECATED_API_LEVEL = 29;
+  private static final String[] PROJECTION_LIST;
+
+  static {
+    ArrayList<String> projection_list =
+        new ArrayList<>(
+            Arrays.asList(
+                Images.Media._ID,
+                Images.Media.MIME_TYPE,
+                Images.Media.BUCKET_DISPLAY_NAME,
+                Images.Media.DATE_TAKEN,
+                MediaStore.MediaColumns.WIDTH,
+                MediaStore.MediaColumns.HEIGHT,
+                MediaStore.MediaColumns.DATA));
+    if (Build.VERSION.SDK_INT < IMAGES_MEDIA_LATITUDE_LONGITUDE_DEPRECATED_API_LEVEL) {
+      projection_list.add(Images.Media.LATITUDE);
+      projection_list.add(Images.Media.LONGITUDE);
+      PROJECTION_LIST = projection_list.toArray(new String[0]);
+    } else {
+      PROJECTION_LIST = projection_list.toArray(new String[0]);
+    }
+  }
 
   public CameraRollManager(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -351,7 +364,7 @@ public class CameraRollManager extends NativeCameraRollManagerSpec {
         Cursor media =
             resolver.query(
                 MediaStore.Files.getContentUri("external"),
-                PROJECTION,
+                PROJECTION_LIST,
                 selection.toString(),
                 selectionArgs.toArray(new String[selectionArgs.size()]),
                 Images.Media.DATE_TAKEN
@@ -413,7 +426,9 @@ public class CameraRollManager extends NativeCameraRollManagerSpec {
               resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex, mimeTypeIndex);
       if (imageInfoSuccess) {
         putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, dateTakenIndex);
-        putLocationInfo(media, node, longitudeIndex, latitudeIndex);
+        if (Build.VERSION.SDK_INT < IMAGES_MEDIA_LATITUDE_LONGITUDE_DEPRECATED_API_LEVEL) {
+          putLocationInfo(media, node, longitudeIndex, latitudeIndex);
+        }
 
         edge.putMap("node", node);
         edges.pushMap(edge);

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.JSIModule;
 import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.common.ReactConstants;
-import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleRegistry;
@@ -142,15 +141,6 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
         /*
          * Always return null after cleanup has started, so that getModule(moduleName) returns null.
          */
-
-        if (ReactFeatureFlags.enableTurboModuleDebugLogs) {
-          // TODO(T46487253): Remove after task is closed
-          FLog.e(
-              ReactConstants.TAG,
-              "TurboModuleManager.getOrMaybeCreateTurboModuleHolder: Tried to require TurboModule "
-                  + moduleName
-                  + " after cleanup initiated");
-        }
         return null;
       }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
@@ -104,8 +104,8 @@ public class DisplayMetricsHolder {
   }
 
   public static Map<String, Map<String, Object>> getDisplayMetricsMap(double fontScale) {
-    Assertions.assertNotNull(
-        sWindowDisplayMetrics != null || sScreenDisplayMetrics != null,
+    Assertions.assertCondition(
+        sWindowDisplayMetrics != null && sScreenDisplayMetrics != null,
         "DisplayMetricsHolder must be initialized with initDisplayMetricsIfNotInitialized or initDisplayMetrics");
     final Map<String, Map<String, Object>> result = new HashMap<>();
     result.put("windowPhysicalPixels", getPhysicalPixelsMap(sWindowDisplayMetrics, fontScale));
@@ -114,8 +114,8 @@ public class DisplayMetricsHolder {
   }
 
   public static WritableNativeMap getDisplayMetricsNativeMap(double fontScale) {
-    Assertions.assertNotNull(
-        sWindowDisplayMetrics != null || sScreenDisplayMetrics != null,
+    Assertions.assertCondition(
+        sWindowDisplayMetrics != null && sScreenDisplayMetrics != null,
         "DisplayMetricsHolder must be initialized with initDisplayMetricsIfNotInitialized or initDisplayMetrics");
     final WritableNativeMap result = new WritableNativeMap();
     result.putMap(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
@@ -73,6 +73,10 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider>
         YogaMeasureMode heightMode) {
       if (!mMeasured) {
         SeekBar reactSlider = new ReactSlider(getThemedContext(), null, STYLE);
+        // reactSlider is used for measurements purposes, it is not necessary to set a
+        // StateListAnimator.
+        // It is not safe to access StateListAnimator from a background thread.
+        reactSlider.setStateListAnimator(null);
         final int spec =
             View.MeasureSpec.makeMeasureSpec(
                 ViewGroup.LayoutParams.WRAP_CONTENT, View.MeasureSpec.UNSPECIFIED);

--- a/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
@@ -41,16 +41,12 @@ void JReactMarker::logPerfMarker(
     const char *tag) {
   switch (markerId) {
     case ReactMarker::RUN_JS_BUNDLE_START:
-      LOG(ERROR) << "logMarker RUN_JS_BUNDLE_START"; // TODO T62192299: delete
       JReactMarker::logMarker("RUN_JS_BUNDLE_START", tag);
       break;
     case ReactMarker::RUN_JS_BUNDLE_STOP:
-      LOG(ERROR) << "logMarker RUN_JS_BUNDLE_END"; // TODO T62192299: delete
       JReactMarker::logMarker("RUN_JS_BUNDLE_END", tag);
       break;
     case ReactMarker::CREATE_REACT_CONTEXT_STOP:
-      LOG(ERROR)
-          << "logMarker CREATE_REACT_CONTEXT_END"; // TODO T62192299: delete
       JReactMarker::logMarker("CREATE_REACT_CONTEXT_END");
       break;
     case ReactMarker::JS_BUNDLE_STRING_CONVERT_START:

--- a/ReactCommon/cxxreact/BUCK
+++ b/ReactCommon/cxxreact/BUCK
@@ -149,6 +149,7 @@ rn_xplat_cxx_library(
         "//xplat/folly:headers_only",
         "//xplat/folly:memory",
         "//xplat/folly:molly",
+        "//xplat/jsi:jsi",
         react_native_xplat_target("callinvoker:callinvoker"),
         react_native_xplat_target("jsinspector:jsinspector"),
         react_native_xplat_target("microprofiler:microprofiler"),

--- a/ReactCommon/cxxreact/Instance.cpp
+++ b/ReactCommon/cxxreact/Instance.cpp
@@ -222,7 +222,11 @@ ModuleRegistry &Instance::getModuleRegistry() {
 }
 
 void Instance::handleMemoryPressure(int pressureLevel) {
-  nativeToJsBridge_->handleMemoryPressure(pressureLevel);
+  if (nativeToJsBridge_) {
+    // This class resets `nativeToJsBridge_` only in the destructor,
+    // hence a race is not possible there.
+    nativeToJsBridge_->handleMemoryPressure(pressureLevel);
+  }
 }
 
 std::shared_ptr<CallInvoker> Instance::getJSCallInvoker() {

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -44,4 +44,5 @@ Pod::Spec.new do |s|
   s.dependency "React-callinvoker", version
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-perflogger", version
+  s.dependency "React-jsi", version
 end

--- a/ReactCommon/fabric/components/view/ViewProps.cpp
+++ b/ReactCommon/fabric/components/view/ViewProps.cpp
@@ -92,7 +92,9 @@ ViewProps::ViewProps(ViewProps const &sourceProps, RawProps const &rawProps)
           rawProps,
           "collapsable",
           sourceProps.collapsable,
-          true)){};
+          true)),
+      elevation(
+          convertRawProp(rawProps, "elevation", sourceProps.elevation, {})){};
 
 #pragma mark - Convenience Methods
 

--- a/ReactCommon/fabric/components/view/ViewProps.h
+++ b/ReactCommon/fabric/components/view/ViewProps.h
@@ -59,6 +59,8 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
 
   bool collapsable{true};
 
+  int elevation{};
+
 #pragma mark - Convenience Methods
 
   BorderMetrics resolveBorderMetrics(LayoutMetrics const &layoutMetrics) const;

--- a/ReactCommon/fabric/components/view/ViewShadowNode.cpp
+++ b/ReactCommon/fabric/components/view/ViewShadowNode.cpp
@@ -43,6 +43,7 @@ void ViewShadowNode::initialize() noexcept {
       viewProps.pointerEvents == PointerEventsMode::None ||
       !viewProps.nativeId.empty() || viewProps.accessible ||
       viewProps.opacity != 1.0 || viewProps.transform != Transform{} ||
+      viewProps.elevation != 0 ||
       (viewProps.zIndex != 0 &&
        viewProps.yogaStyle.positionType() == YGPositionTypeAbsolute) ||
       viewProps.getClipsContentToBounds() ||

--- a/ReactCommon/fabric/mounting/MountingCoordinator.h
+++ b/ReactCommon/fabric/mounting/MountingCoordinator.h
@@ -40,7 +40,7 @@ class MountingCoordinator final {
    */
   MountingCoordinator(
       ShadowTreeRevision baseRevision,
-      MountingOverrideDelegate *delegate);
+      std::weak_ptr<MountingOverrideDelegate const> delegate);
 
   /*
    * Returns the id of the surface that the coordinator belongs to.
@@ -102,7 +102,7 @@ class MountingCoordinator final {
   mutable better::optional<ShadowTreeRevision> lastRevision_{};
   mutable MountingTransaction::Number number_{0};
   mutable std::condition_variable signal_;
-  mutable MountingOverrideDelegate *mountingOverrideDelegate_{nullptr};
+  std::weak_ptr<MountingOverrideDelegate const> mountingOverrideDelegate_;
 
 #ifdef RN_SHADOW_TREE_INTROSPECTION
   void validateTransactionAgainstStubViewTree(

--- a/ReactCommon/fabric/mounting/ShadowTree.cpp
+++ b/ReactCommon/fabric/mounting/ShadowTree.cpp
@@ -222,7 +222,7 @@ ShadowTree::ShadowTree(
     LayoutContext const &layoutContext,
     RootComponentDescriptor const &rootComponentDescriptor,
     ShadowTreeDelegate const &delegate,
-    MountingOverrideDelegate *mountingOverrideDelegate)
+    std::weak_ptr<MountingOverrideDelegate const> mountingOverrideDelegate)
     : surfaceId_(surfaceId), delegate_(delegate) {
   const auto noopEventEmitter = std::make_shared<const ViewEventEmitter>(
       nullptr, -1, std::shared_ptr<const EventDispatcher>());

--- a/ReactCommon/fabric/mounting/ShadowTree.h
+++ b/ReactCommon/fabric/mounting/ShadowTree.h
@@ -40,7 +40,7 @@ class ShadowTree final {
       LayoutContext const &layoutContext,
       RootComponentDescriptor const &rootComponentDescriptor,
       ShadowTreeDelegate const &delegate,
-      MountingOverrideDelegate *mountingOverrideDelegate);
+      std::weak_ptr<MountingOverrideDelegate const> mountingOverrideDelegate);
 
   ~ShadowTree();
 

--- a/ReactCommon/fabric/mounting/tests/StateReconciliationTest.cpp
+++ b/ReactCommon/fabric/mounting/tests/StateReconciliationTest.cpp
@@ -104,7 +104,7 @@ TEST(StateReconciliationTest, testStateReconciliation) {
                         LayoutContext{},
                         rootComponentDescriptor,
                         shadowTreeDelegate,
-                        nullptr};
+                        {}};
 
   shadowTree.commit(
       [&](RootShadowNode::Shared const &oldRootShadowNode) {

--- a/ReactCommon/fabric/scheduler/Scheduler.cpp
+++ b/ReactCommon/fabric/scheduler/Scheduler.cpp
@@ -127,6 +127,7 @@ Scheduler::~Scheduler() {
 
   // The thread-safety of this operation is guaranteed by this requirement.
   uiManager_->setDelegate(nullptr);
+  uiManager_->setAnimationDelegate(nullptr);
 
   // Then, let's verify that the requirement was satisfied.
   auto surfaceIds = std::vector<SurfaceId>{};
@@ -173,7 +174,8 @@ void Scheduler::startSurface(
     const folly::dynamic &initialProps,
     const LayoutConstraints &layoutConstraints,
     const LayoutContext &layoutContext,
-    MountingOverrideDelegate *mountingOverrideDelegate) const {
+    std::weak_ptr<MountingOverrideDelegate const> mountingOverrideDelegate)
+    const {
   SystraceSection s("Scheduler::startSurface");
 
   auto shadowTree = std::make_unique<ShadowTree>(

--- a/ReactCommon/fabric/scheduler/Scheduler.h
+++ b/ReactCommon/fabric/scheduler/Scheduler.h
@@ -46,7 +46,8 @@ class Scheduler final : public UIManagerDelegate {
       const folly::dynamic &initialProps,
       const LayoutConstraints &layoutConstraints = {},
       const LayoutContext &layoutContext = {},
-      MountingOverrideDelegate *mountingOverrideDelegate = nullptr) const;
+      std::weak_ptr<MountingOverrideDelegate const> mountingOverrideDelegate =
+          {}) const;
 
   void renderTemplateToSurface(
       SurfaceId surfaceId,

--- a/ReactCommon/fabric/uimanager/UIManager.cpp
+++ b/ReactCommon/fabric/uimanager/UIManager.cpp
@@ -318,8 +318,7 @@ void UIManager::shadowTreeDidFinishTransaction(
 
 #pragma mark - UIManagerAnimationDelegate
 
-void UIManager::setAnimationDelegate(
-    UIManagerAnimationDelegate *delegate) const {
+void UIManager::setAnimationDelegate(UIManagerAnimationDelegate *delegate) {
   animationDelegate_ = delegate;
 }
 

--- a/ReactCommon/fabric/uimanager/UIManager.h
+++ b/ReactCommon/fabric/uimanager/UIManager.h
@@ -46,7 +46,7 @@ class UIManager final : public ShadowTreeDelegate {
    * The delegate is stored as a raw pointer, so the owner must null
    * the pointer before being destroyed.
    */
-  void setAnimationDelegate(UIManagerAnimationDelegate *delegate) const;
+  void setAnimationDelegate(UIManagerAnimationDelegate *delegate);
 
   void animationTick();
 
@@ -140,7 +140,7 @@ class UIManager final : public ShadowTreeDelegate {
 
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   UIManagerDelegate *delegate_;
-  mutable UIManagerAnimationDelegate *animationDelegate_{nullptr};
+  UIManagerAnimationDelegate *animationDelegate_{nullptr};
   UIManagerBinding *uiManagerBinding_;
   ShadowTreeRegistry shadowTreeRegistry_{};
 };

--- a/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -981,19 +981,6 @@ TEST_P(JSITest, JSErrorsCanBeConstructedWithStack) {
 }
 
 TEST_P(JSITest, JSErrorDoesNotInfinitelyRecurse) {
-  Value globalString = rt.global().getProperty(rt, "String");
-  rt.global().setProperty(rt, "String", Value::undefined());
-  try {
-    eval("throw Error('whoops')");
-    FAIL() << "expected exception";
-  } catch (const JSError& ex) {
-    EXPECT_EQ(
-        ex.getMessage(),
-        "[Exception while creating message string: callGlobalFunction: "
-        "JS global property 'String' is undefined, expected a Function]");
-  }
-  rt.global().setProperty(rt, "String", globalString);
-
   Value globalError = rt.global().getProperty(rt, "Error");
   rt.global().setProperty(rt, "Error", Value::undefined());
   try {
@@ -1270,6 +1257,70 @@ TEST_P(JSITest, SymbolTest) {
   EXPECT_TRUE(Value::strictEquals(
       rt, eval("Symbol.for('a')"), eval("Symbol.for('a')")));
   EXPECT_FALSE(Value::strictEquals(rt, eval("Symbol('a')"), eval("'a'")));
+}
+
+TEST_P(JSITest, JSErrorTest) {
+  // JSError creation can lead to further errors.  Make sure these
+  // cases are handled and don't cause weird crashes or other issues.
+  //
+  // Getting message property can throw
+
+  EXPECT_THROW(
+      eval("var GetMessageThrows = {get message() { throw Error('ex'); }};"
+           "throw GetMessageThrows;"),
+      JSIException);
+
+  EXPECT_THROW(
+      eval("var GetMessageThrows = {get message() { throw GetMessageThrows; }};"
+           "throw GetMessageThrows;"),
+      JSIException);
+
+  // Converting exception message to String can throw
+
+  EXPECT_THROW(
+      eval(
+          "Object.defineProperty("
+          "  globalThis, 'String', {configurable:true, get() { var e = Error(); e.message = 23; throw e; }});"
+          "var e = Error();"
+          "e.message = 17;"
+          "throw e;"),
+      JSIException);
+
+  EXPECT_THROW(
+      eval(
+          "var e = Error();"
+          "Object.defineProperty("
+          "  e, 'message', {configurable:true, get() { throw Error('getter'); }});"
+          "throw e;"),
+      JSIException);
+
+  EXPECT_THROW(
+      eval("var e = Error();"
+           "String = function() { throw Error('ctor'); };"
+           "throw e;"),
+      JSIException);
+
+  // Converting an exception message to String can return a non-String
+
+  EXPECT_THROW(
+      eval("String = function() { return 42; };"
+           "var e = Error();"
+           "e.message = 17;"
+           "throw e;"),
+      JSIException);
+
+  // Exception can be non-Object
+
+  EXPECT_THROW(eval("throw 17;"), JSIException);
+
+  EXPECT_THROW(eval("throw undefined;"), JSIException);
+
+  // Converting exception with no message or stack property to String can throw
+
+  EXPECT_THROW(
+      eval("var e = {toString() { throw new Error('errstr'); }};"
+           "throw e;"),
+      JSIException);
 }
 
 //----------------------------------------------------------------------

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
@@ -40,7 +40,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     id<RCTTurboModule> instance;
     std::shared_ptr<CallInvoker> jsInvoker;
     std::shared_ptr<CallInvoker> nativeInvoker;
-    // Does the NativeModule dispatch async methods to the JS thread?
     bool isSyncModule;
   };
 
@@ -61,16 +60,20 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
   void setMethodArgConversionSelector(NSString *methodName, int argIndex, NSString *fnName);
 
  private:
+  // Does the NativeModule dispatch async methods to the JS thread?
+  const bool isSyncModule_;
+
   /**
    * TODO(ramanpreet):
    * Investigate an optimization that'll let us get rid of this NSMutableDictionary.
    */
   NSMutableDictionary<NSString *, NSMutableArray *> *methodArgConversionSelectors_;
   NSDictionary<NSString *, NSArray<NSString *> *> *methodArgumentTypeNames_;
-  const bool isSyncModule_;
-  bool isMethodSync(TurboModuleMethodValueKind returnType);
-  NSString *getArgumentTypeName(NSString *methodName, int argIndex);
 
+  bool isMethodSync(TurboModuleMethodValueKind returnType);
+  BOOL hasMethodArgConversionSelector(NSString *methodName, int argIndex);
+  SEL getMethodArgConversionSelector(NSString *methodName, int argIndex);
+  NSString *getArgumentTypeName(NSString *methodName, int argIndex);
   NSInvocation *getMethodInvocation(
       jsi::Runtime &runtime,
       TurboModuleMethodValueKind returnType,
@@ -85,9 +88,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
       const char *methodName,
       NSInvocation *inv,
       NSMutableArray *retainedObjectsForInvocation);
-
-  BOOL hasMethodArgConversionSelector(NSString *methodName, int argIndex);
-  SEL getMethodArgConversionSelector(NSString *methodName, int argIndex);
 
   using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
   jsi::Value

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.mm
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.mm
@@ -361,7 +361,7 @@ jsi::Value ObjCTurboModule::performMethodInvocation(
   };
 
   if (wasMethodSync) {
-    nativeInvoker_->invokeSync([block]() -> void { block(); });
+    block();
   } else {
     asyncCallCounter = getUniqueId();
     TurboModulePerfLogger::asyncMethodCallDispatch(moduleName, methodName);

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.h
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.h
@@ -11,6 +11,8 @@
 
 #import "RCTTurboModule.h"
 
+#import <ReactCommon/RuntimeExecutor.h>
+
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 
 // TODO: Move to xplat codegen.
@@ -45,7 +47,7 @@
                       delegate:(id<RCTTurboModuleManagerDelegate>)delegate
                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
 
-- (void)installJSBindingWithRuntime:(facebook::jsi::Runtime *)runtime;
+- (void)installJSBindingWithRuntimeExecutor:(facebook::react::RuntimeExecutor)runtimeExecutor;
 
 - (void)invalidate;
 

--- a/ReactCommon/turbomodule/samples/platform/ios/RCTSampleTurboModule.mm
+++ b/ReactCommon/turbomodule/samples/platform/ios/RCTSampleTurboModule.mm
@@ -8,6 +8,7 @@
 #import "RCTSampleTurboModule.h"
 
 #import <React/RCTUIKit.h> // TODO(macOS GH#774)
+#import <React/RCTUtils.h>
 
 using namespace facebook::react;
 
@@ -45,19 +46,24 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)getConstants
 {
+  __block NSDictionary *constants;
+  RCTUnsafeExecuteOnMainQueueSync(^{
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
-  UIScreen *mainScreen = UIScreen.mainScreen;
-  CGSize screenSize = mainScreen.bounds.size;
+    UIScreen *mainScreen = UIScreen.mainScreen;
+    CGSize screenSize = mainScreen.bounds.size;
 #else // [TODO(macOS GH#774)
-  NSScreen *mainScreen = NSScreen.mainScreen;
-  CGSize screenSize = mainScreen.frame.size;
+    NSScreen *mainScreen = NSScreen.mainScreen;
+    CGSize screenSize = mainScreen.frame.size;
 #endif // ]TODO(macOS GH#774)
 
-  return @{
-    @"const1" : @YES,
-    @"const2" : @(screenSize.width),
-    @"const3" : @"something",
-  };
+    constants = @{
+      @"const1" : @YES,
+      @"const2" : @(screenSize.width),
+      @"const3" : @"something",
+    };
+  });
+
+  return constants;
 }
 
 // TODO: Remove once fully migrated to TurboModule.

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "eslint-plugin-react-hooks": "^3.0.0",
     "eslint-plugin-react-native": "3.8.1",
     "eslint-plugin-relay": "1.7.1",
-    "flow-bin": "^0.125.1",
+    "flow-bin": "^0.126.1",
     "flow-remove-types": "1.2.3",
     "hermes-engine-darwin": "~0.5.0",
     "jest": "^26.0.1",

--- a/template/_flowconfig
+++ b/template/_flowconfig
@@ -69,4 +69,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.125.0
+^0.126.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,6 +1950,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-bind@^1.0.0, call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -2514,7 +2522,7 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-define-properties@^1.1.2:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -2694,6 +2702,29 @@ errorhandler@^1.5.0:
     accepts "~1.3.7"
     escape-html "~1.0.3"
 
+es-abstract@^1.10.0:
+  version "1.18.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.5.tgz#9b10de7d4c206a3581fd5b2124233e04db49ae19"
+  integrity sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.3"
+    is-string "^1.0.6"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
 es-abstract@^1.11.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
@@ -2721,6 +2752,15 @@ es-to-primitive@^1.1.1, es-to-primitive@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
   integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
@@ -3279,10 +3319,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-bin@^0.125.1:
-  version "0.125.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.125.1.tgz#7edbc71e7dc39ddef18086ef75c714bbf1c5917f"
-  integrity sha512-jEury9NTXylxQEOAXLWEE945BjBwYcMwwKVnb+5XORNwMQE7i5hQYF0ysYfsaaYOa7rW/U16rHBfwLuaZfWV7A==
+flow-bin@^0.126.1:
+  version "0.126.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.126.1.tgz#2726595e1891dc35b379b5994627432df4ead52c"
+  integrity sha512-RI05x7rVzruRVJQN3M4vLEjZMwUHJKhGz9FmL8HN7WiSo66/131EyJS6Vo8PkKyM2pgT9GRWfGP/tXlqS54XUg==
 
 flow-parser@0.*:
   version "0.89.0"
@@ -3418,6 +3458,15 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-port@^2.1.0:
   version "2.1.0"
@@ -3560,6 +3609,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3574,6 +3628,18 @@ has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
   integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -3776,6 +3842,15 @@ inquirer@^5.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
@@ -3817,6 +3892,21 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-bigint@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
+  integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
+  dependencies:
+    has-bigints "^1.0.1"
+
+is-boolean-object@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
+  integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -3826,6 +3916,11 @@ is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
+is-callable@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -3910,6 +4005,18 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.0.0.tgz#038c31b774709641bda678b1f06a4e3227c10b3e"
   integrity sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==
 
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-number-object@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0"
+  integrity sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -3946,6 +4053,14 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
+is-regex@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
@@ -3961,12 +4076,26 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
+is-string@^1.0.5, is-string@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-symbol@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
   integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
   dependencies:
     has-symbols "^1.0.0"
+
+is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
+  dependencies:
+    has-symbols "^1.0.2"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -5671,7 +5800,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11:
+object-inspect@^1.11.0, object-inspect@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
+object-keys@^1.0.11, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -5697,6 +5831,16 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.fromentries@^2.0.0:
   version "2.0.0"
@@ -6348,6 +6492,14 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexp.prototype.flags@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 regexpp@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
@@ -6809,6 +6961,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -7097,6 +7258,22 @@ string.prototype.matchall@^2.0.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     regexp.prototype.flags "^1.2.0"
+
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -7487,6 +7664,16 @@ ultron@~1.1.0:
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -7694,6 +7881,17 @@ whatwg-url@^8.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^2.0.0"
     webidl-conversions "^5.0.0"
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,9 +1303,9 @@ acorn-walk@^7.1.1:
   integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
 
 acorn@^6.0.2:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
-  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
 acorn@^7.1.1:
   version "7.1.1"
@@ -1328,11 +1328,11 @@ ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 ajv@^6.0.1, ajv@^6.5.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
-  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
-    fast-deep-equal "^2.0.1"
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -2452,9 +2452,9 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
     ms "2.0.0"
 
 debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
 
@@ -2694,7 +2694,7 @@ errorhandler@^1.5.0:
     accepts "~1.3.7"
     escape-html "~1.0.3"
 
-es-abstract@^1.10.0, es-abstract@^1.11.0:
+es-abstract@^1.11.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
@@ -2885,14 +2885,21 @@ eslint-scope@^4.0.0:
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
-  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@5.1.0:
   version "5.1.0"
@@ -3131,11 +3138,6 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
@@ -3151,7 +3153,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -5753,7 +5755,7 @@ open@^6.2.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
@@ -5764,6 +5766,18 @@ optionator@^0.8.1, optionator@^0.8.2:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+optionator@^0.8.2:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
 
 options@>=0.0.5:
   version "0.0.6"
@@ -6333,13 +6347,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
-
-regexp.prototype.flags@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
-  integrity sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==
-  dependencies:
-    define-properties "^1.1.2"
 
 regexpp@^1.1.0:
   version "1.1.0"
@@ -7713,6 +7720,11 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+word-wrap@~1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Merge facebook/react-native's main branch into react-native-macos's main branch through 2020-06-07 23:59:59 PDT (specifically, a50fa552a7e07f611d626fae99a6ef80845d9d4d).

These changes were made by repeatedly running git merge <commit-id> and resolving merge conflicts as needed.

The only commit that hasn't been brought over is a4757d28235617b6448ea962b66e2ee0c88ca331. See #813 for more information.

## Validation

* yarn lint
* * ✖ 66 problems (0 errors, 66 warnings)
* yarn flow-check-ios
* yarn flow-check-macos
* yarn flow-check-android
* yarn test
* * Test Suites: 128 passed, 128 total
* * Tests: 1 skipped, 1247 passed, 1248 total
* * Snapshots: 573 passed, 573 total
* RNTester compiles on macOS and iOS, and no new regressions have been found
