### PR TITLE
[0.64] Fix CI

### DIFF
--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -280,12 +280,16 @@ try {
       exitCode = 1;
       throw Error(exitCode);
     }
-    describe('Test: Flow check');
-    if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
-      echo('Flow check failed.');
-      exitCode = 1;
-      throw Error(exitCode);
-    }
+    // [TODO(macOS GH#949)
+    // Comment out failing test to unblock CI
+    // It seems It's running the flow checks against react-native-macos 0.63 instead of what is in the repo causing a failure
+    // describe('Test: Flow check');
+    // if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
+    //   echo('Flow check failed.');
+    //   exitCode = 1;
+    //   throw Error(exitCode);
+    // }
+    // ]TODO(macOS GH#949)
   }
   exitCode = 0;
 } finally {

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -280,16 +280,12 @@ try {
       exitCode = 1;
       throw Error(exitCode);
     }
-    // [TODO(macOS GH#949)
-    // Comment out failing test to unblock CI
-    // It seems It's running the flow checks against react-native-macos 0.63 instead of what is in the repo causing a failure
-    // describe('Test: Flow check');
-    // if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
-    //   echo('Flow check failed.');
-    //   exitCode = 1;
-    //   throw Error(exitCode);
-    // }
-    // ]TODO(macOS GH#949)
+    describe('Test: Flow check');
+    if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
+      echo('Flow check failed.');
+      exitCode = 1;
+      throw Error(exitCode);
+    }
   }
   exitCode = 0;
 } finally {

--- a/template/package.json
+++ b/template/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "react": "17.0.1",
+    "react-native": "^0.64.0",
     "react-native-macos": "0.64.22"
   },
   "devDependencies": {

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "17.0.1",
-    "react-native": "0.64.22"
+    "react-native-macos": "0.64.22"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
Cherry pick #945 and whatever else I need to get CI green.

=====

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The `Flow Check` phase of our End to End Circle CI tests fails. This _seems_ to be because the E2E test is installing _react-native-macos` version 0.63 instead of latest (which is missing the `Colors.darker` variable, which is how I figured that out. I haven't figured it out yet (perhaps #944 will help?), but this is blocking PRs quite a bit. Let's comment it out for now

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Removed] - Removed Flow check test from E2E tests temporarily

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

