### PR TITLE
Package .so files in AAR File

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -42,7 +42,7 @@ jobs:
       - task: CmdLine@2
         displayName: gradlew installArchives
         inputs:
-          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
+          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives
 
       - template: templates\prep-android-nuget.yml
 

--- a/.ado/npmOfficePack.js
+++ b/.ado/npmOfficePack.js
@@ -28,7 +28,7 @@ function doPublish(fakeMode) {
   if (!onlyTagSource) {
     // -------- Generating Android Artifacts with JavaDoc
     const depsEnvPrefix = "REACT_NATIVE_BOOST_PATH=" + path.join(process.env.BUILD_SOURCESDIRECTORY, "build_deps");
-    const gradleCommand = path.join(process.env.BUILD_SOURCESDIRECTORY, "gradlew") + " installArchives -Pparam=\"excludeLibs\"";
+    const gradleCommand = path.join(process.env.BUILD_SOURCESDIRECTORY, "gradlew") + " installArchives";
     exec( depsEnvPrefix + " " + gradleCommand );
 
     // undo uncommenting javadoc setting

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -175,7 +175,7 @@ jobs:
       - task: CmdLine@2
         displayName: gradlew installArchives
         inputs:
-          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
+          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives
 
       - template: templates\prep-android-nuget.yml
 

--- a/android-patches/patches/Build/ReactAndroid/release.gradle
+++ b/android-patches/patches/Build/ReactAndroid/release.gradle
@@ -8,3 +8,14 @@
          source = android.sourceSets.main.java.srcDirs
          classpath += files(android.bootClasspath)
          classpath += files(project.getConfigurations().getByName("compile").asList())
+@@ -130,7 +131,9 @@ afterEvaluate { project ->
+         }
+     }
+ 
+-    task installArchives(type: Upload) {
++    tasks.mergeReleaseJniLibFolders.dependsOn packageReactNdkLibs
++
++    task installArchives(type: Upload,dependsOn: mergeReleaseJniLibFolders) {
+         configuration = configurations.archives
+         repositories.mavenDeployer {
+             // Deploy to react-native/android, ready to publish to npm


### PR DESCRIPTION
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [👍 ] I am making a change required for Microsoft usage of react-native

## Summary

The native .so files were missing from AAR packaging. This change adds it back

## Changelog

Remove excludeLibs parameter from build command


