### PR TITLE
Add nullable check

### DIFF
--- a/React/Modules/RCTEventEmitter.h
+++ b/React/Modules/RCTEventEmitter.h
@@ -16,7 +16,7 @@
 
 @property (nonatomic, weak) RCTBridge * _Nullable bridge; // TODO(macOS GH#774)
 
-- (instancetype)initWithDisabledObservation;
+- (instancetype _Nullable)initWithDisabledObservation; // TODO(macOS GH#774)
 
 /**
  * Override this method to return an array of supported event names. Attempting

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
     - OpenSSL-Universal (= 1.1.180)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.3.0):
+  - Flipper-RSocket (1.3.1):
     - Flipper-Folly (~> 2.5)
   - FlipperKit (0.75.1):
     - FlipperKit/Core (= 0.75.1)
@@ -508,13 +508,13 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 0ea4559a49682230337df966e735d6cc7760108e
   FBLazyVector: 22a9cb8b942c7b55809e8b4d96c32a27bda2c8e5
-  FBReactNativeSpec: 372dade600a122e6f1ce13204e392238cb816f54
+  FBReactNativeSpec: bef136c2534e8a6f61395120b3ef0fc327d9da7b
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 602921fee03edacf18f5d6f3d3594ba477f456e5
+  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   glog: 0dc7efada961c0793012970b60faebbd58b0decb
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
@@ -551,4 +551,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: fc89892d7bd92e5bb34cedc778a0e7fff4c0da86
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.10.2


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

There's one more spot we need a nullable type specifier due to downstream deps having the `-Wnullability-completeness` flag enabled.

## Test Plan

Shouldn't affect user scenarios, but if it builds then should be all set.