### PR TITLE
Replace currentAppearance with currentDrawingAppearance on macOS 11+

### DIFF
--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -81,7 +81,11 @@ NSString *RCTColorSchemePreference(NSAppearance *appearance)
     return RCTAppearanceColorSchemeLight;
   }
 
-  appearance = appearance ?: [NSAppearance currentAppearance];
+	if (@available(macOS 11.0, *)) {
+		appearance = appearance ?: [NSAppearance currentDrawingAppearance];
+	} else {
+		appearance = appearance ?: [NSAppearance currentAppearance];
+	}
   NSAppearanceName appearanceName = [appearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
   return appearances[appearanceName] ?: RCTAppearanceColorSchemeLight;
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

[NSAppearance.current](https://developer.apple.com/documentation/appkit/nsappearance/1531945-current) is deprecated. Replace it with [NSAppearance.currentDrawing()](https://developer.apple.com/documentation/appkit/nsappearance/3674648-currentdrawing) for macOS 11+.

Note that both can still only be called on the main thread. I have not found a way to access an NSAppearance on a background thread safely.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Replace currentAppearance with currentDrawingAppearance on macOS 11+

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

RN-Tester still works fine in Dark Mode on my macOS 12 machine. 