### PR TITLE
Remove deprecated/unused context param

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -483,7 +483,7 @@ static BOOL RCTAnyTouchesChanged(NSSet *touches) // [TODO(macOS GH#774)
                                       modifierFlags:[event modifierFlags]
                                           timestamp:[event timestamp]
                                        windowNumber:[event windowNumber]
-                                            context:[event context]
+                                            context:nil
                                         eventNumber:[event eventNumber]
                                          clickCount:[event clickCount]
                                            pressure:[event pressure]];


### PR DESCRIPTION
## Summary

Remove deprecated context param when creating macOS event. The parameter is unused and should be nil, as per Xcode warning.

## Test Plan

N/A