### PR TITLE
[0.66-stable]Adding patches required for running RN66 in Office apps

### DIFF
--- a/.ado/templates/apple-droid-node-patching.yml
+++ b/.ado/templates/apple-droid-node-patching.yml
@@ -5,4 +5,4 @@ steps:
   - task: CmdLine@2
     displayName: Apply Android specific patches for Office consumption
     inputs:
-      script: node $(System.DefaultWorkingDirectory)/android-patches/bundle/bundle.js patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}
+      script: node $(System.DefaultWorkingDirectory)/android-patches/bundle/bundle.js patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor JniUtils RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}

--- a/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
@@ -1,6 +1,6 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/Build/ReactAndroid/ReactAndroid.nuspec	2022-01-12 15:04:31.000000000 -0800
-@@ -0,0 +1,242 @@
+--- /dev/ReactAndroid/ReactAndroid.nuspec	1969-12-31 16:00:00.000000000 -0800
++++ /dev/ReactAndroid/ReactAndroid.nuspec	2022-02-13 23:24:19.927074747 -0800
+@@ -0,0 +1,262 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
@@ -120,6 +120,16 @@
 +    <file src="build\react-ndk\all\x86\libturbomodulejsijni.so" target="lib\droidx86"/>
 +    <file src="build\react-ndk\all\arm64-v8a\libturbomodulejsijni.so" target="lib\droidarm64"/>
 +
++    <file src="build\react-ndk\all\x86_64\libjsi.so" target="lib\droidx64"/>
++    <file src="build\react-ndk\all\armeabi-v7a\libjsi.so" target="lib\droidarm"/>
++    <file src="build\react-ndk\all\x86\libjsi.so" target="lib\droidx86"/>
++    <file src="build\react-ndk\all\arm64-v8a\libjsi.so" target="lib\droidarm64"/>
++
++    <file src="build\react-ndk\all\x86_64\liblogger.so" target="lib\droidx64"/>
++    <file src="build\react-ndk\all\armeabi-v7a\liblogger.so" target="lib\droidarm"/>
++    <file src="build\react-ndk\all\x86\liblogger.so" target="lib\droidx86"/>
++    <file src="build\react-ndk\all\arm64-v8a\liblogger.so" target="lib\droidarm64"/>
++
 +    <!-- Unstripped binaries -->
 +    <file src="build\tmp\buildReactNdkLib\local\x86_64\libfb.so" target="lib\droidx64\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libfb.so" target="lib\droidarm\unstripped"/>
@@ -225,7 +235,17 @@
 +    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libturbomodulejsijni.so" target="lib\droidarm\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\x86\libturbomodulejsijni.so" target="lib\droidx86\unstripped"/>
 +    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libturbomodulejsijni.so" target="lib\droidarm64\unstripped"/>
-+    
++
++    <file src="build\tmp\buildReactNdkLib\local\x86_64\libjsi.so" target="lib\droidx64\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libjsi.so" target="lib\droidarm\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\x86\libjsi.so" target="lib\droidx86\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libjsi.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\tmp\buildReactNdkLib\local\x86_64\liblogger.so" target="lib\droidx64\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\liblogger.so" target="lib\droidarm\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\x86\liblogger.so" target="lib\droidx86\unstripped"/>
++    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\liblogger.so" target="lib\droidarm64\unstripped"/>
++
 +    <!-- AAR and POM -->
 +    <file src="..\android\com\**\*" target="maven\com"/>
 +

--- a/android-patches/patches/JniUtils/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
+++ b/android-patches/patches/JniUtils/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
@@ -1,0 +1,11 @@
+--- /dev/code/rnm-66-fresh/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk	2022-02-13 19:54:48.571686475 -0800
++++ /dev/code/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk	2022-02-13 19:52:50.350473816 -0800
+@@ -11,7 +11,7 @@
+ 
+ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+ 
+-LOCAL_SHARED_LIBRARIES := libjsi libreactconfig librrc_slider librrc_progressbar librrc_switch librrc_modal libyoga libglog libfb libfbjni libglog_init libfolly_json libfolly_futures libreact_render_mounting libreactnativeutilsjni libreact_utils libreact_render_debug libreact_render_graphics libreact_render_core react_render_componentregistry librrc_view librrc_unimplementedview librrc_root librrc_scrollview libbetter libreact_render_attributedstring libreact_render_uimanager libreact_render_templateprocessor libreact_render_scheduler libreact_render_animations libreact_render_imagemanager libreact_render_textlayoutmanager libreact_codegen_rncore rrc_text librrc_image librrc_textinput libreact_debug libreact_render_mapbuffer libmapbufferjni libreact_render_telemetry
++LOCAL_SHARED_LIBRARIES := libjsi libreactconfig librrc_slider librrc_progressbar librrc_switch librrc_modal libyoga libglog libfb libfbjni libglog_init libfolly_json libfolly_futures libreact_render_mounting libreactnativejni libreact_utils libreact_render_debug libreact_render_graphics libreact_render_core react_render_componentregistry librrc_view librrc_unimplementedview librrc_root librrc_scrollview libbetter libreact_render_attributedstring libreact_render_uimanager libreact_render_templateprocessor libreact_render_scheduler libreact_render_animations libreact_render_imagemanager libreact_render_textlayoutmanager libreact_codegen_rncore rrc_text librrc_image librrc_textinput libreact_debug libreact_render_mapbuffer libmapbufferjni libreact_render_telemetry
+ 
+ LOCAL_STATIC_LIBRARIES :=
+ 

