### PR TITLE
Fix RNTester folder name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ specific information, like API docs and blog updates live. We are bootstrapping 
 ### Examples
 
 - Using the CLI in the [Getting Started](https://microsoft.github.io/react-native-windows/docs/rnm-getting-started) guide will set you up with a sample React Native for macOS app that you can begin editing right away.
-- If you're looking for sample code, just browse the [RNTester folder](https://github.com/microsoft/react-native-macos/tree/master/RNTester) for examples
+- If you're looking for sample code, just browse the [RNTester folder](https://github.com/microsoft/react-native-macos/tree/master/packages/rn-tester) for examples
 
 ## License
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

I was looking for a package like this, and whilst looking at the README I clicked a dead link.
I found what I think it was supposed to be, and fixed the link.

## Changelog

[General] [Fixed] - Fixed dead link in README.md

## Test Plan

No code changes were made.
