### PR TITLE
Add a nullable check

### DIFF
--- a/React/Modules/RCTEventEmitter.h
+++ b/React/Modules/RCTEventEmitter.h
@@ -16,7 +16,7 @@
 
 @property (nonatomic, weak) RCTBridge * _Nullable bridge; // TODO(macOS GH#774)
 
-- (instancetype)initWithDisabledObservation;
+- (instancetype _Nullable)initWithDisabledObservation; // TODO(macOS GH#774)
 
 /**
  * Override this method to return an array of supported event names. Attempting

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -510,8 +510,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
-  FBLazyVector: b52fc114a0d52dd9ff8cc2283570ada3457aac84
-  FBReactNativeSpec: be4e0456f993c7191f20eae44b56d9a4a1983f2c
+  FBLazyVector: 2cd8b2450a7de278408f5be1467889e90a08f258
+  FBReactNativeSpec: 02b76af7d3c9034135e4d9d94293bf768752d250
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: e4493b013c02d9347d5e0cb4d128680239f6c78a
@@ -522,33 +522,33 @@ SPEC CHECKSUMS:
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
   RCT-Folly: b3998425a8ee9f695f57a204dc494534246f0fe9
-  RCTRequired: f86fbb8c49d816c29b322f59e080df3fa0c1993f
-  RCTTypeSafety: 06e387a0369dae85677eb70453f2320296d94148
-  React: 0d4baf5072da5a80e865037c41c2c6e9344ec2d8
-  React-callinvoker: 9dc7c52e966663a99e368ea711a915e47ff56308
-  React-Core: 387a8e8a7e332856c2c3f98951a3642cd2556ddf
-  React-CoreModules: 079bb3a35599e8820bd54f25f4339724e8c2c486
-  React-cxxreact: f5fedd90b5ba3a3535d6e6b9d17c79aeec9e8b53
-  React-jsi: b9ba7f7c92208cb13cf01cd2ec6af4b501ed703b
-  React-jsiexecutor: 48e41213eec3d50c27032a68e82b2c5770f40156
-  React-jsinspector: c65c6c077899716150438d2fe176164d97f6b6db
-  React-perflogger: f8d300167f7a408e098bd0f7877160a04cd851fe
-  React-RCTActionSheet: 3505d0c1100d007997bb21f68740a1319114c47b
-  React-RCTAnimation: 22633a55ea2562f296120614073e3da081d910a5
-  React-RCTBlob: c5ea82d0321a4241ae55e7c77b146f0cac310ee8
-  React-RCTImage: 2ddba39665e347637a713423f034d4e7f5d5163c
-  React-RCTLinking: 93adbd992e581dd315ee96d14487a6408d59b1bb
-  React-RCTNetwork: 38d9dd4a8c113c9450b983e3b91c503f89aed004
-  React-RCTPushNotification: 7c96bab5ae61275b03de0a181e7dd9935da04460
-  React-RCTSettings: e448a7c122a2a205300c441256382a968c7543d4
-  React-RCTTest: cdcd38447d05cb0daeb116723a77b971d7fb0940
-  React-RCTText: d56f140650a91a92a480a0ce71d74536b6020ea4
-  React-RCTVibration: dac313c9a1553277f30e5fbd598a68dd711518b2
-  React-runtimeexecutor: c7d714c49eda4b87d0dce4cabf28cf2c53aa36ea
+  RCTRequired: a3bd1751e9cf0e38d20f3cbb929942bba696f228
+  RCTTypeSafety: 9026992c34211be11abe388a656b8293c34ca51d
+  React: bbd3a9e2b0249733cbe9ad7acfaf8a76518d2bc3
+  React-callinvoker: 47411c997957069224b8dab7c54df4120761609c
+  React-Core: 4aed02f28118c924e2ed70fa7986bd972e968375
+  React-CoreModules: caf07250a9edfc74023809086c87b20e85b02c39
+  React-cxxreact: 7c446b2022686f641f436c85ce3f150db8af2673
+  React-jsi: c5d9184708894542c535b444e140def931175718
+  React-jsiexecutor: 5d2ee18b3edcc35465d0bda5792d78d914b3db36
+  React-jsinspector: 811d62cd7cda93f2e20455ce01d145318daad54f
+  React-perflogger: b3498f7e34f9a4d17f894c2881bae1a09c0f0244
+  React-RCTActionSheet: a64e3b4f8443fbb7fa521f0c5c5d12ef32ca7333
+  React-RCTAnimation: 8d43053e147b2a03a0dd814b29fdee7400812db2
+  React-RCTBlob: b085c43bf4c3e6666249b8b3e1059c81e4b0e4da
+  React-RCTImage: c31b49d6fa0aca5f0d156689faf812f2fcbe327d
+  React-RCTLinking: 0f37717500127be6ade174ee0e90b1c2e030812b
+  React-RCTNetwork: 4436de92dd6069a955762d0b236824549e9c181c
+  React-RCTPushNotification: 4214b15df86eb9ca37a755213b0492e94b8e25ac
+  React-RCTSettings: 41666d59dd7f3f4b83308bc529cbd2885b8198ee
+  React-RCTTest: 9d497d39f71774fdceb5636872a31ea8cf6299c4
+  React-RCTText: b6d0d3b2b4e3ea50682364d018343cd9816d457f
+  React-RCTVibration: d99e0b8f6b7c501259d277d4439e57098bccb7c5
+  React-runtimeexecutor: 1c02384ab067ef628535c5ea9fea5237bdd63c0a
   React-TurboModuleCxx-RNW: 12172bdbaaf052406ec571465243fad4b2eb2702
-  React-TurboModuleCxx-WinRTPort: c5d5ef6fbd3de7ba108c7df5e67bf39a03552c66
-  ReactCommon: 4176ab7533e7385e8d274fbee09d9f7cd7c9570e
-  Yoga: df027d67e63ab6ec7bb4cb50101580fb978eeffa
+  React-TurboModuleCxx-WinRTPort: ecb3b6ab042309397cb7473c7d6de5b62f918c0b
+  ReactCommon: 70e4686a26373df89f82a55f093f393d225ae10a
+  Yoga: 4eb93eb55b6973947ed8e71bb82c1dfaa849bd4c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 096cbc796e89167c003b0c49186597432f0fb5e8


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

There's one more spot we need a nullable type specifier due to downstream deps having the `-Wnullability-completeness` flag enabled.

## Test Plan

Shouldn't affect user scenarios, but if it builds then should be all set.