--- a/android-patches/patches/JniUtils/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
+++ b/android-patches/patches/JniUtils/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
@@ -1,0 +1,11 @@
+--- /dev/code/rnm-66-fresh/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk	2022-02-13 19:54:48.579686559 -0800
++++ /dev/code/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk	2022-02-13 19:53:04.134612248 -0800
+@@ -19,7 +19,7 @@
+ 
+ LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+ 
+-LOCAL_SHARED_LIBRARIES = libfb libfbjni libreactnativeutilsjni
++LOCAL_SHARED_LIBRARIES = libfb libfbjni libreactnativejni
+ 
+ LOCAL_STATIC_LIBRARIES = libcallinvoker libreactperfloggerjni libruntimeexecutor
+ 

--- a/android-patches/patches/JniUtils/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/android-patches/patches/JniUtils/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -1,0 +1,11 @@
+--- /dev/code/rnm-66-fresh/ReactAndroid/src/main/jni/react/jni/Android.mk	2022-02-13 19:54:48.595686727 -0800
++++ /dev/code/react-native-macos/ReactAndroid/src/main/jni/react/jni/Android.mk	2022-02-13 19:53:07.962650850 -0800
+@@ -77,7 +77,7 @@
+ LOCAL_LDLIBS += -landroid
+ 
+ # The dynamic libraries (.so files) that this module depends on.
+-LOCAL_SHARED_LIBRARIES := libreactnativeutilsjni libfolly_json libfb libfbjni libglog_init libyoga logger
++LOCAL_SHARED_LIBRARIES := libreactnativejni libfolly_json libfb libfbjni libglog_init libyoga logger
+ 
+ # The static libraries (.a files) that this module depends on.
+ LOCAL_STATIC_LIBRARIES := libreactnative libruntimeexecutor libcallinvokerholder

--- a/android-patches/patches/JniUtils/ReactCommon/react/renderer/components/progressbar/Android.mk
+++ b/android-patches/patches/JniUtils/ReactCommon/react/renderer/components/progressbar/Android.mk
@@ -1,0 +1,11 @@
+--- /dev/code/rnm-66-fresh/ReactCommon/react/renderer/components/progressbar/Android.mk	2022-02-13 19:54:48.619686978 -0800
++++ /dev/code/react-native-macos/ReactCommon/react/renderer/components/progressbar/Android.mk	2022-02-13 19:53:12.522696921 -0800
+@@ -21,7 +21,7 @@
+ 
+ LOCAL_STATIC_LIBRARIES :=
+ 
+-LOCAL_SHARED_LIBRARIES := libfbjni libreact_codegen_rncore libreactnativeutilsjni libreact_render_componentregistry libreact_render_uimanager libyoga libfolly_futures glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics librrc_view libreact_debug
++LOCAL_SHARED_LIBRARIES := libfbjni libreact_codegen_rncore libreactnativejni libreact_render_componentregistry libreact_render_uimanager libyoga libfolly_futures glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics librrc_view libreact_debug
+ 
+ include $(BUILD_SHARED_LIBRARY)
+ 

--- a/android-patches/patches/JniUtils/ReactCommon/react/renderer/components/slider/Android.mk
+++ b/android-patches/patches/JniUtils/ReactCommon/react/renderer/components/slider/Android.mk
@@ -1,0 +1,11 @@
+--- /dev/code/rnm-66-fresh/ReactCommon/react/renderer/components/slider/Android.mk	2022-02-13 19:54:48.619686978 -0800
++++ /dev/code/react-native-macos/ReactCommon/react/renderer/components/slider/Android.mk	2022-02-13 19:53:21.558788484 -0800
+@@ -21,7 +21,7 @@
+ 
+ LOCAL_STATIC_LIBRARIES :=
+ 
+-LOCAL_SHARED_LIBRARIES := libfbjni libreact_codegen_rncore libreact_render_imagemanager libreactnativeutilsjni libreact_render_componentregistry libreact_render_uimanager librrc_image libyoga libfolly_futures glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics librrc_view libreact_debug libreact_render_mapbuffer
++LOCAL_SHARED_LIBRARIES := libfbjni libreact_codegen_rncore libreact_render_imagemanager libreactnativejni libreact_render_componentregistry libreact_render_uimanager librrc_image libyoga libfolly_futures glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics librrc_view libreact_debug libreact_render_mapbuffer
+ 
+ include $(BUILD_SHARED_LIBRARY)
+ 

