### PR TITLE
Add enableFocusRing feature for TextInput component (#932)

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1193,6 +1193,7 @@ function InternalTextInput(props: Props): React.Node {
         accessibilityState={props.accessibilityState}
         nativeID={props.nativeID}
         testID={props.testID}
+        enableFocusRing={props.enableFocusRing} // TODO(macOS GH#774)
         {...additionalTouchableProps}>
         {textInput}
       </TouchableWithoutFeedback>

--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
@@ -87,6 +87,13 @@
     [self replaceSubview:previousTextField with:_backedTextInputView];
   }
 }
+
+- (void)setEnableFocusRing:(BOOL)enableFocusRing {
+  [super setEnableFocusRing:enableFocusRing];
+  if ([_backedTextInputView respondsToSelector:@selector(setEnableFocusRing:)]) {
+    [_backedTextInputView setEnableFocusRing:enableFocusRing];
+  }
+}
 #endif // ]TODO(macOS GH#774)
 
 @end

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSTextAlignment textAlignment;
 @property (nonatomic, getter=isAutomaticTextReplacementEnabled) BOOL automaticTextReplacementEnabled;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
+@property (nonatomic, assign) BOOL enableFocusRing;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor;
 @property (weak, nullable) id<RCTUITextFieldDelegate> delegate;
 #endif // ]TODO(macOS GH#774)

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -213,6 +213,18 @@
   return ((RCTUITextFieldCell*)self.cell).font;
 }
 
+- (void)setEnableFocusRing:(BOOL)enableFocusRing {
+  if (_enableFocusRing != enableFocusRing) {
+    _enableFocusRing = enableFocusRing;
+  }
+
+  if (enableFocusRing) {
+    [self setFocusRingType:NSFocusRingTypeDefault];
+  } else {
+    [self setFocusRingType:NSFocusRingTypeNone];
+  }
+}
+
 #endif // ]TODO(macOS GH#774)
 
 - (void)setPlaceholder:(NSString *)placeholder


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Bringing a [change from master](https://github.com/microsoft/react-native-macos/pull/932) over to our 0.64-stable branch.

`git cherry-pick 053c2b4be5517e57473f922d36ea73975814f880`

## Test Plan

This was tested in master.