### PR TITLE
Make RCTBundleManager's bundleURL a strong property

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -441,7 +441,7 @@ typedef NSURL * (^RCTBridgelessBundleURLGetter)(void);
                            andSetter:(RCTBridgelessBundleURLSetter)setter
                     andDefaultGetter:(RCTBridgelessBundleURLGetter)defaultGetter;
 - (void)resetBundleURL;
-@property (strong) NSURL *bundleURL;
+@property (strong) NSURL *bundleURL; // TODO(macOS GH#774)
 @end
 
 typedef RCTPlatformView * (^RCTBridgelessComponentViewProvider)(NSNumber *); // TODO(macOS GH#774)

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -441,7 +441,7 @@ typedef NSURL * (^RCTBridgelessBundleURLGetter)(void);
                            andSetter:(RCTBridgelessBundleURLSetter)setter
                     andDefaultGetter:(RCTBridgelessBundleURLGetter)defaultGetter;
 - (void)resetBundleURL;
-@property NSURL *bundleURL;
+@property (strong) NSURL *bundleURL;
 @end
 
 typedef RCTPlatformView * (^RCTBridgelessComponentViewProvider)(NSNumber *); // TODO(macOS GH#774)

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -542,8 +542,8 @@ SPEC CHECKSUMS:
   boost-for-react-native: 8f7c9ecfe357664c072ffbe2432569667cbf1f1b
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: e65045693f9c698abed6289559d5664ae43e5480
-  FBReactNativeSpec: bf9a07a61068d690915213286a51f0cc2d0b97ec
+  FBLazyVector: 78833e5b71477e99d0c461260b15805300d8641a
+  FBReactNativeSpec: 443ba1d306c631c846dd7aca2a975387c9cc7bc7
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -558,34 +558,34 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 43adc9ce880eb76792f88c011773cb5c664c1419
-  RCTRequired: f39a92c9f3041de82ab3e3858bf3c2bfb68f3643
-  RCTTypeSafety: ed0561744d5b1a4c12326bbff2c9f8445e1d5d3f
-  React: bfa3e7f3c29eccaff4985862890c24c2e4b06842
-  React-callinvoker: 2bdb27fcccab4b509254fda4826914ad98e8c11b
-  React-Core: afad14ebb15e6ae07999da604fa15bdcb800ca65
-  React-CoreModules: 2a8c0d2c22401551f12d3b012a5f4bf7103bc98f
-  React-cxxreact: 254672a8cda933664d014db45c8162367fa912e6
-  React-jsi: 0c6cbbedfb44b4ca1698dcf6af317f080e7831cb
-  React-jsiexecutor: 3fa2a7dee4b638c61021d4d05c437b6b9638a6b1
-  React-jsinspector: 2827b8e7516aaa294055729b2f7244ef69499707
-  React-logger: 8d88188659268d4ad69136412ebf2a5346ce89cb
-  React-perflogger: ba1e7782405ee712a7fa1c663e0ae3ee0908e83e
-  React-RCTActionSheet: 369bd420b79981236cd8cd46192652af5abb785d
-  React-RCTAnimation: 53910b1a7478de6ffc01a9628ebb7d23cf38b547
-  React-RCTBlob: f1af9675b3b09a9398b361f9cadd474c3ff3493f
-  React-RCTImage: 286f777ecb039851127546674e505b25c51af3d4
-  React-RCTLinking: 3757095369be633778f3bd3d1126b8004957611e
-  React-RCTNetwork: 5d36da20e4bd4ce6bbaa32b188cf4686de480da4
-  React-RCTPushNotification: 1ab38f9e07a6f99bf1e8be119bf5d20a51bbde0d
-  React-RCTSettings: 98dcf3bcab4cda7bf1fdde49bb23ccf8081fa79e
-  React-RCTTest: 0284c8f42efb670ecf77384ec59d80c2ac56955c
-  React-RCTText: b7fcfdec742abc97d6dc9523cfee34c3dbdbf5a7
-  React-RCTVibration: fb5edfe2d51244e6e3944d0030fef7f655af1ead
-  React-runtimeexecutor: 5b90d3c2d5cf3763aa57572e11d39bf0435f500f
+  RCTRequired: d93d172489b8c773611e3efd9e227f5364594dd6
+  RCTTypeSafety: 3fc1581c2a865e39da6f99845e0ac6a8d9264460
+  React: 2f225b706f487a4c28da24f397cf398ccd39e982
+  React-callinvoker: b405a5dddbe24432f30a609ade5a19b51a46664e
+  React-Core: c9f3e60e3317528fdf90b41626a4f05f947aee08
+  React-CoreModules: f72a78971f386eee4c2100819278316b6f877491
+  React-cxxreact: 918aea0822c0211558092ae051f51e67d5306cb0
+  React-jsi: 11cd72d65a3435ab8ff942f63070ff3152bf0865
+  React-jsiexecutor: cfd80e02b8374637f4916150d8ee0d5f17afb9d2
+  React-jsinspector: 3171bf801725090c0dacc3e262f98bed08d69fdc
+  React-logger: f0d2226ebca93060b9a823722d9fec2606d7e7fe
+  React-perflogger: a0318f108de40b646149abe1cc1e949e2ac666c2
+  React-RCTActionSheet: ab8183f6cc730c57f466a9278edb01077e8fedd0
+  React-RCTAnimation: 48abe93d62ba56c83860c8e4c8fc7864e79c4a32
+  React-RCTBlob: c09e48087fa0b1843b1e72c865d2942847c2177e
+  React-RCTImage: e5cc9ae582ebb8e522cbdb4f5832178b5f06f41a
+  React-RCTLinking: 8ede7e34da8c6b4a0d84e9cb6bd7cccdb194763b
+  React-RCTNetwork: baa74ca81816e4c2d0a35e8c8e5dc55556dceff2
+  React-RCTPushNotification: b6c085f1e2027651cf5c45f1404c685075fb6dae
+  React-RCTSettings: d1497a02d747b9a7125d3c13fc97a04a17cb625c
+  React-RCTTest: bfe35790510a0dadb4677b87eca86762e0ca6df9
+  React-RCTText: 5268eb98f9ed610f06a41f2713fe029cfb0d159c
+  React-RCTVibration: 2374c6ae5cd333aecc32207780ba42d090b8e549
+  React-runtimeexecutor: de57453247bb893e197996c97355de11be14687d
   React-TurboModuleCxx-RNW: f2e32cbfced49190a61d66c993a8975de79a158a
-  React-TurboModuleCxx-WinRTPort: cebbef8a4cff3e6c3c9479ee85d65b089bb11e67
-  ReactCommon: 64ed3825048af91d1a040c267ced649ffbb57bcb
-  Yoga: 1f267b00765ea972d7471f70656a4d4820fc7ae0
+  React-TurboModuleCxx-WinRTPort: 42aadf2acef5d136d987df13aef3f0f2487a4aba
+  ReactCommon: fd25a74759c207c56ac433e996fa19ad9c4b5a04
+  Yoga: 602a226654e13710c61f951673946820bef68ce9
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: c7a7110b242497f2bf323ba74caedb9ee61ee05e


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

We've seen a downstream compilation error where RCTBundleManager's bundleURL property isn't given a good memory management attribute. Making this property strong seems like the right thing to do here, since if someone is interested in knowing this URL they might as well hold a strong reference to it.

## Test Plan

Validated that RNTester still compiles.