### PR TITLE
Adding patch to ensure rn-tester for android builds successfully

### DIFF
--- a/android-patches/patches/Build/ReactAndroid/Android-prebuilt.mk
+++ b/android-patches/patches/Build/ReactAndroid/Android-prebuilt.mk
@@ -1,0 +1,13 @@
+diff --git a/ReactAndroid/Android-prebuilt.mk b/ReactAndroid/Android-prebuilt.mk
+index 18f8c26620..1e5afe5751 100644
+--- a/ReactAndroid/Android-prebuilt.mk
++++ b/ReactAndroid/Android-prebuilt.mk
+@@ -34,7 +34,7 @@ include $(CLEAR_VARS)
+ LOCAL_MODULE := folly_json
+ LOCAL_SRC_FILES := $(REACT_NDK_EXPORT_DIR)/$(TARGET_ARCH_ABI)/libfolly_json.so
+ LOCAL_EXPORT_C_INCLUDES := \
+-  $(THIRD_PARTY_NDK_DIR)/boost/boost_1_63_0 \
++  $(THIRD_PARTY_NDK_DIR)/boost/boost_1_68_0 \
+   $(THIRD_PARTY_NDK_DIR)/double-conversion \
+   $(THIRD_PARTY_NDK_DIR)/folly
+ # Note: Sync with folly/Android.mk.


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Cherry-picks a change to enable rntester to build successfully for Android in 0.66-stable.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Ensure rn-tester for android builds successfully in 0.66-stable

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Built via the commands in the pr pipeline for android, and then ran `./gradlew :packages:rn-tester:android:app:assemblehermesdebug` which built successfully
