### PR TITLE
Add nullability type

### DIFF
--- a/React/Base/RCTJSInvokerModule.h
+++ b/React/Base/RCTJSInvokerModule.h
@@ -12,6 +12,6 @@
 @protocol RCTJSInvokerModule
 
 @property (nonatomic, copy, nonnull) void (^invokeJS)(NSString * _Nullable module, NSString * _Nullable method, NSArray * _Nullable args); // TODO(macOS GH#774)
-@property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString * _Nullable moduleDotMethod, NSArray * _Nullable args); // TODO(macOS GH#774)
+@property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString *moduleDotMethod, NSArray *args);
 
 @end

--- a/React/Base/RCTJSInvokerModule.h
+++ b/React/Base/RCTJSInvokerModule.h
@@ -12,6 +12,6 @@
 @protocol RCTJSInvokerModule
 
 @property (nonatomic, copy, nonnull) void (^invokeJS)(NSString * _Nullable module, NSString * _Nullable method, NSArray * _Nullable args); // TODO(macOS GH#774)
-@property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString * _Nullable moduleDotMethod, NSArray * _Nullable args);
+@property (nonatomic, copy, nonnull) void (^invokeJSWithModuleDotMethod)(NSString * _Nullable moduleDotMethod, NSArray * _Nullable args); // TODO(macOS GH#774)
 
 @end

--- a/React/Base/RCTJSInvokerModule.h
+++ b/React/Base/RCTJSInvokerModule.h
@@ -12,6 +12,6 @@
 @protocol RCTJSInvokerModule
 
 @property (nonatomic, copy, nonnull) void (^invokeJS)(NSString * _Nullable module, NSString * _Nullable method, NSArray * _Nullable args); // TODO(macOS GH#774)
-@property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString *moduleDotMethod, NSArray *args);
+@property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString * _Nullable moduleDotMethod, NSArray * _Nullable args); // TODO(macOS GH#774)
 
 @end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -510,8 +510,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: 0af9c548d05821b8d3d8b1158af257ad82eb8c90
