### PR TITLE
Use RCTEventDispatcherProtocol in RCTView

### DIFF
--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -9,7 +9,7 @@
 
 #import <React/RCTBorderStyle.h>
 #import <React/RCTComponent.h>
-#import <React/RCTEventDispatcher.h> // TODO(OSS Candidate ISS#2710739)
+#import <React/RCTEventDispatcherProtocol.h> // TODO(OSS Candidate ISS#2710739)
 #import <React/RCTPointerEvents.h>
 
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
@@ -23,7 +23,7 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @interface RCTView : RCTUIView // TODO(macOS ISS#3536887)
 
 // [TODO(OSS Candidate ISS#2710739)
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher;
+- (instancetype)initWithEventDispatcher:(id<RCTEventDispatcherProtocol>)eventDispatcher;
 
 - (BOOL)becomeFirstResponder;
 - (BOOL)resignFirstResponder;

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -123,7 +123,7 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // TODO(macOS I
 
 @implementation RCTView {
   RCTUIColor *_backgroundColor; // TODO(OSS Candidate ISS#2710739)
-  RCTEventDispatcher *_eventDispatcher; // TODO(OSS Candidate ISS#2710739)
+  id<RCTEventDispatcherProtocol> _eventDispatcher; // TODO(OSS Candidate ISS#2710739)
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
   NSTrackingArea *_trackingArea;
   BOOL _hasMouseOver;
@@ -133,7 +133,7 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // TODO(macOS I
 }
 
 // [TODO(OSS Candidate ISS#2710739)
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
+- (instancetype)initWithEventDispatcher:(id<RCTEventDispatcherProtocol>)eventDispatcher
 {
   if ((self = [self initWithFrame:CGRectZero])) {
     _eventDispatcher = eventDispatcher;


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
This change makes the macOS fork compatible with react-native-core and the current RTCBridge implementation.
It changed in react-native-core in https://github.com/facebook/react-native/commit/ea93151f21003df6f65dd173dd5dcb3135b0ae94


## Changelog

[macOS] [Fixed] - Use RCTEventDispatcherProtocol in RCTView.h/.m (instead of RCTEventDispatcher*)

## Test Plan

Ran rn-tester app

<img width="1288" alt="Screen Shot 2022-02-21 at 3 16 51 PM" src="https://user-images.githubusercontent.com/484044/155037353-aa650dd6-d391-490f-b044-c925e1a7118c.png">

Used at Meta Inc. for Facebook Messenger macOS

