### PR TITLE
Revert unneeded diff in metro config

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -29,13 +29,4 @@ const config = {
   transformer: {},
 };
 
-// In scripts/run-ci-e2e-tests.js this file gets copied to a new app, in which
-// case these settings do not apply.
-if (!process.env.REACT_NATIVE_RUNNING_E2E_TESTS) {
-  const InitializeCore = require.resolve('./Libraries/Core/InitializeCore');
-  const AssetRegistry = require.resolve('./Libraries/Image/AssetRegistry');
-  config.serializer.getModulesRunBeforeMainModule = () => [InitializeCore];
-  config.transformer.assetRegistryPath = AssetRegistry;
-}
-
 module.exports = config;

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -276,12 +276,16 @@ try {
       exitCode = 1;
       throw Error(exitCode);
     }
-    describe('Test: Flow check');
-    if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
-      echo('Flow check failed.');
-      exitCode = 1;
-      throw Error(exitCode);
-    }
+    // [TODO(macOS GH#949)
+    // Comment out failing test to unblock CI
+    // It seems It's running the flow checks against react-native-macos 0.63 instead of what is in the repo causing a failure
+    // describe('Test: Flow check');
+    // if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
+    //   echo('Flow check failed.');
+    //   exitCode = 1;
+    //   throw Error(exitCode);
+    // }
+    // ]TODO(macOS GH#949)
   }
   exitCode = 0;
 } finally {

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -100,10 +100,6 @@ try {
   mv('_flowconfig', '.flowconfig');
   mv('_watchmanconfig', '.watchmanconfig');
 
-  // [TODO(macOS GH#774)
-  process.env.REACT_NATIVE_RUNNING_E2E_TESTS = 'true';
-  // ]TODO(macOS GH#774)
-
   describe('Install React Native package');
   exec(`npm install ${REACT_NATIVE_PACKAGE}`);
 
@@ -280,16 +276,12 @@ try {
       exitCode = 1;
       throw Error(exitCode);
     }
-    // [TODO(macOS GH#949)
-    // Comment out failing test to unblock CI
-    // It seems It's running the flow checks against react-native-macos 0.63 instead of what is in the repo causing a failure
-    // describe('Test: Flow check');
-    // if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
-    //   echo('Flow check failed.');
-    //   exitCode = 1;
-    //   throw Error(exitCode);
-    // }
-    // ]TODO(macOS GH#949)
+    describe('Test: Flow check');
+    if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
+      echo('Flow check failed.');
+      exitCode = 1;
+      throw Error(exitCode);
+    }
   }
   exitCode = 0;
 } finally {


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

I was looking into our Circle CI E2E tests, when I noticed we had this strange diff. Our metro config was loading two modules (InitializeCore + Image Asset Registry) before other modules. Looking deeper, I saw React Native Windows had a bug around this too. They added that behavior to their metro config in https://github.com/microsoft/react-native-windows/pull/4814 , fixed the issue upstream in the CLI with https://github.com/react-native-community/cli/pull/1115 , and then backed out the change in React Native Windows in https://github.com/microsoft/react-native-windows/pull/4939 .

After the CLI change went in, it seems like we too should not need to load these modules first, so I am removing this change. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Removed unnecessary diff from upstream in our metro config

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


This change was originally added to fix fast refresh, so I'm hoping testing fast refresh on rn-tester + CI checks should be enough. I'll also tag @acoates-ms who made the CLI / RNW changes to verify I'm not being dumb or missed anything. 