### PR TITLE
Add a safety check in -[RCTTextView description]

### DIFF
--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -61,9 +61,21 @@ steps:
     inputs:
       script: node scripts/bump-oss-version.js --nightly -v 0.0.1000
 
+  # Publish will fail if package.json is marked as private
+  - task: CmdLine@2
+    displayName: Remove workspace config from package.json
+    inputs:
+      script: node .ado/removeWorkspaceConfig.js
+
   - script: |
       npm publish --registry http://localhost:4873
     displayName: Publish react-native-macos to verdaccio
+
+  # Put the private flag back
+  - task: CmdLine@2
+    displayName: Restore package.json workspace config
+    inputs:
+      script: node .ado/restoreWorkspaceConfig.js
 
   - script: |
       npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public

--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -104,12 +104,13 @@
   NSString *superDescription = super.description;
   NSRange semicolonRange = [superDescription rangeOfString:@";"];
   NSString *replacement = [NSString stringWithFormat:@"; reactTag: %@; text: %@", self.reactTag, _textStorage.string];
-  // TODO(macOS GH#774): super.description isn't guaranteed to have a semicolon in it on macOS
+  // [TODO(macOS GH#774): super.description isn't guaranteed to have a semicolon in it on macOS
   if (semicolonRange.location == NSNotFound) {
     return [superDescription stringByAppendingString:replacement];
   } else {
     return [superDescription stringByReplacingCharactersInRange:semicolonRange withString:replacement];
   }
+  // TODO(macOS GH#774)]
 }
 
 - (void)setSelectable:(BOOL)selectable

--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -104,7 +104,12 @@
   NSString *superDescription = super.description;
   NSRange semicolonRange = [superDescription rangeOfString:@";"];
   NSString *replacement = [NSString stringWithFormat:@"; reactTag: %@; text: %@", self.reactTag, _textStorage.string];
-  return [superDescription stringByReplacingCharactersInRange:semicolonRange withString:replacement];
+  // TODO(macOS GH#774): super.description isn't guaranteed to have a semicolon in it on macOS
+  if (semicolonRange.location == NSNotFound) {
+    return [superDescription stringByAppendingString:replacement];
+  } else {
+    return [superDescription stringByReplacingCharactersInRange:semicolonRange withString:replacement];
+  }
 }
 
 - (void)setSelectable:(BOOL)selectable


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

By default, `-[RCTTextView description]` works by adding information specific to `RCTTextView` in its superclass's description. However, the current implementation depends on the existence of a semicolon in the superclass's description. This assumption appears to hold on iOS, but it doesn't hold on macOS, which can cause `-[NSString stringByReplacingCharactersInRange:withString:]` to do some weird stuff on macOS.

This fix addresses this problem by checking that the result of `[superDescription rangeOfString:@";"]` is valid before trying to replace it.