### PR TITLE
Updating the android code owner to a microsoft github group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 * @microsoft/apple-rn-team
 
 # React Android specific ones
-/ReactAndroid/ @mganandraj
-/android-patches/ @mganandraj
+/ReactAndroid/ @microsoft/rnandroid
+/android-patches/ @microsoft/rnandroid


### PR DESCRIPTION
## Summary

Updating the android code owner to a github group under microsoft org. This is required for EO compliance.

## Changelog

Updating the android code owner to a github group under microsoft org. This is required for EO compliance.
