### PR TITLE
Add --autogenerateVersionNumber option to bump-oss-version.js

### DIFF
--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -43,12 +43,12 @@ steps:
   # ReactCommon/cxxreact/ReactNativeVersion.h
   # Libraries/Core/ReactNativeVersion.js
   #
-  # --nightly => version = `0.0.0-${currentCommit.slice(0, 9)}`;
+  # --nightly --autogenerateVersionNumber => version = `0.0.0-${currentCommit.slice(0, 9)}`;
   # When on main branch or non-stable branch.
   - task: CmdLine@2
     displayName: Bump canary package version
     inputs:
-      script: node scripts/bump-oss-version.js --nightly
+      script: node scripts/bump-oss-version.js --nightly --autogenerateVersionNumber
     condition: or(eq(variables['Build.SourceBranchName'], 'main'), not(contains(variables['Build.SourceBranchName'], '-stable')))
 
   # TODO: We don't seem to be running bump-oss-version.js for stable branches, hence we would end up publishing using the values in the repository.

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -12,7 +12,7 @@
            CatalystInstanceImpl::handleMemoryPressure),
        makeNativeMethod(
            "getRuntimeExecutor", CatalystInstanceImpl::getRuntimeExecutor),
-+      makeNativeMethod("getPointerOfInstancePointer", CatalystInstanceImpl::getPointerOfInstancePointer)
++      makeNativeMethod("getPointerOfInstancePointer", CatalystInstanceImpl::getPointerOfInstancePointer),
        makeNativeMethod(
            "warnOnLegacyNativeModuleSystemUse",
            CatalystInstanceImpl::warnOnLegacyNativeModuleSystemUse),

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -36,6 +36,11 @@
      type: 'boolean',
      default: false,
    })
+   .option('a', { // TODO(macOS GH#774): See note below
+     alias: 'autogenerate-version-number',
+     type: 'boolean',
+     default: false,
+   })
    .option('v', {
      alias: 'to-version',
      type: 'string',
@@ -46,14 +51,23 @@
      default: false,
    }).argv;
 
+ const autogenerateVersionNumber = argv.autogenerateVersionNumber;
  const nightlyBuild = argv.nightly;
- const version = argv.toVersion;
+ let version = argv.toVersion;
 
  if (!version) {
-   echo(
-     'You must specify a version using -v',
-   );
-   exit(1);
+   // TODO(macOS GH#774): Some of our calls to bump-oss-version.js still depend on an automatically generated version number
+   if (nightlyBuild && autogenerateVersionNumber) {
+     const currentCommit = exec('git rev-parse HEAD', {
+       silent: true,
+     }).stdout.trim();
+     version = `0.0.0-${currentCommit.slice(0, 9)}`;
+   } else {
+     echo(
+       'You must specify a version using -v',
+     );
+     exit(1);
+   }
  }
 
  let branch;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Add an `--autogenerateVersionNumber` flag to scripts/bump-oss-version.js.

Some CI checks have been failing due to a change in this script. We still have some old invocations that assume the script will generate an ad-hoc version number. This change helps make the transition easier. If we so desire, we can change our CI scripts as needed in the future.