### PR TITLE
0.66-stable: Pass -v to android CI

### DIFF
--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -48,7 +48,7 @@ steps:
   - task: CmdLine@2
     displayName: Bump canary package version
     inputs:
-      script: node scripts/bump-oss-version.js --nightly
+      script: node scripts/bump-oss-version.js --nightly -v 0.0.1000
     condition: or(eq(variables['Build.SourceBranchName'], 'main'), not(contains(variables['Build.SourceBranchName'], '-stable')))
 
   # TODO: We don't seem to be running bump-oss-version.js for stable branches, hence we would end up publishing using the values in the repository.


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Fix up some broken Android CI

## Test Plan

When android cI passes then we know the fix is correct.