### PR TITLE
Attaching RootView to instance in RootView.startReactApplication

### DIFF
--- a/.ado/templates/apple-droid-node-patching.yml
+++ b/.ado/templates/apple-droid-node-patching.yml
@@ -5,4 +5,4 @@ steps:
   - task: CmdLine@2
     displayName: Apply Android specific patches for Office consumption
     inputs:
-      script: node $(System.DefaultWorkingDirectory)/android-patches/bundle/bundle.js patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}
+      script: node $(System.DefaultWorkingDirectory)/android-patches/bundle/bundle.js patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}

--- a/android-patches/patches/RootViewAttach/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/android-patches/patches/RootViewAttach/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -1,0 +1,10 @@
+--- "E:\\gh\\react-native-macos2\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactRootView.java"	2021-11-05 17:21:36.664481900 -0700
++++ "E:\\gh\\react-native-macos\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactRootView.java"	2021-11-05 17:24:21.975326400 -0700
+@@ -384,6 +384,7 @@
+       mInitialUITemplate = initialUITemplate;
+ 
+       mReactInstanceManager.createReactContextInBackground();
++      attachToReactInstanceManager();
+ 
+     } finally {
+       Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);


### PR DESCRIPTION
This is a revert of this PR: https://github.com/facebook/react-native/commit/2c896d35782cd04c873aefadc947447cc30a7f60#diff-c6c68fb9580db5698d241fdd97b31a25ca1fdc061023a1bf1959f64fc4a00743

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

The PR mentioned above is breaking assumption taken by our RNHost. Hence reverting the commit until we have a better solution.

## Changelog

The PR mentioned above (https://github.com/facebook/react-native/commit/2c896d35782cd04c873aefadc947447cc30a7f60#diff-c6c68fb9580db5698d241fdd97b31a25ca1fdc061023a1bf1959f64fc4a00743) is breaking assumption taken by our RNHost. Hence reverting the commit until we have a better solution.

[CATEGORY] [TYPE] - Message

## Test Plan

Verified the functioning of LPC and commenting in devmain.
