### PR TITLE
Cherry pick #1004 into 0.66-stable

### DIFF
--- a/React/CoreModules/RCTDevSettings.h
+++ b/React/CoreModules/RCTDevSettings.h
@@ -48,16 +48,6 @@
 
 @end
 
-@protocol RCTDevSettingsInspectable <NSObject>
-
-/**
- * Whether current jsi::Runtime is inspectable.
- * Only set when using as a bridgeless turbo module.
- */
-@property (nonatomic, assign, readwrite) BOOL isInspectable;
-
-@end
-
 @interface RCTDevSettings : RCTEventEmitter <RCTInitializing>
 
 - (instancetype)initWithDataSource:(id<RCTDevSettingsDataSource>)dataSource;

--- a/React/Modules/RCTEventEmitter.h
+++ b/React/Modules/RCTEventEmitter.h
@@ -14,8 +14,8 @@
 @interface RCTEventEmitter : NSObject <RCTBridgeModule, RCTInvalidating>
 
 @property (nonatomic, weak) RCTBridge * _Nullable bridge; // TODO(macOS GH#774)
-@property (nonatomic, weak) RCTModuleRegistry *moduleRegistry;
-@property (nonatomic, weak) RCTViewRegistry *viewRegistry_DEPRECATED;
+@property (nonatomic, weak) RCTModuleRegistry * _Nullable moduleRegistry; // TODO(macOS GH#774)
+@property (nonatomic, weak) RCTViewRegistry * _Nullable viewRegistry_DEPRECATED; // TODO(macOS GH#774)
 
 - (instancetype _Nullable)initWithDisabledObservation; // TODO(macOS GH#774)
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This cherry-picks the two commits from #1004 into 0.66-stable to fix downstream compilation errors.