### PR TITLE
Fixes for publishing from stable branches

### DIFF
--- a/.ado/gitTagRelease.js
+++ b/.ado/gitTagRelease.js
@@ -28,7 +28,7 @@ function doPublish() {
   exec(`git config --global user.email "53619745+rnbot@users.noreply.github.com"`);
   exec(`git config --global user.name "React-Native Bot"`);
 
-  exec(`git add ${pkgJsonPath}`);
+  exec(`git add .`);
   exec(`git commit -m "Applying package update to ${releaseVersion} ***NO_CI***"`);
   exec(`git tag v${releaseVersion}`);
   exec(`git push origin HEAD:${tempPublishBranch} --follow-tags --verbose`);

--- a/.ado/npmOfficePack.js
+++ b/.ado/npmOfficePack.js
@@ -28,7 +28,7 @@ function doPublish(fakeMode) {
   if (!onlyTagSource) {
     // -------- Generating Android Artifacts with JavaDoc
     const depsEnvPrefix = "REACT_NATIVE_BOOST_PATH=" + path.join(process.env.BUILD_SOURCESDIRECTORY, "build_deps");
-    const gradleCommand = path.join(process.env.BUILD_SOURCESDIRECTORY, "gradlew") + " installArchives";
+    const gradleCommand = path.join(process.env.BUILD_SOURCESDIRECTORY, "gradlew") + " installArchives -Pparam=\"excludeLibs\"";
     exec( depsEnvPrefix + " " + gradleCommand );
 
     // undo uncommenting javadoc setting

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -16,11 +16,14 @@ trigger:
 
 pr: none
 
+variables:
+  - template: variables/mac.yml
+
 jobs:
   - job: RNGithubNpmJSPublish
     displayName: React-Native GitHub Publish to npmjs.org
     pool:
-      vmImage: vs2017-win2016
+      vmImage: $(VmImage)
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:
@@ -47,6 +50,8 @@ jobs:
         displayName: Set dist-tag to v0.x-stable
         condition: and(ne(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.SourceBranchName'], variables.latestStableBranch))
 
+      - template: templates/apple-node-setup.yml
+
       - task: CmdLine@2
         displayName: yarn install
         inputs:
@@ -56,13 +61,21 @@ jobs:
         displayName: Bump stable package version
         inputs:
           script: node .ado/bumpFileVersions.js
-        condition: ne(variables['Build.SourceBranchName'], 'master')
+        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
+
+      - task: CmdLine@2
+        displayName: pod update React-TurboModuleCxx-RNW
+        inputs:
+          script: |
+            cd packages/rn-tester
+            pod update React-TurboModuleCxx-RNW
+        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
 
       - task: CmdLine@2
         displayName: Bump canary package version
         inputs:
           script: node scripts/bump-oss-version.js --nightly
-        condition: eq(variables['Build.SourceBranchName'], 'master')
+        condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
 
       # Publish will fail if package.json is marked as private
       - task: CmdLine@2
@@ -88,7 +101,7 @@ jobs:
           BUILD_SOURCEBRANCH: $(Build.SourceBranch)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           githubApiToken: $(githubApiToken)
-        condition: ne(variables['Build.SourceBranchName'], 'master')
+        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
 
 
   - job: RNMacOSInitNpmJSPublish
@@ -148,6 +161,12 @@ jobs:
         displayName: Bump package version
         inputs:
           script: node .ado/bumpOfficeFileVersions.js
+
+      # Publish will fail if package.json is marked as private
+      - task: CmdLine@2
+        displayName: Remove workspace config from package.json
+        inputs:
+          script: node .ado/removeWorkspaceConfig.js
 
       - task: CmdLine@2
         displayName: gradlew installArchives

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const semver = require('semver');
+const {execSync} = require('child_process');
 
 const pkgJsonPath = path.resolve(__dirname, "../package.json");
 let publishBranchName = '';
@@ -41,9 +42,9 @@ function updateVersionsInFiles(patchVersionPrefix) {
     }
  
     pkgJson.version = releaseVersion;
-    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
-    console.log(`Updating package.json to version ${releaseVersion}`);
-  
+    console.log(`Bumping files to version ${releaseVersion}`);
+    execSync(`node ./scripts/bump-oss-version.js --rnmpublish ${releaseVersion}`, {stdio: 'inherit', env: process.env});
+
     return {releaseVersion, branchVersionSuffix};
 }
 


### PR DESCRIPTION
Porting various fixes I made to the 0.64-stable branch to get publishing working again.

In particular makes publish update the version numbers of various files that were not being bumped before, and the RNTester pod lock file will get updated when the version of its dependencies gets bumped.  -- which was previously causing publish to break the lock file, which would cause PRs to start failing.