### PR TITLE
[chore] bump all references to Node 16

### DIFF
--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -1,14 +1,14 @@
 steps:
   - task: UseNode@1
     inputs:
-      version: '12.x'
+      version: '16.x'
 
   - template: apple-droid-node-patching.yml
     parameters:
       apply_office_patches: true
 
-  # This is currently required as the command task (strangely) always runs elevated .. 
-  # which makes all the files touched by the above patching step unreadable by following non-command tasks without sudo. 
+  # This is currently required as the command task (strangely) always runs elevated ..
+  # which makes all the files touched by the above patching step unreadable by following non-command tasks without sudo.
   # This makes all the files readable.
   - task: CmdLine@2
     displayName: chmod

--- a/.ado/templates/apple-node-setup.yml
+++ b/.ado/templates/apple-node-setup.yml
@@ -9,5 +9,5 @@ steps:
   - script: sudo chown -R $(whoami) /usr/local/*
     displayName: 'fix node permissions'
 
-  - script: brew link node@12 --overwrite --force
-    displayName: 'ensure node 12'
+  - script: brew link node@16 --overwrite --force
+    displayName: 'ensure node 16'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ executors:
     <<: *defaults
     docker:
       # Note: Version set separately for Windows builds, see below.
-      - image: circleci/node:14
+      - image: circleci/node:16
   nodeprevlts:
     <<: *defaults
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
   reactnativeandroid:
     <<: *defaults
     docker:
@@ -399,7 +399,7 @@ jobs:
             - brew_install:
                 package: watchman
             - brew_install:
-                package: node@12
+                package: node@16
             - run:
                 name: "Brew: Tap wix/brew"
                 command: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "node@16"
+brew "watchman"

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,0 @@
-brew "node@16"
-brew "watchman"

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,2 @@
-brew "node@12"
+brew "node@16"
 brew "watchman"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "git@github.com:microsoft/react-native-macos.git",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "jest-junit": {
     "outputDirectory": "reports/junit",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "git@github.com:microsoft/react-native-macos.git",
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "jest-junit": {
     "outputDirectory": "reports/junit",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Currently, the CI setup is still using Node 12, which is 2-LTS(s) old. The current [LTS is 16](https://nodejs.org/en/), so I'm updating all the references to match that.

~While doing so, I've noticed that there's a local brewfile but that is clearly not used - since the end of the lock shows that it was last "run & commited" back when `"Xcode": "11.5",` was the used version. So I've removed it to declutter a bit.~
NVM it looks like it's used on CI and it doesn't seem to matter of the lock is outdated 🤷‍♂️

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->
N/A
## Test Plan

CI is the test, locally everything seems to be running fine.
