### PR TITLE
[0.63] Pull in upstream fixes to expose hover props on Pressable #884

### DIFF
--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -25,11 +25,13 @@ import type {
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
 import {normalizeRect, type RectOrSize} from '../../StyleSheet/Rect';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 import type {
   LayoutEvent,
   MouseEvent,
   PressEvent,
 } from '../../Types/CoreEventTypes';
+import type {DraggedTypesType} from '../View/DraggedType'; // TODO(macOS ISS#2323203)
 import View from '../View/View';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -159,8 +159,6 @@ type Props = $ReadOnly<{|
   acceptsFirstMouse?: ?boolean,
   enableFocusRing?: ?boolean,
   tooltip?: ?string,
-  onMouseEnter?: (event: MouseEvent) => void,
-  onMouseLeave?: (event: MouseEvent) => void,
   onDragEnter?: (event: MouseEvent) => void,
   onDragLeave?: (event: MouseEvent) => void,
   onDrop?: (event: MouseEvent) => void,

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -25,13 +25,11 @@ import type {
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
 import {normalizeRect, type RectOrSize} from '../../StyleSheet/Rect';
-import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 import type {
   LayoutEvent,
-  MouseEvent, // TODO(macOS ISS#2323203)
+  MouseEvent,
   PressEvent,
 } from '../../Types/CoreEventTypes';
-import type {DraggedTypesType} from '../View/DraggedType'; // TODO(macOS ISS#2323203)
 import View from '../View/View';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
@@ -66,6 +64,16 @@ type Props = $ReadOnly<{|
   children: React.Node | ((state: StateCallbackType) => React.Node),
 
   /**
+   * Duration to wait after hover in before calling `onHoverIn`.
+   */
+  delayHoverIn?: ?number,
+
+  /**
+   * Duration to wait after hover out before calling `onHoverOut`.
+   */
+  delayHoverOut?: ?number,
+
+  /**
    * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
    */
   delayLongPress?: ?number,
@@ -90,6 +98,16 @@ type Props = $ReadOnly<{|
    * Called when this view's layout changes.
    */
   onLayout?: ?(event: LayoutEvent) => void,
+
+  /**
+   * Called when the hover is activated to provide visual feedback.
+   */
+  onHoverIn?: ?(event: MouseEvent) => mixed,
+
+  /**
+   * Called when the hover is deactivated to undo visual feedback.
+   */
+  onHoverOut?: ?(event: MouseEvent) => mixed,
 
   /**
    * Called when a long-tap gesture is detected.
@@ -162,11 +180,13 @@ function Pressable(props: Props, forwardedRef): React.Node {
     android_disableSound,
     android_ripple,
     children,
+    delayHoverIn,
+    delayHoverOut,
     delayLongPress,
     disabled,
     focusable,
-    onMouseEnter, // [TODO(macOS GH#774)
-    onMouseLeave, // ]TODO(macOS GH#774)
+    onHoverIn,
+    onHoverOut,
     onLongPress,
     onPress,
     onPressIn,
@@ -192,9 +212,12 @@ function Pressable(props: Props, forwardedRef): React.Node {
       hitSlop,
       pressRectOffset: pressRetentionOffset,
       android_disableSound,
+      delayHoverIn,
+      delayHoverOut,
       delayLongPress,
-      onHoverIn: onMouseEnter, // [TODO(macOS GH#774)
-      onHoverOut: onMouseLeave, // ]TODO(macOS GH#774)
+      delayPressIn: unstable_pressDelay,
+      onHoverIn,
+      onHoverOut,
       onLongPress,
       onPress,
       onPressIn(event: PressEvent): void {
@@ -220,11 +243,13 @@ function Pressable(props: Props, forwardedRef): React.Node {
     [
       android_disableSound,
       android_rippleConfig,
+      delayHoverIn,
+      delayHoverOut,
       delayLongPress,
       disabled,
       hitSlop,
-      onMouseEnter, // [TODO(macOS GH#774)
-      onMouseLeave, // ]TODO(macOS GH#774)
+      onHoverIn,
+      onHoverOut,
       onLongPress,
       onPress,
       onPressIn,

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -215,7 +215,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
       delayHoverIn,
       delayHoverOut,
       delayLongPress,
-      delayPressIn: unstable_pressDelay,
       onHoverIn,
       onHoverOut,
       onLongPress,

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.63.41)
-  - FBReactNativeSpec (0.63.41):
+  - FBLazyVector (0.63.43)
+  - FBReactNativeSpec (0.63.43):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.41)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
+    - RCTRequired (= 0.63.43)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -19,283 +19,283 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.63.41)
-  - RCTTypeSafety (0.63.41):
-    - FBLazyVector (= 0.63.41)
+  - RCTRequired (0.63.43)
+  - RCTTypeSafety (0.63.43):
+    - FBLazyVector (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.63.41)
-    - React-Core (= 0.63.41)
-  - React (0.63.41):
-    - React-Core (= 0.63.41)
-    - React-Core/DevSupport (= 0.63.41)
-    - React-Core/RCTWebSocket (= 0.63.41)
-    - React-RCTActionSheet (= 0.63.41)
-    - React-RCTAnimation (= 0.63.41)
-    - React-RCTBlob (= 0.63.41)
-    - React-RCTImage (= 0.63.41)
-    - React-RCTLinking (= 0.63.41)
-    - React-RCTNetwork (= 0.63.41)
-    - React-RCTSettings (= 0.63.41)
-    - React-RCTText (= 0.63.41)
-    - React-RCTVibration (= 0.63.41)
-  - React-ART (0.63.41):
-    - React-Core/ARTHeaders (= 0.63.41)
-  - React-callinvoker (0.63.41)
-  - React-Core (0.63.41):
+    - RCTRequired (= 0.63.43)
+    - React-Core (= 0.63.43)
+  - React (0.63.43):
+    - React-Core (= 0.63.43)
+    - React-Core/DevSupport (= 0.63.43)
+    - React-Core/RCTWebSocket (= 0.63.43)
+    - React-RCTActionSheet (= 0.63.43)
+    - React-RCTAnimation (= 0.63.43)
+    - React-RCTBlob (= 0.63.43)
+    - React-RCTImage (= 0.63.43)
+    - React-RCTLinking (= 0.63.43)
+    - React-RCTNetwork (= 0.63.43)
+    - React-RCTSettings (= 0.63.43)
+    - React-RCTText (= 0.63.43)
+    - React-RCTVibration (= 0.63.43)
+  - React-ART (0.63.43):
+    - React-Core/ARTHeaders (= 0.63.43)
+  - React-callinvoker (0.63.43)
+  - React-Core (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-Core/Default (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/ARTHeaders (0.63.41):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
-    - Yoga
-  - React-Core/CoreModulesHeaders (0.63.41):
+  - React-Core/ARTHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/Default (0.63.41):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
-    - Yoga
-  - React-Core/DevSupport (0.63.41):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.41)
-    - React-Core/RCTWebSocket (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
-    - React-jsinspector (= 0.63.41)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.63.41):
+  - React-Core/CoreModulesHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.63.41):
+  - React-Core/Default (0.63.43):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
+    - Yoga
+  - React-Core/DevSupport (0.63.43):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.63.43)
+    - React-Core/RCTWebSocket (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
+    - React-jsinspector (= 0.63.43)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.63.41):
+  - React-Core/RCTAnimationHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTImageHeaders (0.63.41):
+  - React-Core/RCTBlobHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.63.41):
+  - React-Core/RCTImageHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.63.41):
+  - React-Core/RCTLinkingHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.63.41):
+  - React-Core/RCTNetworkHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.63.41):
+  - React-Core/RCTPushNotificationHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTTextHeaders (0.63.41):
+  - React-Core/RCTSettingsHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.63.41):
+  - React-Core/RCTTextHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-Core/RCTWebSocket (0.63.41):
+  - React-Core/RCTVibrationHeaders (0.63.43):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-jsiexecutor (= 0.63.41)
+    - React-Core/Default
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
     - Yoga
-  - React-CoreModules (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+  - React-Core/RCTWebSocket (0.63.43):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/CoreModulesHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-RCTImage (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-cxxreact (0.63.41):
+    - React-Core/Default (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-jsiexecutor (= 0.63.43)
+    - Yoga
+  - React-CoreModules (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/CoreModulesHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-RCTImage (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-cxxreact (0.63.43):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-jsinspector (= 0.63.41)
-  - React-jsi (0.63.41):
+    - React-callinvoker (= 0.63.43)
+    - React-jsinspector (= 0.63.43)
+  - React-jsi (0.63.43):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.63.41)
-  - React-jsi/Default (0.63.41):
+    - React-jsi/Default (= 0.63.43)
+  - React-jsi/Default (0.63.43):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.63.41):
+  - React-jsiexecutor (0.63.43):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-  - React-jsinspector (0.63.41)
-  - React-RCTActionSheet (0.63.41):
-    - React-Core/RCTActionSheetHeaders (= 0.63.41)
-  - React-RCTAnimation (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+  - React-jsinspector (0.63.43)
+  - React-RCTActionSheet (0.63.43):
+    - React-Core/RCTActionSheetHeaders (= 0.63.43)
+  - React-RCTAnimation (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTAnimationHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTBlob (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTAnimationHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTBlob (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.63.41)
-    - React-Core/RCTWebSocket (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-RCTNetwork (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTImage (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - React-Core/RCTBlobHeaders (= 0.63.43)
+    - React-Core/RCTWebSocket (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-RCTNetwork (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTImage (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTImageHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - React-RCTNetwork (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTLinking (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
-    - React-Core/RCTLinkingHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTNetwork (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTImageHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - React-RCTNetwork (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTLinking (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
+    - React-Core/RCTLinkingHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTNetwork (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTNetworkHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTPushNotification (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTPushNotificationHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTSettings (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTNetworkHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTPushNotification (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTPushNotificationHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTSettings (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.63.41)
-    - React-Core/RCTSettingsHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTTest (0.63.41):
+    - RCTTypeSafety (= 0.63.43)
+    - React-Core/RCTSettingsHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTTest (0.63.43):
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core (= 0.63.41)
-    - React-CoreModules (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-RCTText (0.63.41):
-    - React-Core/RCTTextHeaders (= 0.63.41)
-  - React-RCTVibration (0.63.41):
-    - FBReactNativeSpec (= 0.63.41)
+    - React-Core (= 0.63.43)
+    - React-CoreModules (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-RCTText (0.63.43):
+    - React-Core/RCTTextHeaders (= 0.63.43)
+  - React-RCTVibration (0.63.43):
+    - FBReactNativeSpec (= 0.63.43)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-TurboModuleCxx-RNW (0.63.41):
+    - React-Core/RCTVibrationHeaders (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-TurboModuleCxx-RNW (0.63.43):
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-TurboModuleCxx-WinRTPort (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
-  - React-TurboModuleCxx-WinRTPort (0.63.41):
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.41)
-    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.63.41)
-  - React-TurboModuleCxx-WinRTPort/Shared (0.63.41)
-  - React-TurboModuleCxx-WinRTPort/WinRT (0.63.41):
-    - React-callinvoker (= 0.63.41)
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.41)
-  - ReactCommon/turbomodule/core (0.63.41):
+    - React-callinvoker (= 0.63.43)
+    - React-TurboModuleCxx-WinRTPort (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
+  - React-TurboModuleCxx-WinRTPort (0.63.43):
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.43)
+    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.63.43)
+  - React-TurboModuleCxx-WinRTPort/Shared (0.63.43)
+  - React-TurboModuleCxx-WinRTPort/WinRT (0.63.43):
+    - React-callinvoker (= 0.63.43)
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.63.43)
+  - ReactCommon/turbomodule/core (0.63.43):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-Core (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-  - ReactCommon/turbomodule/samples (0.63.41):
+    - React-callinvoker (= 0.63.43)
+    - React-Core (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+  - ReactCommon/turbomodule/samples (0.63.43):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.63.41)
-    - React-Core (= 0.63.41)
-    - React-cxxreact (= 0.63.41)
-    - React-jsi (= 0.63.41)
-    - ReactCommon/turbomodule/core (= 0.63.41)
+    - React-callinvoker (= 0.63.43)
+    - React-Core (= 0.63.43)
+    - React-cxxreact (= 0.63.43)
+    - React-jsi (= 0.63.43)
+    - ReactCommon/turbomodule/core (= 0.63.43)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -402,38 +402,38 @@ EXTERNAL SOURCES:
     :path: "../ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost-for-react-native: dabda8622e76020607c2ae1e65cc0cda8b61479d
-  DoubleConversion: 56a44bcfd14ab2ff66f5a146b2e875eb4b69b19b
-  FBLazyVector: 9dde2e0340ba783233dba7c6b77e65889047fbb3
-  FBReactNativeSpec: 6088d5ab01851853cc3fc5384d3f5edf7c898e54
-  glog: 1cb7c408c781ae8f35bbababe459b45e3dee4ec1
-  RCT-Folly: 1347093ffe75e152d846f7e45a3ef901b60021aa
-  RCTRequired: 64eedb6cf5f0ae7d4c3925e0b9a87747d0391735
-  RCTTypeSafety: a8ce68a3ce4aa22cd6a9cbf09607ad2b016b51d5
-  React: a8f98b76204f8a85b22311e8fe145b7bbe5b80e5
-  React-ART: ba4b53b0d3948e3c98242e57369d83a437d3338e
-  React-callinvoker: 523751195c41602db85fa2889e44a6afae271e3a
-  React-Core: b0b37e0216951b0706bdcec7b7fb9400d8167433
-  React-CoreModules: 3e81ecb9ea29b3a4eba630fad23d42747bb28c4c
-  React-cxxreact: 745b1fb1cfc8133c5ab52177172128fba3bc7411
-  React-jsi: 5d60daef9bfdfb1f2b7d69281643a113c99844d3
-  React-jsiexecutor: 235cf6a0975b88e7c3c56f1862e5ec3512993e47
-  React-jsinspector: d067ff9e6a75ffc7472ca71007ba47cdfcc8cc1c
-  React-RCTActionSheet: 5d6d53371715660224937186559d0d3019b79621
-  React-RCTAnimation: eb2094b698230b3750722074419baebfb40dba06
-  React-RCTBlob: 03d37739783ed896197505ad6268efcb3ffe4643
-  React-RCTImage: 0fe6e8aa7b8d986b464d176da8998ea2ddd91690
-  React-RCTLinking: f07a3e0e6c0be023c0bb9eac06825a06cc7485f3
-  React-RCTNetwork: 8f1d5d7bf12d75fd5505c3beb0f868a77843f148
-  React-RCTPushNotification: 44e7bff3ed11f81de9c1f5b7f721046fa13f9ae2
-  React-RCTSettings: cfb0fea9d8d9397290c8b32c980e753a0f2312a3
-  React-RCTTest: 6ec6bdeb0b9a65f8fb959d1183789b632534717c
-  React-RCTText: e6457242755b1dd6fa444264361db8a9a8d0a56a
-  React-RCTVibration: d7cbf797347b9505acc4573a7308292755655050
-  React-TurboModuleCxx-RNW: 1d1e609d1bf4b7b788093738ac3bf17028647c80
-  React-TurboModuleCxx-WinRTPort: 747fdb606a9696e494d6d0a97d36b7607fc15b35
-  ReactCommon: 6d21cc720730a31a9b63a67f751d991e56def287
-  Yoga: 6a194db2cebcae86e56caf702b8c659f5c0da133
+  boost-for-react-native: a110407d9db2642fd2e1bcd7c5a51c81f2521dc9
+  DoubleConversion: 2b45d0f8e156a5b02354c8a4062de64d41ccb4e0
+  FBLazyVector: 40c32d4336fa0f0359adb2970c9fdcd7bc9d2937
+  FBReactNativeSpec: f01aafe907f0095df9f38b6192c2720a322a7df4
+  glog: 789873d01e4b200777d0a09bc23d548446758699
+  RCT-Folly: 55d0039b24e192081ec0b2257f7bd9f42e382fb7
+  RCTRequired: 19162253ff1760f0803296337f7f3ca3f51aae70
+  RCTTypeSafety: b9e00438e1dfe29a7870edac614d4cebb07b30af
+  React: 09a8ce3c329a2a3230cb78098f1bf15e96dabb95
+  React-ART: 532b2c743cfa4c79458d810d40c795674cbb980e
+  React-callinvoker: f44a8434957c84958fd18bc535e4649308afc555
+  React-Core: 729ed83856e212945122471cdfb65499305356f3
+  React-CoreModules: b8d8441afbca073b6b3ea4f156d9d45407fa7a2c
+  React-cxxreact: 7cf233342d36dae1f83557b9301d88ee813c59c2
+  React-jsi: 53f99d6cbb015afd2d58d306bf2789a6925d1906
+  React-jsiexecutor: 91974adabf0f994eedd1455028ef15bd2db048cf
+  React-jsinspector: 96981df4d10f63fb4eed4c14485af362e4c4f039
+  React-RCTActionSheet: b196ffcbceca9116118ca18c0cc33f39ed04f691
+  React-RCTAnimation: c8b2e1afe176af822789748e8a8175b7072bdd04
+  React-RCTBlob: 611dbe18e056edd5365b18d91e1f829452bcc732
+  React-RCTImage: 6b219a51c9b6bd1cdd84e37607310eb7d59e4aba
+  React-RCTLinking: ac91b594f758bdbc7cb9105eb67dee48383ab083
+  React-RCTNetwork: ea5d2454e68a1ffb99a49330736a52cc4a4b5e8a
+  React-RCTPushNotification: 05acfe0e2c62dc976ce6ef2fc45b33dd99a2ec6b
+  React-RCTSettings: 07aeffaa279ec4258fb7440f474ac7ce93fc6973
+  React-RCTTest: 4981d3e1337d8cf1cb67a58606a58f8bfb8e742a
+  React-RCTText: 96dff9862a881a75fcce406eef159e3b96c52acd
+  React-RCTVibration: dd55a9e7b42025e9408cb61a7c8e459c5d52a4a4
+  React-TurboModuleCxx-RNW: 1f2ca67d0de041dea9993778a9442ee387d5d5ea
+  React-TurboModuleCxx-WinRTPort: 171761437f8420999b3239914761f9fb2afd5b5c
+  ReactCommon: 68efb851b7557cae32b2785c16d38663904b1083
+  Yoga: dc381c5b6bf950564c2d6b92f39ffb04a6b1faaa
 
 PODFILE CHECKSUM: dbdccdd110aedfbfec53a1685103e6291c57a217
 

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -99,8 +99,8 @@ function PressableFeedbackEvents() {
           testID="pressable_feedback_events_button"
           accessibilityLabel="pressable feedback events"
           accessibilityRole="button"
-          onMouseEnter={() => appendEvent('mouseEnter')} // [TODO(macOS GH#774)
-          onMouseLeave={() => appendEvent('mouseLeave')} // ]TODO(macOS GH#774)
+          onHoverIn={() => appendEvent('hoverIn')} // [TODO(macOS GH#774)
+          onHoverOut={() => appendEvent('hoverOut')} // ]TODO(macOS GH#774)
           onPress={() => appendEvent('press')}
           onPressIn={() => appendEvent('pressIn')}
           onPressOut={() => appendEvent('pressOut')}


### PR DESCRIPTION
Same as #884 except targeting the 0.63-stable branch. 