### PR TITLE
Disable a bugprone-move-forwarding-reference static analysis error

### DIFF
--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -937,7 +937,9 @@ class JSI_EXPORT Value {
             std::is_base_of<String, T>::value ||
             std::is_base_of<Object, T>::value,
         "Value cannot be implicitly move-constructed from this type");
+#ifndef __clang_analyzer__ // TODO(macOS GH#774) Disable [bugprone-move-forwarding-reference] when running clang static analysis
     new (&data_.pointer) T(std::move(other));
+#endif // __clang_analyzer__
   }
 
   /// Value("foo") will treat foo as a bool.  This makes doing that a


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ x ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry pick #934 to 0.64-stable to unblock static analyzer usage

## Changelog

[General] [Fixed] Suppress errors running static analysis when including jsi.h

## Test Plan

See #934 