### PR TITLE
Fix Danger bot

### DIFF
--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -82,14 +82,9 @@ if (!includesChangelog) {
 // Fails if the PR is opened against anything other than `master` or `-stable`.
 const isMergeRefMaster = danger.github.pr.base.ref === 'master';
 const isMergeRefStable = danger.github.pr.base.ref.indexOf('-stable') !== -1;
-if (!isMergeRefMaster && isMergeRefStable) {
-  const title = ':grey_question: Base Branch';
-  const idea =
-    'The base branch for this PR is something other than `master`. Are you sure you want to merge these changes into a stable release? If you are interested in backporting updates to an older release, the suggested approach is to land those changes on `master` first and then cherry-pick the commits into the branch for that release. The [Releases Guide](https://github.com/facebook/react-native/blob/master/Releases.md) has more information.';
-  warn(`${title} - <i>${idea}</i>`);
-} else if (!isMergeRefMaster && !isMergeRefStable) {
+if (!isMergeRefMaster && !isMergeRefStable) {
   const title = ':exclamation: Base Branch';
   const idea =
-    'The base branch for this PR is something other than `master`. [Are you sure you want to target something other than the `master` branch?](https://reactnative.dev/docs/contributing.html#pull-requests)';
+    'The base branch for this PR is something other than `main` or a `-stable` branch. [Are you sure you want to target something other than the `main` branch?](https://reactnative.dev/docs/contributing#pull-requests)';
   fail(`${title} - <i>${idea}</i>`);
 }


### PR DESCRIPTION
Cherry Pick https://github.com/facebook/react-native/commit/90f0de99ada68fc0d877f2efe297538e733d9b56#diff-bbe0a01c823e91c3b712b516d840a2c86b13925e5f06bd8335e72b29f74468e8 to fix our danger bot

---

Summary:
Changelog: [Internal] Remove warning about creating a pull request to a release branch

We want to support this use case as we want pick requesters to land the cherry-picks themselves and rely on CircleCI automation to test

Reviewed By: cortinico

Differential Revision: D32780819

fbshipit-source-id: 882625a016653dbf480da33fd499d3718b2b5524
