### PR TITLE
(Test) Fix Circle CI config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ orbs:
 #        DEFAULTS
 # -------------------------
 defaults: &defaults
-  working_directory: ~/react-native
+  working_directory: ~/react-native-macos
   environment:
     - GIT_COMMIT_DESC: git log --format=oneline -n 1 $CIRCLE_SHA1
     # The public github tokens are publicly visible by design


### PR DESCRIPTION
I noticed that it's pointing to react-native instead of react-native-macos. I wonder if that will fix our issues..