-  FBReactNativeSpec: c2d79a2c8c07216f6626c39111124f41d76d4c40
+  FBLazyVector: b52fc114a0d52dd9ff8cc2283570ada3457aac84
+  FBReactNativeSpec: be4e0456f993c7191f20eae44b56d9a4a1983f2c
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
@@ -522,35 +522,35 @@ SPEC CHECKSUMS:
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTRequired: 3da9abe24673584d7a79f5248832059899068f05
-  RCTTypeSafety: 7119233a5389023ed13c58d09d8ee7bb7088bad8
-  React: c0de64975793cccf0f4138daa4e590146b162f11
-  React-callinvoker: b1124c70c39d3ba0d015d32a158dc0a2eb9c7fa4
-  React-Core: 96446146b7e864c6198b23d7337a252cc9adab55
-  React-CoreModules: 7325e9048de2bbc116bcdb545cf747012d7afa6b
-  React-cxxreact: d86b284a0f9a7a3048459c9c770f4957586d63b8
-  React-jsi: fd6c9fc27e417504fcc0a2839e4d49ee62cd6147
-  React-jsiexecutor: db69b2bd700a8d0e1f45acbd4f67579eac008594
-  React-jsinspector: 89f8d52f0864887a8111927bfc2ca46bc92e42bc
-  React-perflogger: 880d12b4d24001fe05caa7dd97fc65a59d86a8ce
-  React-RCTActionSheet: 07569f6bbccf555da01fe45a85dc77fa73538e73
-  React-RCTAnimation: 953a20ae7e65edc4597db2f42bb1ab6f49139dbf
-  React-RCTBlob: 956b7b4fbca784a2c12a24670a153663a341af8d
-  React-RCTImage: ae01e26d1e08e7ec14efdcc495e11e270fd5d7e6
-  React-RCTLinking: ebb5724a94de55dba5b3ca4d81c3265a8e29906e
-  React-RCTNetwork: 170c0fb1fb9af1ee2a22dcc9b6210210a90e9ff0
-  React-RCTPushNotification: ee9e0b11dee6dad4fabb74bfbae70a3d2eed8ea3
-  React-RCTSettings: 1348016b05923c4eba469f7eb4de9f14d6c199ed
-  React-RCTTest: 922247d62baab8fdc5fdd050ca23b0d5f3d2dc17
-  React-RCTText: c3a41352baca01610f860dc955658574dc0a763c
-  React-RCTVibration: 4faffa992f29eacda03ade258837d2b66525efdf
-  React-runtimeexecutor: 05f6110ddd6882d227293094c983dbfc5db315b7
+  RCTRequired: f86fbb8c49d816c29b322f59e080df3fa0c1993f
+  RCTTypeSafety: 06e387a0369dae85677eb70453f2320296d94148
+  React: 0d4baf5072da5a80e865037c41c2c6e9344ec2d8
+  React-callinvoker: 9dc7c52e966663a99e368ea711a915e47ff56308
+  React-Core: 387a8e8a7e332856c2c3f98951a3642cd2556ddf
+  React-CoreModules: 079bb3a35599e8820bd54f25f4339724e8c2c486
+  React-cxxreact: f5fedd90b5ba3a3535d6e6b9d17c79aeec9e8b53
+  React-jsi: b9ba7f7c92208cb13cf01cd2ec6af4b501ed703b
+  React-jsiexecutor: 48e41213eec3d50c27032a68e82b2c5770f40156
+  React-jsinspector: c65c6c077899716150438d2fe176164d97f6b6db
+  React-perflogger: f8d300167f7a408e098bd0f7877160a04cd851fe
+  React-RCTActionSheet: 3505d0c1100d007997bb21f68740a1319114c47b
+  React-RCTAnimation: 22633a55ea2562f296120614073e3da081d910a5
+  React-RCTBlob: c5ea82d0321a4241ae55e7c77b146f0cac310ee8
+  React-RCTImage: 2ddba39665e347637a713423f034d4e7f5d5163c
+  React-RCTLinking: 93adbd992e581dd315ee96d14487a6408d59b1bb
+  React-RCTNetwork: 38d9dd4a8c113c9450b983e3b91c503f89aed004
+  React-RCTPushNotification: 7c96bab5ae61275b03de0a181e7dd9935da04460
+  React-RCTSettings: e448a7c122a2a205300c441256382a968c7543d4
+  React-RCTTest: cdcd38447d05cb0daeb116723a77b971d7fb0940
+  React-RCTText: d56f140650a91a92a480a0ce71d74536b6020ea4
+  React-RCTVibration: dac313c9a1553277f30e5fbd598a68dd711518b2
+  React-runtimeexecutor: c7d714c49eda4b87d0dce4cabf28cf2c53aa36ea
   React-TurboModuleCxx-RNW: 12172bdbaaf052406ec571465243fad4b2eb2702
-  React-TurboModuleCxx-WinRTPort: 557ca6d53cca3bf5f9d42a1cb1cd9ff5d887d006
-  ReactCommon: e3384ac2e3de59fce90c35524d6fae1ca82a21fe
-  Yoga: c80bf412b7c3f863cbb5aa73cfb6568c33b20220
+  React-TurboModuleCxx-WinRTPort: c5d5ef6fbd3de7ba108c7df5e67bf39a03552c66
+  ReactCommon: 4176ab7533e7385e8d274fbee09d9f7cd7c9570e
+  Yoga: df027d67e63ab6ec7bb4cb50101580fb978eeffa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 096cbc796e89167c003b0c49186597432f0fb5e8
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

We have more strict warning -> error checks downstream and one of the checks requires the block pointer to have a nullability type.

## Changelog

[Bug] [iOS/macOS] - Add nullability check

## Test Plan

Just fixes up a warning- if CI passes then everything should be clear.