### PR TITLE
add enableFocusRing feature for TextInput component

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1191,7 +1191,7 @@ function InternalTextInput(props: Props): React.Node {
         accessibilityState={props.accessibilityState}
         nativeID={props.nativeID}
         testID={props.testID}
-        enableFocusRing={props.enableFocusRing}
+        enableFocusRing={props.enableFocusRing} // TODO(macOS GH#774)
         {...additionalTouchableProps}>
         {textInput}
       </TouchableWithoutFeedback>

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1191,6 +1191,7 @@ function InternalTextInput(props: Props): React.Node {
         accessibilityState={props.accessibilityState}
         nativeID={props.nativeID}
         testID={props.testID}
+        enableFocusRing={props.enableFocusRing}
         {...additionalTouchableProps}>
         {textInput}
       </TouchableWithoutFeedback>

--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
@@ -87,6 +87,13 @@
     [self replaceSubview:previousTextField with:_backedTextInputView];
   }
 }
+
+- (void)setEnableFocusRing:(BOOL)enableFocusRing {
+  [super setEnableFocusRing:enableFocusRing];
+  if ([_backedTextInputView respondsToSelector:@selector(setEnableFocusRing:)]) {
+    [_backedTextInputView setEnableFocusRing:enableFocusRing];
+  }
+}
 #endif // ]TODO(macOS GH#774)
 
 @end

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSTextAlignment textAlignment;
 @property (nonatomic, getter=isAutomaticTextReplacementEnabled) BOOL automaticTextReplacementEnabled;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
+@property (nonatomic, assign) BOOL enableFocusRing;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor;
 @property (weak, nullable) id<RCTUITextFieldDelegate> delegate;
 #endif // ]TODO(macOS GH#774)

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -212,6 +212,24 @@
 {
   return ((RCTUITextFieldCell*)self.cell).font;
 }
+    
+@synthesize enableFocusRing = _enableFocusRing;
+
+- (BOOL)enableFocusRing {
+  return _enableFocusRing;
+}
+
+- (void)setEnableFocusRing:(BOOL)enableFocusRing {
+  if (_enableFocusRing != enableFocusRing) {
+    _enableFocusRing = enableFocusRing;
+  }
+
+  if (enableFocusRing) {
+    [self setFocusRingType:NSFocusRingTypeDefault];
+  } else {
+    [self setFocusRingType:NSFocusRingTypeNone];
+  }
+}
 
 #endif // ]TODO(macOS GH#774)
 
@@ -304,24 +322,6 @@
   NSAttributedString *originalText = [self.attributedText copy];
   self.attributedText = [NSAttributedString new];
   self.attributedText = originalText;
-}
-
-@synthesize enableFocusRing = _enableFocusRing;
-
-- (BOOL)enableFocusRing {
-  return _enableFocusRing;
-}
-
-- (void)setEnableFocusRing:(BOOL)enableFocusRing {
-  if (_enableFocusRing != enableFocusRing) {
-    _enableFocusRing = enableFocusRing;
-  }
-
-  if (enableFocusRing) {
-    [self setFocusRingType:NSFocusRingTypeDefault];
-  } else {
-    [self setFocusRingType:NSFocusRingTypeNone];
-  }
 }
 
 

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -306,6 +306,25 @@
   self.attributedText = originalText;
 }
 
+@synthesize enableFocusRing = _enableFocusRing;
+
+- (BOOL)enableFocusRing {
+  return _enableFocusRing;
+}
+
+- (void)setEnableFocusRing:(BOOL)enableFocusRing {
+  if (_enableFocusRing != enableFocusRing) {
+    _enableFocusRing = enableFocusRing;
+  }
+
+  if (enableFocusRing) {
+    [self setFocusRingType:NSFocusRingTypeDefault];
+  } else {
+    [self setFocusRingType:NSFocusRingTypeNone];
+  }
+}
+
+
 #endif // ]TODO(macOS GH#774)
 
 

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -212,12 +212,6 @@
 {
   return ((RCTUITextFieldCell*)self.cell).font;
 }
-    
-@synthesize enableFocusRing = _enableFocusRing;
-
-- (BOOL)enableFocusRing {
-  return _enableFocusRing;
-}
 
 - (void)setEnableFocusRing:(BOOL)enableFocusRing {
   if (_enableFocusRing != enableFocusRing) {
@@ -323,7 +317,6 @@
   self.attributedText = [NSAttributedString new];
   self.attributedText = originalText;
 }
-
 
 #endif // ]TODO(macOS GH#774)
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Implements `enableFocusRing` for TextInput component. Solves https://github.com/microsoft/react-native-macos/issues/795

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed #795] - add ability to disable focus ring for TextInput component https://github.com/microsoft/react-native-macos/issues/795

## Test Plan

I've created fresh new react-native-macos app and add 2 TextInput components to the App.tsx

```typescript
...

<SafeAreaView style={backgroundStyle}>
      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />

      <TextInput
        enableFocusRing={false}
        style={{
          width: 200,
          borderBottomColor: isDarkMode ? 'white' : 'gray',
          borderBottomWidth: 1,
          alignItems: 'center',
          justifyContent: 'center',
          flexDirection: 'row',
        }}
      />
      <TextInput
        style={{
          width: 200,
          borderBottomColor: isDarkMode ? 'white' : 'gray',
          borderBottomWidth: 1,
          alignItems: 'center',
          justifyContent: 'center',
          flexDirection: 'row',
        }}
        enableFocusRing={true}
      />
    </SafeAreaView>

...
```