### PR TITLE
[0.64] Fix nonnull compat issue

### DIFF
--- a/React/Base/RCTJSInvokerModule.h
+++ b/React/Base/RCTJSInvokerModule.h
@@ -12,6 +12,6 @@
 @protocol RCTJSInvokerModule
 
 @property (nonatomic, copy, nonnull) void (^invokeJS)(NSString * _Nullable module, NSString * _Nullable method, NSArray * _Nullable args); // TODO(macOS GH#774)
-@property (nonatomic, copy, nonnull) void (^invokeJSWithModuleDotMethod)(NSString *moduleDotMethod, NSArray *args); // TODO(macOS GH#774)
+@property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString * _Nullable moduleDotMethod, NSArray * _Nullable args); // TODO(macOS GH#774)
 
 @end

--- a/React/Base/RCTJSInvokerModule.h
+++ b/React/Base/RCTJSInvokerModule.h
@@ -12,6 +12,6 @@
 @protocol RCTJSInvokerModule
 
 @property (nonatomic, copy, nonnull) void (^invokeJS)(NSString * _Nullable module, NSString * _Nullable method, NSArray * _Nullable args); // TODO(macOS GH#774)
-@property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString *moduleDotMethod, NSArray *args);
+@property (nonatomic, copy, nonnull) void (^invokeJSWithModuleDotMethod)(NSString *moduleDotMethod, NSArray *args); // TODO(macOS GH#774)
 
 @end


### PR DESCRIPTION
#### Please select one of the following
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Some downstream dependencies have non null checks that fail here if we don't tag appropriately. This is also a virtuous change as it adds clarity to the method header.

## Changelog

[Bug] [iOS/macOS] - Nonnull compatibility check

## Test Plan

No functional change