### PR TITLE
Disable a bugprone-move-forwarding-reference error when running static analysis against jsi.h

### DIFF
--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -937,7 +937,9 @@ class JSI_EXPORT Value {
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
+#ifndef __clang_analyzer__
     new (&data_.pointer) T(std::move(other));
+#endif // __clang_analyzer__
   }
 
   /// Value("foo") will treat foo as a bool.  This makes doing that a

--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -937,7 +937,7 @@ class JSI_EXPORT Value {
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
-#ifndef __clang_analyzer__ // Disable [bugprone-move-forwarding-reference] when running clang static analysis
+#ifndef __clang_analyzer__ // TODO(macOS GH#774) Disable [bugprone-move-forwarding-reference] when running clang static analysis
     new (&data_.pointer) T(std::move(other));
 #endif // __clang_analyzer__
   }

--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -937,7 +937,7 @@ class JSI_EXPORT Value {
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
-#ifndef __clang_analyzer__
+#ifndef __clang_analyzer__ // Disable [bugprone-move-forwarding-reference] when running clang static analysis
     new (&data_.pointer) T(std::move(other));
 #endif // __clang_analyzer__
   }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x ] I am making a change required for Microsoft usage of react-native

## Summary
When running clang static analysis on any project that includes jsi.h, we hit an error:
jsi.h:940:28: Forwarding reference passed to std::move(), which may unexpectedly cause lvalues to be moved; use std::forward() instead

In clang's static-analyzer, this is classified as a `[bugprone-move-forwarding-reference]`. From all the docs and source code I can find, I can't find a way to suppress this error in the static analysis invocation because this seems like it is a clang-tidy check that somehow clang's analyzer also checks.

I'm not positive std::forward is the right way to move forward here, so let's just suppress for now to minimize risk while unblocking use of the static-analyzer (unblocked = "it passes on every run so engineers can trust failures"). Submitting here rather than Facebook because getting static analysis unblocked for our use case is rather urgent.

## Changelog
[General] [Fixed] Suppress errors running static analysis when including jsi.h

## Test Plan
Locally run static analysis through Xcode and through command line xcodebuild invocation