### PR TITLE
Add --autogenerateVersionNumber flag for canary version in publish.yml

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - task: CmdLine@2
         displayName: Bump canary package version
         inputs:
-          script: node scripts/bump-oss-version.js --nightly
+          script: node scripts/bump-oss-version.js --nightly --autogenerateVersionNumber
         condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
 
       # Publish will fail if package.json is marked as private


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Add the `--autogenerateVersionNumber` flag for the bump-oss-version.js invocation in publish.yml.

This new flag was introduced with #989. While this ADO task won't get run in a non-main branch, we're still making it here for the sake of correctness.
