### PR TITLE
Load Required Libraries in ReactBridge's static init

### DIFF
--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
@@ -1,6 +1,6 @@
 --- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
 +++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
-@@ -31,6 +31,22 @@ public class ReactBridge {
+@@ -31,6 +31,25 @@ public class ReactBridge {
      Systrace.beginSection(
          TRACE_TAG_REACT_JAVA_BRIDGE, "ReactBridge.staticInit::load:reactnativejni");
      ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START);
@@ -15,10 +15,13 @@
 +	SoLoader.loadLibrary("v8jsi");
 +    }catch (UnsatisfiedLinkError jscE){}
 +
++    SoLoader.loadLibrary("glog");
 +    SoLoader.loadLibrary("glog_init");
 +    SoLoader.loadLibrary("fb");
 +    SoLoader.loadLibrary("fbjni");
 +    SoLoader.loadLibrary("yoga");
++    SoLoader.loadLibrary("folly_json");
++    SoLoader.loadLibrary("reactperfloggerjni");
 +    SoLoader.loadLibrary("jsinspector");
      SoLoader.loadLibrary("reactnativejni");
      ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END);

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
@@ -1,0 +1,25 @@
+--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
++++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
+@@ -31,6 +31,22 @@ public class ReactBridge {
+     Systrace.beginSection(
+         TRACE_TAG_REACT_JAVA_BRIDGE, "ReactBridge.staticInit::load:reactnativejni");
+     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START);
++
++    // JS Engine is configurable.. And we exepct only one packaged
++    // Hence ignore failure
++    try {
++	SoLoader.loadLibrary("hermes");
++    }catch (UnsatisfiedLinkError jscE){}
++
++    try {
++	SoLoader.loadLibrary("v8jsi");
++    }catch (UnsatisfiedLinkError jscE){}
++
++    SoLoader.loadLibrary("glog_init");
++    SoLoader.loadLibrary("fb");
++    SoLoader.loadLibrary("fbjni");
++    SoLoader.loadLibrary("yoga");
++    SoLoader.loadLibrary("jsinspector");
+     SoLoader.loadLibrary("reactnativejni");
+     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END);
+     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [👍] I am making a change required for Microsoft usage of react-native

## Summary

This change was there in RN63 and was removed in RN64 as an optimization.
However, this is a probable root cause for a regression. Hence adding the
patch again

## Changelog

Modified the ReactBridge.java through a patch file in android-patches folder

