### PR TITLE
Add the missing android folder to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "scripts/react-native-xcode.sh",
     "template.config.js",
     "template",
-    "third-party-podspecs"
+    "third-party-podspecs",
+    "android"
   ],
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION


#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [*] I am making a change required for Microsoft usage of react-native

## Summary

The android folder got missing in the files section of package.json during 0.64 merge from upstream.
Due to this the internal builds which were dependent on this folder being present in internal npm package were failing

