### PR TITLE
fix: (0.63-stable) Post NSAccessibilityLayoutChangedNotification when we call setAccessibilityFocus on macOS

### DIFF
--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.63.41)
-  - FBReactNativeSpec (0.63.41):
+  - FBLazyVector (0.63.42)
+  - FBReactNativeSpec (0.63.42):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.41)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
+    - RCTRequired (= 0.63.42)
+    - RCTTypeSafety (= 0.63.42)
+    - React-Core (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -19,283 +19,283 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.63.41)
-  - RCTTypeSafety (0.63.41):
-    - FBLazyVector (= 0.63.41)
+  - RCTRequired (0.63.42)
+  - RCTTypeSafety (0.63.42):
+    - FBLazyVector (= 0.63.42)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.41)
-    - React-Core (= 0.63.41)
-  - React (0.63.41):
-    - React-Core (= 0.63.41)
-    - React-Core/DevSupport (= 0.63.41)
-    - React-Core/RCTWebSocket (= 0.63.41)
-    - React-RCTActionSheet (= 0.63.41)
-    - React-RCTAnimation (= 0.63.41)
-    - React-RCTBlob (= 0.63.41)
-    - React-RCTImage (= 0.63.41)
-    - React-RCTLinking (= 0.63.41)
-    - React-RCTNetwork (= 0.63.41)
-    - React-RCTSettings (= 0.63.41)
-    - React-RCTText (= 0.63.41)
-    - React-RCTVibration (= 0.63.41)
-  - React-ART (0.63.41):
-    - React-Core/ARTHeaders (= 0.63.41)
-  - React-callinvoker (0.63.41)
-  - React-Core (0.63.41):
+    - RCTRequired (= 0.63.42)
+    - React-Core (= 0.63.42)
+  - React (0.63.42):
+    - React-Core (= 0.63.42)
+    - React-Core/DevSupport (= 0.63.42)
+    - React-Core/RCTWebSocket (= 0.63.42)
+    - React-RCTActionSheet (= 0.63.42)
+    - React-RCTAnimation (= 0.63.42)
+    - React-RCTBlob (= 0.63.42)
+    - React-RCTImage (= 0.63.42)
+    - React-RCTLinking (= 0.63.42)
+    - React-RCTNetwork (= 0.63.42)
+    - React-RCTSettings (= 0.63.42)
+    - React-RCTText (= 0.63.42)
+    - React-RCTVibration (= 0.63.42)
+  - React-ART (0.63.42):
+    - React-Core/ARTHeaders (= 0.63.42)
+  - React-callinvoker (0.63.42)
+  - React-Core (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-Core/Default (= 0.63.42)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/ARTHeaders (0.63.41):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
-    - Yoga
-  - React-Core/CoreModulesHeaders (0.63.41):
+  - React-Core/ARTHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/Default (0.63.41):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
-    - Yoga
-  - React-Core/DevSupport (0.63.41):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.41)
-    - React-Core/RCTWebSocket (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
-    - React-jsinspector (= 0.63.41)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.41):
+  - React-Core/CoreModulesHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.41):
+  - React-Core/Default (0.63.42):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
+    - Yoga
+  - React-Core/DevSupport (0.63.42):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.63.42)
+    - React-Core/RCTWebSocket (= 0.63.42)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
+    - React-jsinspector (= 0.63.42)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.41):
+  - React-Core/RCTAnimationHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.41):
+  - React-Core/RCTBlobHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.41):
+  - React-Core/RCTImageHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.41):
+  - React-Core/RCTLinkingHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.63.41):
+  - React-Core/RCTNetworkHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.41):
+  - React-Core/RCTPushNotificationHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.41):
+  - React-Core/RCTSettingsHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.41):
+  - React-Core/RCTTextHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.41):
+  - React-Core/RCTVibrationHeaders (0.63.42):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
     - Yoga
