### PR TITLE
fix: Hermes no longer builds without `Exception.cpp`

### DIFF
--- a/third-party-podspecs/RCT-Folly.podspec
+++ b/third-party-podspecs/RCT-Folly.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |spec|
                       'folly/hash/SpookyHashV2.cpp',
                       'folly/lang/Assume.cpp',
                       'folly/lang/CString.cpp',
-                      # 'folly/lang/Exception.cpp', # TODO(macOS GH#214) later versions of boost don't support macOS, revert this back to upstream when fixed
+                      'folly/lang/Exception.cpp',
                       'folly/memory/detail/MallocImpl.cpp',
                       'folly/net/NetOps.cpp',
                       'folly/portability/SysUio.cpp',


### PR DESCRIPTION
#### Please select one of the following

- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

react-native-macos fails to build if Hermes is enabled:

```
Undefined symbols for architecture x86_64:
  "folly::exception_ptr_get_type(std::exception_ptr const&)", referenced from:
      folly::exception_wrapper::ExceptionPtr::type_(folly::exception_wrapper const*) in libRCT-Folly.a(ExceptionWrapper.o)
      folly::exceptionStr(std::exception_ptr const&) in libRCT-Folly.a(ExceptionString.o)
  "folly::exception_ptr_get_object(std::exception_ptr const&, std::type_info const*)", referenced from:
      std::exception* folly::exception_ptr_get_object<std::exception>(std::exception_ptr const&) in libReact-hermes.a(Connection.o)
      std::exception* folly::exception_ptr_get_object<std::exception>(std::exception_ptr const&) in libRCT-Folly.a(ExceptionWrapper.o)
      std::exception* folly::exception_ptr_get_object<std::exception>(std::exception_ptr const&) in libRCT-Folly.a(ExceptionString.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Resolves #214
Resolves #952

## Changelog

[macOS] [Fixed] - Hermes no longer builds without `Exception.cpp`

## Test Plan

```
npm run set-react-version 0.66
yarn
cd example
rm -rf macos/Pods macos/Podfile.lock
# apply this patch manually in node_modules folder
# enable Hermes in `macos/Podfile`
pod install --project-directory=macos
yarn macos
```

![image](https://user-images.githubusercontent.com/4123478/151042249-6bbf87a9-db30-46c0-8d3d-02108456eecc.png)