### PR TITLE
fix (iOS): Only try to make the alert window key if the app recognizes it

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -32,10 +32,10 @@
 
 - (void)show:(BOOL)animated completion:(void (^)(void))completion
 {
+  // [TODO(macOS GH#774)
   // Call self.alertWindow to ensure that it gets populated
   UIWindow *alertWindow = self.alertWindow;
 
-  // [TODO(macOS GH#774)
   // If the window is tracked by our application then it will show the alert
   if ([[[UIApplication sharedApplication] windows] containsObject:alertWindow]) {
     // On iOS 14, makeKeyAndVisible should only be called if alertWindow is tracked by the application.

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -32,12 +32,16 @@
 
 - (void)show:(BOOL)animated completion:(void (^)(void))completion
 {
-  [self.alertWindow makeKeyAndVisible];
+  // Call self.alertWindow to ensure that it gets populated
+  UIWindow *alertWindow = self.alertWindow;
 
   // [TODO(macOS GH#774)
   // If the window is tracked by our application then it will show the alert
-  if ([[[UIApplication sharedApplication] windows] containsObject:self.alertWindow]) {
-    [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
+  if ([[[UIApplication sharedApplication] windows] containsObject:alertWindow]) {
+    // On iOS 14, makeKeyAndVisible should only be called if alertWindow is tracked by the application.
+    // Later versions of iOS appear to already do this check for us behind the scenes.
+    [alertWindow makeKeyAndVisible];
+    [alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
   } else {
     // When using Scenes, we must present the alert from a view controller associated with a window in the Scene. A fresh window (i.e. _alertWindow) cannot show the alert.
     [RCTPresentedViewController() presentViewController:self animated:animated completion:completion];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

This is a follow-up to #917.

In iOS 14, if we call `-[UIWindow makeKeyAndVisible]` from a `UIWindow` that isn't part of the app, the current key window gets made non-key. This can result in `RCTKeyWindow()`, and thusly, `RCTPresentedViewController()`, to come back as `nil`, which means that the alert never shows up.

The fix here is to ensure that we don't try to make the alert window key unless it's actually tracked by the application.

## Test Plan

Validated in a downstream app on iOS 14.
