### PR TITLE
Scene support for alerts

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -33,7 +33,16 @@
 - (void)show:(BOOL)animated completion:(void (^)(void))completion
 {
   [self.alertWindow makeKeyAndVisible];
-  [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
+
+  // [TODO(macOS GH#774)
+  // If the window is tracked by our application then it will show the alert
+  if ([[[UIApplication sharedApplication] windows] containsObject:self.alertWindow]) {
+    [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
+  } else {
+    // When using Scenes, we must present the alert from a view controller associated with a window in the Scene. A fresh window (i.e. _alertWindow) cannot show the alert.
+    [RCTPresentedViewController() presentViewController:self animated:animated completion:completion];
+  }
+  // TODO(macOS GH#774)]
 }
 #endif // ]TODO(macOS GH#774)
 

--- a/React/CoreModules/RCTAlertManager.mm
+++ b/React/CoreModules/RCTAlertManager.mm
@@ -199,7 +199,7 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::NativeArgs &)args cal
   [_alertControllers addObject:alertController];
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    [RCTPresentedViewController() presentViewController:alertController animated:animated completion:completion]; // [TODO(macOS GH#774) When using Scenes, we must present the alert from a view controller associated with a window in the Scene
+    [alertController show:YES completion:nil];
   });
 #else // [TODO(macOS GH#774)
   

--- a/React/CoreModules/RCTAlertManager.mm
+++ b/React/CoreModules/RCTAlertManager.mm
@@ -199,7 +199,7 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::NativeArgs &)args cal
   [_alertControllers addObject:alertController];
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    [alertController show:YES completion:nil];
+    [RCTPresentedViewController() presentViewController:alertController animated:animated completion:completion]; // [TODO(macOS GH#774) When using Scenes, we must present the alert from a view controller associated with a window in the Scene
   });
 #else // [TODO(macOS GH#774)
   


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

We hit a bug downstream with the existing implementation where we use Scenes in our app which require alerts to be presented from a window associated with the app's UIWindowScene.

Currently without this fix, when we attempt to create a new UIWindow and UIViewController to present a modal alert, that UIWindow isn't associated with any of the app's scenes which results in the app silently failing to show the alert.

The fix is to more or less revert the incriminating part of [this](https://github.com/facebook/react-native/commit/f319ff321c4b7c0929b99e3ebe7e1ce1fa50b34c) change. This is the least intrusive way to make a safe fix, but once this is in, I'd like to make a fuller fix where we find a reasonable way to pair the new UIWindow with the app's scene and continue using that instead.

## Changelog

[iOS] [Alert] - Fix modal alert issue using UIScenes

## Test Plan

Tested in a downstream app and this is required to show an alert in response to an action sheet closing in an app leveraging UIScenes.