### PR TITLE
Use yarn in a few places that are using npm

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -48,9 +48,9 @@ jobs:
         condition: and(ne(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.SourceBranchName'], variables.latestStableBranch))
 
       - task: CmdLine@2
-        displayName: npm install
+        displayName: yarn install
         inputs:
-          script: npm install
+          script: yarn install --frozen-lockfile
 
       - task: CmdLine@2
         displayName: Bump stable package version

--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -26,9 +26,9 @@ steps:
       script: node .ado/renamePackageForOffice.js
 
   - task: CmdLine@2
-    displayName: npm install
+    displayName: yarn install
     inputs:
-      script: npm install
+      script: yarn install --frozen-lockfile
 
   - task: CmdLine@2
     displayName: Bump canary package version

--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -22,7 +22,7 @@ steps:
     inputs:
       script: |
         cd packages/react-native-macos-init
-        yarn install
+        yarn install --frozen-lockfile
 
   - task: CmdLine@2
     displayName: yarn build (local react-native-macos-init)

--- a/android-patches/build.sh
+++ b/android-patches/build.sh
@@ -6,7 +6,7 @@ chmod -R +r .
 
 mono ./nuget-bin/nuget.exe restore ./ReactAndroid/packages.config -PackagesDirectory ./ReactAndroid/packages/ -Verbosity Detailed -NonInteractive
 
-npm install
+yarn install --frozen-lockfile
 
 chmod +x .ado/setup_droid_deps.sh && .ado/setup_droid_deps.sh
 

--- a/android-patches/scripts/patch.sh
+++ b/android-patches/scripts/patch.sh
@@ -15,7 +15,7 @@ RUNBUNDLE=1
 if [["$RUNBUNDLE" == "1"]]; then
   SCRIPT=$DIR/../bundle/bundle.js
 else then
-# Make sure to npm install.
+# Make sure to yarn install.
   SCRIPT=$DIR/../dist/index.js
 )
 

--- a/scripts/vsto-test-ci.sh
+++ b/scripts/vsto-test-ci.sh
@@ -12,8 +12,8 @@ rm -rf node_modules
 
 # Begin VSTO build agent tasks
 
-# npm install
-npm install
+# yarn install
+yarn install
 
 # Setup packager and WebSocket test server
 . ./scripts/vsto-test-setup.sh


### PR DESCRIPTION
The main repo is now using yarn workspaces, with a yarn lockfile.  The various CI tasks need to use yarn to pickup the workspace definition and the lockfile.  