-  - React-CoreModules (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+  - React-Core/RCTWebSocket (0.63.42):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/CoreModulesHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-RCTImage (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-cxxreact (0.63.41):
+    - React-Core/Default (= 0.63.42)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-jsiexecutor (= 0.63.42)
+    - Yoga
+  - React-CoreModules (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.42)
+    - React-Core/CoreModulesHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-RCTImage (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-cxxreact (0.63.42):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-jsinspector (= 0.63.41)
-  - React-jsi (0.63.41):
+    - React-callinvoker (= 0.63.42)
+    - React-jsinspector (= 0.63.42)
+  - React-jsi (0.63.42):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.63.41)
-  - React-jsi/Default (0.63.41):
+    - React-jsi/Default (= 0.63.42)
+  - React-jsi/Default (0.63.42):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.63.41):
+  - React-jsiexecutor (0.63.42):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-  - React-jsinspector (0.63.41)
-  - React-RCTActionSheet (0.63.41):
-    - React-Core/RCTActionSheetHeaders (= 0.63.41)
-  - React-RCTAnimation (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+  - React-jsinspector (0.63.42)
+  - React-RCTActionSheet (0.63.42):
+    - React-Core/RCTActionSheetHeaders (= 0.63.42)
+  - React-RCTAnimation (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTAnimationHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTBlob (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - RCTTypeSafety (= 0.63.42)
+    - React-Core/RCTAnimationHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTBlob (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.41)
-    - React-Core/RCTWebSocket (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-RCTNetwork (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTImage (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - React-Core/RCTBlobHeaders (= 0.63.42)
+    - React-Core/RCTWebSocket (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-RCTNetwork (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTImage (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTImageHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-RCTNetwork (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTLinking (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
-    - React-Core/RCTLinkingHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTNetwork (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - RCTTypeSafety (= 0.63.42)
+    - React-Core/RCTImageHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - React-RCTNetwork (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTLinking (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
+    - React-Core/RCTLinkingHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTNetwork (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTNetworkHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTPushNotification (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTPushNotificationHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTSettings (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - RCTTypeSafety (= 0.63.42)
+    - React-Core/RCTNetworkHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTPushNotification (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
+    - RCTTypeSafety (= 0.63.42)
+    - React-Core/RCTPushNotificationHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTSettings (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTSettingsHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTTest (0.63.41):
+    - RCTTypeSafety (= 0.63.42)
+    - React-Core/RCTSettingsHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTTest (0.63.42):
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core (= 0.63.41)
-    - React-CoreModules (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTText (0.63.41):
-    - React-Core/RCTTextHeaders (= 0.63.41)
-  - React-RCTVibration (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - React-Core (= 0.63.42)
+    - React-CoreModules (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-RCTText (0.63.42):
+    - React-Core/RCTTextHeaders (= 0.63.42)
+  - React-RCTVibration (0.63.42):
+    - FBReactNativeSpec (= 0.63.42)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-TurboModuleCxx-RNW (0.63.41):
+    - React-Core/RCTVibrationHeaders (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-TurboModuleCxx-RNW (0.63.42):
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-TurboModuleCxx-WinRTPort (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-TurboModuleCxx-WinRTPort (0.63.41):
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.41)
-    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.63.41)
-  - React-TurboModuleCxx-WinRTPort/Shared (0.63.41)
-  - React-TurboModuleCxx-WinRTPort/WinRT (0.63.41):
-    - React-callinvoker (= 0.63.41)
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.41)
-  - ReactCommon/turbomodule/core (0.63.41):
+    - React-callinvoker (= 0.63.42)
+    - React-TurboModuleCxx-WinRTPort (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
+  - React-TurboModuleCxx-WinRTPort (0.63.42):
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.42)
+    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.63.42)
+  - React-TurboModuleCxx-WinRTPort/Shared (0.63.42)
+  - React-TurboModuleCxx-WinRTPort/WinRT (0.63.42):
+    - React-callinvoker (= 0.63.42)
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.42)
+  - ReactCommon/turbomodule/core (0.63.42):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-Core (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-  - ReactCommon/turbomodule/samples (0.63.41):
+    - React-callinvoker (= 0.63.42)
+    - React-Core (= 0.63.42)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+  - ReactCommon/turbomodule/samples (0.63.42):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-Core (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
+    - React-callinvoker (= 0.63.42)
+    - React-Core (= 0.63.42)
+    - React-cxxreact (= 0.63.42)
+    - React-jsi (= 0.63.42)
+    - ReactCommon/turbomodule/core (= 0.63.42)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -404,36 +404,36 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: 9dde2e0340ba783233dba7c6b77e65889047fbb3
-  FBReactNativeSpec: 6088d5ab01851853cc3fc5384d3f5edf7c898e54
+  FBLazyVector: e05d2910307c0a86ff548acdffed2ab0901bdb78
+  FBReactNativeSpec: cb9877a821a0a3d3eb2f9dc47db63d93b29be866
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 64eedb6cf5f0ae7d4c3925e0b9a87747d0391735
-  RCTTypeSafety: a8ce68a3ce4aa22cd6a9cbf09607ad2b016b51d5
-  React: a8f98b76204f8a85b22311e8fe145b7bbe5b80e5
-  React-ART: ba4b53b0d3948e3c98242e57369d83a437d3338e
-  React-callinvoker: 523751195c41602db85fa2889e44a6afae271e3a
-  React-Core: b0b37e0216951b0706bdcec7b7fb9400d8167433
-  React-CoreModules: 3e81ecb9ea29b3a4eba630fad23d42747bb28c4c
-  React-cxxreact: 745b1fb1cfc8133c5ab52177172128fba3bc7411
-  React-jsi: 5d60daef9bfdfb1f2b7d69281643a113c99844d3
-  React-jsiexecutor: 235cf6a0975b88e7c3c56f1862e5ec3512993e47
-  React-jsinspector: d067ff9e6a75ffc7472ca71007ba47cdfcc8cc1c
-  React-RCTActionSheet: 5d6d53371715660224937186559d0d3019b79621
-  React-RCTAnimation: eb2094b698230b3750722074419baebfb40dba06
-  React-RCTBlob: 03d37739783ed896197505ad6268efcb3ffe4643
-  React-RCTImage: 0fe6e8aa7b8d986b464d176da8998ea2ddd91690
-  React-RCTLinking: f07a3e0e6c0be023c0bb9eac06825a06cc7485f3
-  React-RCTNetwork: 8f1d5d7bf12d75fd5505c3beb0f868a77843f148
-  React-RCTPushNotification: 44e7bff3ed11f81de9c1f5b7f721046fa13f9ae2
-  React-RCTSettings: cfb0fea9d8d9397290c8b32c980e753a0f2312a3
-  React-RCTTest: 6ec6bdeb0b9a65f8fb959d1183789b632534717c
-  React-RCTText: e6457242755b1dd6fa444264361db8a9a8d0a56a
-  React-RCTVibration: d7cbf797347b9505acc4573a7308292755655050
-  React-TurboModuleCxx-RNW: 1d1e609d1bf4b7b788093738ac3bf17028647c80
-  React-TurboModuleCxx-WinRTPort: 747fdb606a9696e494d6d0a97d36b7607fc15b35
-  ReactCommon: 6d21cc720730a31a9b63a67f751d991e56def287
-  Yoga: 6a194db2cebcae86e56caf702b8c659f5c0da133
+  RCTRequired: 605779283fc1087bc0cebf665fc39c48ae66a32f
+  RCTTypeSafety: c6f764bf94d5aab5eabfd6424c1808b8eb1b3a4f
+  React: 84a2c1871e27224434422e225dca0523a5923b4a
+  React-ART: e0ef95c8aec64353932654de8f21a66cbb27df7e
+  React-callinvoker: 2ed7d4268d5c49f781bd325f2e73e100743a0b22
+  React-Core: 83c5a9b27a6eba692b4d5817e1bbd34f23fb5f67
+  React-CoreModules: eba607224a0db69c3e760b355e2c1fc327144add
+  React-cxxreact: 89b0f6f44452eb2829071cbc3245ae870a3303b2
+  React-jsi: 0dc4dea7c1585d0c38755d81965688d43324339f
+  React-jsiexecutor: 2a5085de721c38fb15bf3441e7fed303263e4371
+  React-jsinspector: af23901d0294ce55b8c9cb7368877cb35d6635d1
+  React-RCTActionSheet: 3104e360e1a6756d730670056c6b894c29cc9156
+  React-RCTAnimation: c93d2598ee7b613419ccdf587629dc05c766e6db
+  React-RCTBlob: 4ed6800421db1c41454f9df290bc3ccb6aa7e65a
+  React-RCTImage: b84c8d64e154e1139a2e44f1dc188ed3da8ad968
+  React-RCTLinking: 9eacb7862749686b01b86580e9a1cedf921d0841
+  React-RCTNetwork: 9282763c637e510b12c0bd97ff49e45caf9d8af1
+  React-RCTPushNotification: 64c4f337c0395f0841cd2678b912a23151bf04c8
+  React-RCTSettings: e082fe308ae17d29c3dff072031604a28563c81f
+  React-RCTTest: bd4660492625e8816aea668a8ec3f28f4dfb551d
+  React-RCTText: 8e7c9dba8fc7ba3fd8261b221ca09b2b20c46f21
+  React-RCTVibration: 55ffe9a64738bd2b141dca118a648561d3270b93
+  React-TurboModuleCxx-RNW: 156f4166eea27ec6cc5aa74fa9c529c7349ff95b
+  React-TurboModuleCxx-WinRTPort: df1c345fa29b5d6f6b06f42f16d1b6c145d91a30
+  ReactCommon: 0487b78f06ea70eaa72990628418fe872d6f6aa4
+  Yoga: ed0d1c7b233fd2f8465320ed0aaacc441b8eb6a5
 
 PODFILE CHECKSUM: dbdccdd110aedfbfec53a1685103e6291c57a217
 

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.63.42)
-  - FBReactNativeSpec (0.63.42):
+  - FBLazyVector (0.63.43)
+  - FBReactNativeSpec (0.63.43):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.42)
-    - RCTTypeSafety (= 0.63.42)
-    - React-Core (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
+    - RCTRequired (= 0.63.43)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -19,283 +19,283 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.63.42)
-  - RCTTypeSafety (0.63.42):
-    - FBLazyVector (= 0.63.42)
+  - RCTRequired (0.63.43)
+  - RCTTypeSafety (0.63.43):
+    - FBLazyVector (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.42)
-    - React-Core (= 0.63.42)
-  - React (0.63.42):
-    - React-Core (= 0.63.42)
-    - React-Core/DevSupport (= 0.63.42)
-    - React-Core/RCTWebSocket (= 0.63.42)
-    - React-RCTActionSheet (= 0.63.42)
-    - React-RCTAnimation (= 0.63.42)
-    - React-RCTBlob (= 0.63.42)
-    - React-RCTImage (= 0.63.42)
-    - React-RCTLinking (= 0.63.42)
-    - React-RCTNetwork (= 0.63.42)
-    - React-RCTSettings (= 0.63.42)
-    - React-RCTText (= 0.63.42)
-    - React-RCTVibration (= 0.63.42)
-  - React-ART (0.63.42):
-    - React-Core/ARTHeaders (= 0.63.42)
-  - React-callinvoker (0.63.42)
-  - React-Core (0.63.42):
+    - RCTRequired (= 0.63.43)
+    - React-Core (= 0.63.43)
+  - React (0.63.43):
+    - React-Core (= 0.63.43)
+    - React-Core/DevSupport (= 0.63.43)
+    - React-Core/RCTWebSocket (= 0.63.43)
+    - React-RCTActionSheet (= 0.63.43)
+    - React-RCTAnimation (= 0.63.43)
+    - React-RCTBlob (= 0.63.43)
+    - React-RCTImage (= 0.63.43)
+    - React-RCTLinking (= 0.63.43)
+    - React-RCTNetwork (= 0.63.43)
+    - React-RCTSettings (= 0.63.43)
+    - React-RCTText (= 0.63.43)
+    - React-RCTVibration (= 0.63.43)
+  - React-ART (0.63.43):
+    - React-Core/ARTHeaders (= 0.63.43)
+  - React-callinvoker (0.63.43)
+  - React-Core (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.42)
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-Core/Default (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/ARTHeaders (0.63.42):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
-    - Yoga
-  - React-Core/CoreModulesHeaders (0.63.42):
+  - React-Core/ARTHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/Default (0.63.42):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
-    - Yoga
-  - React-Core/DevSupport (0.63.42):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.42)
-    - React-Core/RCTWebSocket (= 0.63.42)
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
-    - React-jsinspector (= 0.63.42)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.42):
+  - React-Core/CoreModulesHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.42):
+  - React-Core/Default (0.63.43):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
+    - Yoga
+  - React-Core/DevSupport (0.63.43):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.63.43)
+    - React-Core/RCTWebSocket (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
+    - React-jsinspector (= 0.63.43)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.42):
+  - React-Core/RCTAnimationHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.42):
+  - React-Core/RCTBlobHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.42):
+  - React-Core/RCTImageHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.42):
+  - React-Core/RCTLinkingHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.63.42):
+  - React-Core/RCTNetworkHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.42):
+  - React-Core/RCTPushNotificationHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.42):
+  - React-Core/RCTSettingsHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.42):
+  - React-Core/RCTTextHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.42):
+  - React-Core/RCTVibrationHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.42)
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-jsiexecutor (= 0.63.42)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-CoreModules (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
+  - React-Core/RCTWebSocket (0.63.43):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.42)
-    - React-Core/CoreModulesHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-RCTImage (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-cxxreact (0.63.42):
+    - React-Core/Default (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
+    - Yoga
+  - React-CoreModules (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/CoreModulesHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-RCTImage (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-cxxreact (0.63.43):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.42)
-    - React-jsinspector (= 0.63.42)
-  - React-jsi (0.63.42):
+    - React-callinvoker (= 0.63.43)
+    - React-jsinspector (= 0.63.43)
+  - React-jsi (0.63.43):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.63.42)
-  - React-jsi/Default (0.63.42):
+    - React-jsi/Default (= 0.63.43)
+  - React-jsi/Default (0.63.43):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.63.42):
+  - React-jsiexecutor (0.63.43):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-  - React-jsinspector (0.63.42)
-  - React-RCTActionSheet (0.63.42):
-    - React-Core/RCTActionSheetHeaders (= 0.63.42)
-  - React-RCTAnimation (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+  - React-jsinspector (0.63.43)
+  - React-RCTActionSheet (0.63.43):
+    - React-Core/RCTActionSheetHeaders (= 0.63.43)
+  - React-RCTAnimation (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.42)
-    - React-Core/RCTAnimationHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTBlob (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTAnimationHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTBlob (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.42)
-    - React-Core/RCTWebSocket (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-RCTNetwork (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTImage (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
+    - React-Core/RCTBlobHeaders (= 0.63.43)
+    - React-Core/RCTWebSocket (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-RCTNetwork (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTImage (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.42)
-    - React-Core/RCTImageHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - React-RCTNetwork (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTLinking (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
-    - React-Core/RCTLinkingHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTNetwork (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTImageHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-RCTNetwork (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTLinking (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
+    - React-Core/RCTLinkingHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTNetwork (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.42)
-    - React-Core/RCTNetworkHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTPushNotification (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
-    - RCTTypeSafety (= 0.63.42)
-    - React-Core/RCTPushNotificationHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTSettings (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTNetworkHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTPushNotification (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTPushNotificationHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTSettings (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.42)
-    - React-Core/RCTSettingsHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTTest (0.63.42):
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTSettingsHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTTest (0.63.43):
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core (= 0.63.42)
-    - React-CoreModules (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-RCTText (0.63.42):
-    - React-Core/RCTTextHeaders (= 0.63.42)
-  - React-RCTVibration (0.63.42):
-    - FBReactNativeSpec (= 0.63.42)
+    - React-Core (= 0.63.43)
+    - React-CoreModules (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTText (0.63.43):
+    - React-Core/RCTTextHeaders (= 0.63.43)
+  - React-RCTVibration (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-TurboModuleCxx-RNW (0.63.42):
+    - React-Core/RCTVibrationHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-TurboModuleCxx-RNW (0.63.43):
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.42)
-    - React-TurboModuleCxx-WinRTPort (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
-  - React-TurboModuleCxx-WinRTPort (0.63.42):
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.42)
-    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.63.42)
-  - React-TurboModuleCxx-WinRTPort/Shared (0.63.42)
-  - React-TurboModuleCxx-WinRTPort/WinRT (0.63.42):
-    - React-callinvoker (= 0.63.42)
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.42)
-  - ReactCommon/turbomodule/core (0.63.42):
+    - React-callinvoker (= 0.63.43)
+    - React-TurboModuleCxx-WinRTPort (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-TurboModuleCxx-WinRTPort (0.63.43):
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.43)
+    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.63.43)
+  - React-TurboModuleCxx-WinRTPort/Shared (0.63.43)
+  - React-TurboModuleCxx-WinRTPort/WinRT (0.63.43):
+    - React-callinvoker (= 0.63.43)
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.43)
+  - ReactCommon/turbomodule/core (0.63.43):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.42)
-    - React-Core (= 0.63.42)
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-  - ReactCommon/turbomodule/samples (0.63.42):
+    - React-callinvoker (= 0.63.43)
+    - React-Core (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+  - ReactCommon/turbomodule/samples (0.63.43):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.42)
-    - React-Core (= 0.63.42)
-    - React-cxxreact (= 0.63.42)
-    - React-jsi (= 0.63.42)
-    - ReactCommon/turbomodule/core (= 0.63.42)
+    - React-callinvoker (= 0.63.43)
+    - React-Core (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -404,36 +404,36 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
   DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: e05d2910307c0a86ff548acdffed2ab0901bdb78
-  FBReactNativeSpec: cb9877a821a0a3d3eb2f9dc47db63d93b29be866
+  FBLazyVector: 40c32d4336fa0f0359adb2970c9fdcd7bc9d2937
+  FBReactNativeSpec: f01aafe907f0095df9f38b6192c2720a322a7df4
   glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
   RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 605779283fc1087bc0cebf665fc39c48ae66a32f
-  RCTTypeSafety: c6f764bf94d5aab5eabfd6424c1808b8eb1b3a4f
-  React: 84a2c1871e27224434422e225dca0523a5923b4a
-  React-ART: e0ef95c8aec64353932654de8f21a66cbb27df7e
-  React-callinvoker: 2ed7d4268d5c49f781bd325f2e73e100743a0b22
-  React-Core: 83c5a9b27a6eba692b4d5817e1bbd34f23fb5f67
-  React-CoreModules: eba607224a0db69c3e760b355e2c1fc327144add
-  React-cxxreact: 89b0f6f44452eb2829071cbc3245ae870a3303b2
-  React-jsi: 0dc4dea7c1585d0c38755d81965688d43324339f
-  React-jsiexecutor: 2a5085de721c38fb15bf3441e7fed303263e4371
-  React-jsinspector: af23901d0294ce55b8c9cb7368877cb35d6635d1
-  React-RCTActionSheet: 3104e360e1a6756d730670056c6b894c29cc9156
-  React-RCTAnimation: c93d2598ee7b613419ccdf587629dc05c766e6db
-  React-RCTBlob: 4ed6800421db1c41454f9df290bc3ccb6aa7e65a
-  React-RCTImage: b84c8d64e154e1139a2e44f1dc188ed3da8ad968
-  React-RCTLinking: 9eacb7862749686b01b86580e9a1cedf921d0841
-  React-RCTNetwork: 9282763c637e510b12c0bd97ff49e45caf9d8af1
-  React-RCTPushNotification: 64c4f337c0395f0841cd2678b912a23151bf04c8
-  React-RCTSettings: e082fe308ae17d29c3dff072031604a28563c81f
-  React-RCTTest: bd4660492625e8816aea668a8ec3f28f4dfb551d
-  React-RCTText: 8e7c9dba8fc7ba3fd8261b221ca09b2b20c46f21
-  React-RCTVibration: 55ffe9a64738bd2b141dca118a648561d3270b93
-  React-TurboModuleCxx-RNW: 156f4166eea27ec6cc5aa74fa9c529c7349ff95b
-  React-TurboModuleCxx-WinRTPort: df1c345fa29b5d6f6b06f42f16d1b6c145d91a30
-  ReactCommon: 0487b78f06ea70eaa72990628418fe872d6f6aa4
-  Yoga: ed0d1c7b233fd2f8465320ed0aaacc441b8eb6a5
+  RCTRequired: 19162253ff1760f0803296337f7f3ca3f51aae70
+  RCTTypeSafety: b9e00438e1dfe29a7870edac614d4cebb07b30af
+  React: 09a8ce3c329a2a3230cb78098f1bf15e96dabb95
+  React-ART: 532b2c743cfa4c79458d810d40c795674cbb980e
+  React-callinvoker: f44a8434957c84958fd18bc535e4649308afc555
+  React-Core: 729ed83856e212945122471cdfb65499305356f3
+  React-CoreModules: b8d8441afbca073b6b3ea4f156d9d45407fa7a2c
+  React-cxxreact: 7cf233342d36dae1f83557b9301d88ee813c59c2
+  React-jsi: 53f99d6cbb015afd2d58d306bf2789a6925d1906
+  React-jsiexecutor: 91974adabf0f994eedd1455028ef15bd2db048cf
+  React-jsinspector: 96981df4d10f63fb4eed4c14485af362e4c4f039
+  React-RCTActionSheet: b196ffcbceca9116118ca18c0cc33f39ed04f691
+  React-RCTAnimation: c8b2e1afe176af822789748e8a8175b7072bdd04
+  React-RCTBlob: 611dbe18e056edd5365b18d91e1f829452bcc732
+  React-RCTImage: 6b219a51c9b6bd1cdd84e37607310eb7d59e4aba
+  React-RCTLinking: ac91b594f758bdbc7cb9105eb67dee48383ab083
+  React-RCTNetwork: ea5d2454e68a1ffb99a49330736a52cc4a4b5e8a
+  React-RCTPushNotification: 05acfe0e2c62dc976ce6ef2fc45b33dd99a2ec6b
+  React-RCTSettings: 07aeffaa279ec4258fb7440f474ac7ce93fc6973
+  React-RCTTest: 4981d3e1337d8cf1cb67a58606a58f8bfb8e742a
+  React-RCTText: 96dff9862a881a75fcce406eef159e3b96c52acd
+  React-RCTVibration: dd55a9e7b42025e9408cb61a7c8e459c5d52a4a4
+  React-TurboModuleCxx-RNW: 1f2ca67d0de041dea9993778a9442ee387d5d5ea
+  React-TurboModuleCxx-WinRTPort: 171761437f8420999b3239914761f9fb2afd5b5c
+  ReactCommon: 68efb851b7557cae32b2785c16d38663904b1083
+  Yoga: dc381c5b6bf950564c2d6b92f39ffb04a6b1faaa
 
 PODFILE CHECKSUM: dbdccdd110aedfbfec53a1685103e6291c57a217
 

--- a/React/Modules/MacOS/RCTAccessibilityManager.m
+++ b/React/Modules/MacOS/RCTAccessibilityManager.m
@@ -94,9 +94,10 @@ RCT_EXPORT_METHOD(getCurrentVoiceOverState:(RCTResponseSenderBlock)callback
 
 RCT_EXPORT_METHOD(setAccessibilityFocus:(nonnull NSNumber *)reactTag)
 {
-   dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(dispatch_get_main_queue(), ^{
     NSView *view = [self.bridge.uiManager viewForReactTag:reactTag];
     [[view window] makeFirstResponder:view];
+    NSAccessibilityPostNotification(view, NSAccessibilityLayoutChangedNotification);
   });
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry pick of e1ea6d2e66e7236b65e294b68503b3257523eb80

## Changelog

[macOS] [Fixed] - Post NSAccessibilityLayoutChangedNotification when we call setAccessibilityFocus