### PR TITLE
[chore] address codeowners to reflect current status

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,9 @@
-** @acoates-ms
-** @tom-un
-** @alloy
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the global will be requested for
+# review when someone opens a pull request.
+* @HeyImChris @acoates-ms @Saadnajmi @amgleitman
+
+# React Android specific ones
+/ReactAndroid/ @mganandraj
+/android-patches/ @mganandraj

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # the repo. Unless a later match takes precedence,
 # the global will be requested for
 # review when someone opens a pull request.
-* @HeyImChris @acoates-ms @Saadnajmi @amgleitman
+* @microsoft/apple-rn-team
 
 # React Android specific ones
 /ReactAndroid/ @mganandraj


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

One thing I noticed is that whenever a new PR is opened @alloy gets assigned as codeowner to review. (the reason why it was only him is because the 3 owners were in 3 separate lines, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

I've updated the file to reflect the current status (as far as I can tell) of who is in charge of this repo at this point in time.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

N/A
## Test Plan
N/A
