### PR TITLE
Use new version parameter name

### DIFF
--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -43,7 +43,7 @@ function updateVersionsInFiles(patchVersionPrefix) {
  
     pkgJson.version = releaseVersion;
     console.log(`Bumping files to version ${releaseVersion}`);
-    execSync(`node ./scripts/bump-oss-version.js --rnmpublish --version ${releaseVersion}`, {stdio: 'inherit', env: process.env});
+    execSync(`node ./scripts/bump-oss-version.js --rnmpublish --to-version ${releaseVersion}`, {stdio: 'inherit', env: process.env});
 
     return {releaseVersion, branchVersionSuffix};
 }


### PR DESCRIPTION
The version arg on the bump script was changed to to-version, but the script calling it was never updated.