### PR TITLE
[0.64] Expose text tooltip

### DIFF
--- a/Libraries/Text/TextNativeComponent.js
+++ b/Libraries/Text/TextNativeComponent.js
@@ -42,6 +42,7 @@ export const NativeText: HostComponent<NativeTextProps> = (createReactNativeComp
       onTextLayout: true,
       onInlineViewLayout: true,
       dataDetectorType: true,
+      tooltip: true, // [TODO(macOS GH#774)]
     },
     directEventTypes: {
       topTextLayout: {


### PR DESCRIPTION
Cherry pick #960 into 0.64-stable
=========================
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

A client was reporting that tooltip wasn't showing up on the text component. This seems to be a simple one line fix.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fix Tooltip on Text not showing up

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Checked the tooltip test page that tooltip on <Text> shows up.

![Screen Shot 2022-01-14 at 10 28 53 PM](https://user-images.githubusercontent.com/6722175/149608901-b170a2f8-499d-4520-ae57-bdc7978b40cd.png)


