### PR TITLE
Disable dev mode on ship builds

### DIFF
--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -966,15 +966,13 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
           UIImage *image = RCTDecodeImageWithData(data, size, scale, resizeMode);
 
 #if !TARGET_OS_OSX && RCT_DEV // TODO(macOS GH#774)
-          if ([[self->_bridge devSettings] isDevModeEnabled]) { // TODO(OSS Candidate ISS#2710739)
-            CGSize imagePixelSize = RCTSizeInPixels(image.size, UIImageGetScale(image)); // TODO(macOS GH#774)
-            CGSize screenPixelSize = RCTSizeInPixels(RCTScreenSize(), RCTScreenScale());
-            if (imagePixelSize.width * imagePixelSize.height >
-                screenPixelSize.width * screenPixelSize.height) {
-              RCTLogInfo(@"[PERF ASSETS] Loading image at size %@, which is larger "
-                        "than the screen size %@", NSStringFromCGSize(imagePixelSize),
-                        NSStringFromCGSize(screenPixelSize));
-            }
+          CGSize imagePixelSize = RCTSizeInPixels(image.size, UIImageGetScale(image)); // TODO(macOS GH#774)
+          CGSize screenPixelSize = RCTSizeInPixels(RCTScreenSize(), RCTScreenScale());
+          if (imagePixelSize.width * imagePixelSize.height >
+              screenPixelSize.width * screenPixelSize.height) {
+            RCTLogInfo(@"[PERF ASSETS] Loading image at size %@, which is larger "
+                      "than the screen size %@", NSStringFromCGSize(imagePixelSize),
+                      NSStringFromCGSize(screenPixelSize));
           }
 #endif
 

--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -42,8 +42,7 @@
 #if DEBUG
 #define RCT_DEV 1
 #else
-// Dev Mode is now enabled or disabled at runtime via the -[RCTDevSettings isDevModeEnabled] property
-#define RCT_DEV 1
+#define RCT_DEV 0
 #endif
 #endif
 

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -467,9 +467,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
   NSMenu *menu = nil;
 #if __has_include("RCTDevMenu.h") && RCT_DEV
-  if ([[_bridge devSettings] isDevModeEnabled]) {
-    menu = [[_bridge devMenu] menu];
-  }
+  menu = [[_bridge devMenu] menu];
 #endif
   if (menu == nil) {
     menu = [super menuForEvent:event];

--- a/React/CoreModules/RCTDevLoadingView.mm
+++ b/React/CoreModules/RCTDevLoadingView.mm
@@ -71,7 +71,7 @@ RCT_EXPORT_MODULE()
                                                name:RCTJavaScriptDidFailToLoadNotification
                                              object:nil];
 
-  if ([[bridge devSettings] isDevModeEnabled] && bridge.loading) { // TODO(OSS Candidate ISS#2710739)
+  if (bridge.loading) {
     [self showWithURL:bridge.bundleURL];
   }
 }

--- a/React/CoreModules/RCTDevLoadingView.mm
+++ b/React/CoreModules/RCTDevLoadingView.mm
@@ -339,7 +339,7 @@ RCT_EXPORT_METHOD(hide)
 + (void)setEnabled:(BOOL)enabled
 {
 }
-- (void)showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor
+- (void)showMessage:(NSString *)message color:(RCTUIColor *)color backgroundColor:(RCTUIColor *)backgroundColor // TODO(macOS GH#774) RCTUIColor
 {
 }
 - (void)showMessage:(NSString *)message withColor:(NSNumber *)color withBackgroundColor:(NSNumber *)backgroundColor

--- a/React/CoreModules/RCTDevMenu.mm
+++ b/React/CoreModules/RCTDevMenu.mm
@@ -511,7 +511,6 @@ RCT_EXPORT_METHOD(show)
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
 - (NSMenu *)menu
 {
-  NSMenu *menu = nil;
   if ([_bridge.devSettings isSecondaryClickToShowDevMenuEnabled]) {
     NSMenu *menu = nil;
     if (_bridge) {

--- a/React/CoreModules/RCTDevSettings.h
+++ b/React/CoreModules/RCTDevSettings.h
@@ -41,14 +41,6 @@
 
 - (instancetype)initWithDataSource:(id<RCTDevSettingsDataSource>)dataSource;
 
-// [TODO(OSS Candidate ISS#2710739)
-/**
- * Whether Dev Mode is enabled meaning the development tools
- * such as the debug executors, dev menu, red box, etc. are available.
- */
-@property (nonatomic, assign, setter=setDevModeEnabled:) BOOL isDevModeEnabled;
-// ]TODO(OSS Candidate ISS#2710739)
-
 @property (nonatomic, readonly) BOOL isHotLoadingAvailable;
 @property (nonatomic, readonly) BOOL isLiveReloadAvailable;
 @property (nonatomic, readonly) BOOL isRemoteDebuggingAvailable;

--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -250,18 +250,6 @@ RCT_EXPORT_MODULE()
 #endif // RCT_ENABLE_INSPECTOR
 }
 
-// [TODO(OSS Candidate ISS#2710739)
-RCT_EXPORT_METHOD(setDevModeEnabled:(BOOL)enabled)
-{
-  [self _updateSettingWithValue:@(enabled) forKey:kRCTDevSettingDevModeEnabled];
-}
-
-- (BOOL)isDevModeEnabled
-{
-  return [[self settingForKey:kRCTDevSettingDevModeEnabled] boolValue];
-}
-// ]TODO(OSS Candidate ISS#2710739)
-
 - (BOOL)isRemoteDebuggingAvailable
 {
   if (RCTTurboModuleEnabled()) {

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -470,7 +470,7 @@ struct RCTInstanceCallback : public InstanceCallback {
 #if (RCT_DEV | RCT_ENABLE_LOADING_VIEW) && __has_include(<React/RCTDevLoadingViewProtocol.h>)
         // [TODO(OSS Candidate ISS#2710739)
         // Note: RCTDevLoadingView should have been loaded at this point, so no need to allow lazy loading.
-        if ([weakSelf isValid] && [[weakSelf devSettings] isDevModeEnabled]) {
+        if ([weakSelf isValid]) {
           id<RCTDevLoadingViewProtocol> loadingView = [weakSelf moduleForName:@"DevLoadingView"
                                                         lazilyLoadIfNecessary:YES];
           [loadingView updateProgress:progressData];
@@ -673,9 +673,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   // This can only be false if the bridge was invalidated before startup completed
   if (_reactInstance) {
 #if RCT_DEV
-    if ([[self devSettings] isDevModeEnabled]) { // TODO(OSS Candidate ISS#2710739)
-      executorFactory = std::make_shared<GetDescAdapter>(self, executorFactory);
-    } // TODO(OSS Candidate ISS#2710739)
+    executorFactory = std::make_shared<GetDescAdapter>(self, executorFactory);
 #endif
 
     [self _initializeBridgeLocked:executorFactory];
@@ -1037,9 +1035,7 @@ struct RCTInstanceCallback : public InstanceCallback {
     [self enqueueApplicationScript:sourceCode url:self.bundleURL onComplete:completion];
   }
 
-  if (self.devSettings.isDevModeEnabled) { // TODO(OSS Candidate ISS#2710739)
-    [self.devSettings setupHMRClientWithBundleURL:self.bundleURL];
-  }
+  [self.devSettings setupHMRClientWithBundleURL:self.bundleURL];
 }
 
 #if RCT_DEV_MENU

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -510,8 +510,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: 0af9c548d05821b8d3d8b1158af257ad82eb8c90
-  FBReactNativeSpec: c2d79a2c8c07216f6626c39111124f41d76d4c40
+  FBLazyVector: 5eb0a225a78cba5a4b33c393a3987c78452feff1
+  FBReactNativeSpec: b41a1a227a37d5a6bc2de5c03c3b31e32c081084
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
@@ -522,35 +522,35 @@ SPEC CHECKSUMS:
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTRequired: 3da9abe24673584d7a79f5248832059899068f05
-  RCTTypeSafety: 7119233a5389023ed13c58d09d8ee7bb7088bad8
-  React: c0de64975793cccf0f4138daa4e590146b162f11
-  React-callinvoker: b1124c70c39d3ba0d015d32a158dc0a2eb9c7fa4
-  React-Core: 96446146b7e864c6198b23d7337a252cc9adab55
-  React-CoreModules: 7325e9048de2bbc116bcdb545cf747012d7afa6b
-  React-cxxreact: d86b284a0f9a7a3048459c9c770f4957586d63b8
-  React-jsi: fd6c9fc27e417504fcc0a2839e4d49ee62cd6147
-  React-jsiexecutor: db69b2bd700a8d0e1f45acbd4f67579eac008594
-  React-jsinspector: 89f8d52f0864887a8111927bfc2ca46bc92e42bc
-  React-perflogger: 880d12b4d24001fe05caa7dd97fc65a59d86a8ce
-  React-RCTActionSheet: 07569f6bbccf555da01fe45a85dc77fa73538e73
-  React-RCTAnimation: 953a20ae7e65edc4597db2f42bb1ab6f49139dbf
-  React-RCTBlob: 956b7b4fbca784a2c12a24670a153663a341af8d
-  React-RCTImage: ae01e26d1e08e7ec14efdcc495e11e270fd5d7e6
-  React-RCTLinking: ebb5724a94de55dba5b3ca4d81c3265a8e29906e
-  React-RCTNetwork: 170c0fb1fb9af1ee2a22dcc9b6210210a90e9ff0
-  React-RCTPushNotification: ee9e0b11dee6dad4fabb74bfbae70a3d2eed8ea3
-  React-RCTSettings: 1348016b05923c4eba469f7eb4de9f14d6c199ed
-  React-RCTTest: 922247d62baab8fdc5fdd050ca23b0d5f3d2dc17
-  React-RCTText: c3a41352baca01610f860dc955658574dc0a763c
-  React-RCTVibration: 4faffa992f29eacda03ade258837d2b66525efdf
-  React-runtimeexecutor: 05f6110ddd6882d227293094c983dbfc5db315b7
+  RCTRequired: ff8c2af2149b8a6eb763d4ec074df18363c64a2a
+  RCTTypeSafety: 0b78f421f36614823ca4659558d6ff3b8b5f687d
+  React: 9536b3ee6852171a54339f2c58c3210711859a13
+  React-callinvoker: eed7d5e3e6766f4a65b56db416426509120ae0b4
+  React-Core: abba3c16676376786954a2155fb768d460f56d03
+  React-CoreModules: 6f77945100d0e554c688e5d8c8d7d26cabf204ca
+  React-cxxreact: edda11a62ff4d07c59e9594a96b263b22c96bfdf
+  React-jsi: ea7c8015ed6c0ecc214a8473d1d6d73f31bced1f
+  React-jsiexecutor: acbbe98dd2be75eac087b65e7826510f53736aa3
+  React-jsinspector: 7bde733b92c85bb7e6c8a97ab2a192e9c08ab29d
+  React-perflogger: c169071b3a8321d4f45af9cbaa0cba6aaa70f0e7
+  React-RCTActionSheet: 98c744e34b5f1b835fa81a954f061923d90a1b4d
+  React-RCTAnimation: 5473f8d8ae09b65a52e61f338b27beef7c267c1b
+  React-RCTBlob: 6a09fcbf8be80c39917d2ffb4bd91f7e263fa220
+  React-RCTImage: 17b095be7fe71fdbb515abd2b85e1d6b8e5b862e
+  React-RCTLinking: d8f9a2bd2ddfb45e7cfc6f4d7cb2eae438d50726
+  React-RCTNetwork: 151b01b53adf3066380e7a4267aeb47fcbf4084e
+  React-RCTPushNotification: d7489c15a5965df0baf3ad8e9a6c3429f7886510
+  React-RCTSettings: f7e431f4d712010b1b3a31eb5a3ec881045339d6
+  React-RCTTest: 3dd7edd7ca91b545120597091d1cb1cc5b2f9ad0
+  React-RCTText: e5ce1de8642ece7c7f45af10efd835ad6315e58f
+  React-RCTVibration: 87cf642254b6f087cde6a6c28c4297bd5dc53278
+  React-runtimeexecutor: a79d5b213731a09e832cd83ae3730cb035b79401
   React-TurboModuleCxx-RNW: 12172bdbaaf052406ec571465243fad4b2eb2702
-  React-TurboModuleCxx-WinRTPort: 557ca6d53cca3bf5f9d42a1cb1cd9ff5d887d006
-  ReactCommon: e3384ac2e3de59fce90c35524d6fae1ca82a21fe
-  Yoga: c80bf412b7c3f863cbb5aa73cfb6568c33b20220
+  React-TurboModuleCxx-WinRTPort: f8772e879ba6bfc904af3ad814924fc5a4cc95bc
+  ReactCommon: b50d1cb4db7097dbf9fe9822cae91d8db16d66a7
+  Yoga: 392bd4e59f34535ea9ddac17e2ba91ee8cad475e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 096cbc796e89167c003b0c49186597432f0fb5e8
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -510,8 +510,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: b52fc114a0d52dd9ff8cc2283570ada3457aac84
-  FBReactNativeSpec: be4e0456f993c7191f20eae44b56d9a4a1983f2c
+  FBLazyVector: 6c1f51ce3bb40c071c795664cea3c7f54c44a946
+  FBReactNativeSpec: 3e48c599ddd3c4960bf00f58cae7d81193a54dfb
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
@@ -522,33 +522,33 @@ SPEC CHECKSUMS:
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTRequired: f86fbb8c49d816c29b322f59e080df3fa0c1993f
-  RCTTypeSafety: 06e387a0369dae85677eb70453f2320296d94148
-  React: 0d4baf5072da5a80e865037c41c2c6e9344ec2d8
-  React-callinvoker: 9dc7c52e966663a99e368ea711a915e47ff56308
-  React-Core: 387a8e8a7e332856c2c3f98951a3642cd2556ddf
-  React-CoreModules: 079bb3a35599e8820bd54f25f4339724e8c2c486
-  React-cxxreact: f5fedd90b5ba3a3535d6e6b9d17c79aeec9e8b53
-  React-jsi: b9ba7f7c92208cb13cf01cd2ec6af4b501ed703b
-  React-jsiexecutor: 48e41213eec3d50c27032a68e82b2c5770f40156
-  React-jsinspector: c65c6c077899716150438d2fe176164d97f6b6db
-  React-perflogger: f8d300167f7a408e098bd0f7877160a04cd851fe
-  React-RCTActionSheet: 3505d0c1100d007997bb21f68740a1319114c47b
-  React-RCTAnimation: 22633a55ea2562f296120614073e3da081d910a5
-  React-RCTBlob: c5ea82d0321a4241ae55e7c77b146f0cac310ee8
-  React-RCTImage: 2ddba39665e347637a713423f034d4e7f5d5163c
-  React-RCTLinking: 93adbd992e581dd315ee96d14487a6408d59b1bb
-  React-RCTNetwork: 38d9dd4a8c113c9450b983e3b91c503f89aed004
-  React-RCTPushNotification: 7c96bab5ae61275b03de0a181e7dd9935da04460
-  React-RCTSettings: e448a7c122a2a205300c441256382a968c7543d4
-  React-RCTTest: cdcd38447d05cb0daeb116723a77b971d7fb0940
-  React-RCTText: d56f140650a91a92a480a0ce71d74536b6020ea4
-  React-RCTVibration: dac313c9a1553277f30e5fbd598a68dd711518b2
-  React-runtimeexecutor: c7d714c49eda4b87d0dce4cabf28cf2c53aa36ea
+  RCTRequired: 0ea88026d060bf199215a7d610be2cf6a22f666e
+  RCTTypeSafety: dd795222885edbe07f6d0735a955b05aff0ff9cf
+  React: 384ded38f36dd3f41a8ef4c685cfdcb4c9846418
+  React-callinvoker: 72030345aa920ee219954baacd167c6658c29bc8
+  React-Core: 7096fb74f13096f2c4cf4b542c6cacf9429ccd78
+  React-CoreModules: 982c9ed4b295434956f0614ea3eee5b7f55cd752
+  React-cxxreact: 33d26e6091794c31bb2679f8c3a125b176a8b67d
+  React-jsi: 99e2161fba887e25586dd26b5c63ff180740d8a3
+  React-jsiexecutor: 37b2e1b997d6b587f0c9850639b686e15887ae35
+  React-jsinspector: b0d98c9a96c834e3f8004d99fe0da49f68e63498
+  React-perflogger: e588c6d84fca7be07b60c52ac454b55a70eff6e3
+  React-RCTActionSheet: 605eded25566da17f233129379364b42885fc899
+  React-RCTAnimation: 52fd19e6059675252ab72c5e4863656e94559759
+  React-RCTBlob: 80ce770c5837394db360a0670f130f449d2bc220
+  React-RCTImage: 520ce37c343f2f62aa432110cd9ad8e767b5184c
+  React-RCTLinking: e84d5182aa9e4b7cf15bfdfbe400e4a6bc9aa01a
+  React-RCTNetwork: 2ded2ed8792f6e45f0f778077ec98b411c916f0c
+  React-RCTPushNotification: 75c7c42ae493185404ea5119b82a05dba2ef6d13
+  React-RCTSettings: 47b1b1470060966e34d61b35fadbe357e6f0acd5
+  React-RCTTest: ff70fe9055c72d7958712ff69146a58601000dc2
+  React-RCTText: 99efea5385bfc15661a51840c2faaacf1e0c6477
+  React-RCTVibration: ef36951f5864f9fba315b7d82092a40cc28ca37e
+  React-runtimeexecutor: 8bda60ba754e77dbc11df27fcd866575f418a2de
   React-TurboModuleCxx-RNW: 12172bdbaaf052406ec571465243fad4b2eb2702
-  React-TurboModuleCxx-WinRTPort: c5d5ef6fbd3de7ba108c7df5e67bf39a03552c66
-  ReactCommon: 4176ab7533e7385e8d274fbee09d9f7cd7c9570e
-  Yoga: df027d67e63ab6ec7bb4cb50101580fb978eeffa
+  React-TurboModuleCxx-WinRTPort: bf2b356cfe7da8682172de772ab31c44b8448508
+  ReactCommon: d254384dcbf18c08a9ccfb1001111122b5f73cd1
+  Yoga: e3c3e406f22955812d99050ad25c1dd797dcb549
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 096cbc796e89167c003b0c49186597432f0fb5e8


### PR DESCRIPTION
#### Please select one of the following
- [X] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Years ago we added in a runtime setting to allow third-party SDX clients to control if they're in debug mode on any builds, regardless of flavor. For the following reasons I'd like to revert this change:
1) Having this diff with FB upstream caused confusion with clients who don't realize we have this macOS repo specific change
2) After 3+ years we have zero clients who have communicated using this feature
3) Debug mode running by accident on ship builds has happened on multiple occasions
4) We've hit ship related crashers to being on debug mode in ship builds by accident

## Changelog

[iOS/macOS] [Feature] - Disabling debugging of ship builds

## Test Plan

I can no longer launch the debug menu from ship builds in rn-tester