### PR TITLE
Rename directory for ship .so files to be ship instead of release

### DIFF
--- a/android-patches/scripts/downloadDependencies.py
+++ b/android-patches/scripts/downloadDependencies.py
@@ -523,7 +523,7 @@ def main():
     shutil.copy(os.path.join(hermes_engine_node_modules_path, "package.json"), dependency_dir_hermes)
 
     dependency_dir_hermes_android_native_debug = os.path.join(dependency_dir_hermes_android_aar_path, "debug")
-    dependency_dir_hermes_android_native_release = os.path.join(dependency_dir_hermes_android_aar_path, "release")
+    dependency_dir_hermes_android_native_release = os.path.join(dependency_dir_hermes_android_aar_path, "ship")
     extract_so(dependency_dir_hermes_android_aar_path, dependency_dir_hermes_android_native_debug, "hermes-debug.aar")
     extract_so(dependency_dir_hermes_android_aar_path, dependency_dir_hermes_android_native_debug, "hermes-cppruntime-debug.aar")
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Office has special build variables that allow specifying paths to flavor specific binaries at a single location. In order for this to work however, it is expected that the directories are named debug and ship, instead of debug and release. This change simply renames the directory that hermes release .so files are copied to from "release" to "ship".

## Changelog

[Android] [Fixed] - Copy release hermes related binaries to a directory named ship instead of release

## Test Plan

Created a draft PR which published the android nuget package, which I then copied locally and ran a ship build to ensure the build works as expected.