--- a/android-patches/patches/JniUtils/ReactCommon/react/renderer/components/switch/Android.mk
+++ b/android-patches/patches/JniUtils/ReactCommon/react/renderer/components/switch/Android.mk
@@ -1,0 +1,11 @@
+--- /home/mganandraj/code/rnm-66-fresh/ReactCommon/react/renderer/components/switch/Android.mk	2022-02-13 19:54:48.619686978 -0800
++++ /home/mganandraj/code/react-native-macos/ReactCommon/react/renderer/components/switch/Android.mk	2022-02-13 19:53:25.274826242 -0800
+@@ -21,7 +21,7 @@
+ 
+ LOCAL_STATIC_LIBRARIES :=
+ 
+-LOCAL_SHARED_LIBRARIES := libfbjni libreact_codegen_rncore libreactnativeutilsjni libreact_render_componentregistry libreact_render_uimanager libyoga libfolly_futures glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics librrc_view libreact_debug
++LOCAL_SHARED_LIBRARIES := libfbjni libreact_codegen_rncore libreactnativejni libreact_render_componentregistry libreact_render_uimanager libyoga libfolly_futures glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics librrc_view libreact_debug
+ 
+ include $(BUILD_SHARED_LIBRARY)
+ 

--- a/android-patches/patches/JniUtils/ReactCommon/react/renderer/textlayoutmanager/Android.mk
+++ b/android-patches/patches/JniUtils/ReactCommon/react/renderer/textlayoutmanager/Android.mk
@@ -1,0 +1,11 @@
+--- /home/mganandraj/code/rnm-66-fresh/ReactCommon/react/renderer/textlayoutmanager/Android.mk	2022-02-13 19:54:48.631687103 -0800
++++ /home/mganandraj/code/react-native-macos/ReactCommon/react/renderer/textlayoutmanager/Android.mk	2022-02-13 19:53:28.338857418 -0800
+@@ -11,7 +11,7 @@
+ 
+ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp $(LOCAL_PATH)/platform/android/react/renderer/textlayoutmanager/*.cpp)
+ 
+-LOCAL_SHARED_LIBRARIES := libfolly_futures libreactnativeutilsjni libreact_utils libfb libfbjni libreact_render_uimanager libreact_render_componentregistry libreact_render_attributedstring libreact_render_mounting glog libfolly_json libglog_init libyoga libreact_render_core libreact_render_debug libreact_render_graphics libreact_debug libreact_render_mapbuffer libmapbufferjni libreact_render_telemetry
++LOCAL_SHARED_LIBRARIES := libfolly_futures libreactnativejni libreact_utils libfb libfbjni libreact_render_uimanager libreact_render_componentregistry libreact_render_attributedstring libreact_render_mounting glog libfolly_json libglog_init libyoga libreact_render_core libreact_render_debug libreact_render_graphics libreact_debug libreact_render_mapbuffer libmapbufferjni libreact_render_telemetry
+ 
+ LOCAL_STATIC_LIBRARIES :=
+ 

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
@@ -1,0 +1,30 @@
+--- /dev/code/rnm-66-fresh/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java	2022-02-13 19:54:48.563686391 -0800
++++ /dev/code/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java	2022-02-13 22:53:50.732054489 -0800
+@@ -31,6 +31,27 @@
+     Systrace.beginSection(
+         TRACE_TAG_REACT_JAVA_BRIDGE, "ReactBridge.staticInit::load:reactnativejni");
+     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START);
++
++    // JS Engine is configurable.. And we exepct only one packaged
++    // Hence ignore failure
++    try {
++	SoLoader.loadLibrary("hermes");
++    }catch (UnsatisfiedLinkError jscE){}
++
++    try {
++	SoLoader.loadLibrary("v8jsi");
++    }catch (UnsatisfiedLinkError jscE){}
++
++    SoLoader.loadLibrary("glog");
++    SoLoader.loadLibrary("glog_init");
++    SoLoader.loadLibrary("fb");
++    SoLoader.loadLibrary("fbjni");
++    SoLoader.loadLibrary("yoga");
++    SoLoader.loadLibrary("folly_json");
++    SoLoader.loadLibrary("reactperfloggerjni");
++    SoLoader.loadLibrary("jsinspector");
++    SoLoader.loadLibrary("jsi");
++    SoLoader.loadLibrary("logger");
+     SoLoader.loadLibrary("reactnativejni");
+     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END);
+     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);

--- a/android-patches/patches/RootViewAttach/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/android-patches/patches/RootViewAttach/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -1,0 +1,10 @@
+--- /dev/code/rnm-66-fresh/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java	2022-02-13 19:54:48.563686391 -0800
++++ /dev/code/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java	2022-02-13 22:34:45.828345952 -0800
+@@ -410,6 +410,7 @@
+       mInitialUITemplate = initialUITemplate;
+ 
+       mReactInstanceManager.createReactContextInBackground();
++      attachToReactInstanceManager();
+ 
+     } finally {
+       Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Patches already applied in 0.64 but weren't brought to main
New patches to bring new SO files to devmain

This change is cherry picked from main
`git cherry-pick cadd8890f761d4e2e4a331a0db0d4ce2c9c91d85`

## Changelog

Patches already applied in 0.64 but weren't brought to main
New patches to bring new SO files to devmain

This change is cherry picked from main
`git cherry-pick cadd8890f761d4e2e4a331a0db0d4ce2c9c91d85`

[CATEGORY] [TYPE] - Message
