### PR TITLE
RCTShadowView: use 1x alignment

### DIFF
--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -52,7 +52,7 @@ typedef NS_ENUM(unsigned int, meta_prop_t) {
 #if !TARGET_OS_OSX // [TODO(macOS GH#774)
     float pixelsInPoint = RCTScreenScale();
 #else
-    float pixelsInPoint = 0; // TODO(ISS#1656079): Turn off pixel rounding for macOS until we can get screen resolution passed here
+    float pixelsInPoint = 1; // TODO(ISS#1656079): Use 1x alignment for macOS until we can use backing resolution
 #endif // ]TODO(macOS GH#774)
     YGConfigSetPointScaleFactor(yogaConfig, pixelsInPoint);
     YGConfigSetUseLegacyStretchBehaviour(yogaConfig, true);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Passing 0 to `YGConfigSetPointScaleFactor()` turns off layout rounding entirely, which makes things look blurry.  While it would be nice to use the backing scale factor of the window, that would be a very involved change.  Instead, hardcode 1x alignment.  On 2x displays, this just means that views cannot sit on half-point boundaries.  (They're still *rendered* at 2x, though.)

## Changelog

[macOS] [Fixed] - Use 1x frame alignment

## Test Plan

Ran a React Native demo project on macOS 10.15.7 / MacBookAir6,2.

Before:

![image](https://user-images.githubusercontent.com/1477437/152977442-82aa9135-11dd-4bf6-a083-569860637b8f.png)

After:

![image](https://user-images.githubusercontent.com/1477437/152977460-119c5480-07f4-4fe9-8e8a-8c0a5036a5ee.png)
