### PR TITLE
fix: ensure scripts always have Unix newlines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure scripts always have Unix newlines, even on Windows.
+*.command  text eol=lf
+*.sh       text eol=lf


### PR DESCRIPTION
#### Please select one of the following

- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

`pod install` is currently failing on latest canary with an error message: `: command not found`. This is caused by Windows newlines in shell scripts. The added `.gitattributes` file should ensure that they will always be checked out with Unix newlines, even on Windows machines.

Fixes #850

## Changelog

[General] [Fixed] - Shell scripts fail to execute because they contain Windows newlines.

## Test Plan

Check out the branch on a Windows machine and ensure that scripts (e.g. `scripts/ios-configure-glog.sh`) don't contain carriage return (`\r`). Alternatively, verify that Git has the correct attributes set with:

```
git ls-files | git check-attr --stdin -a
```