### PR TITLE
Cleaning up parts of android-pr.yml

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -35,12 +35,12 @@ jobs:
       - task: CmdLine@2
         displayName: Remove RNTesterApp.android.bundle
         inputs:
-          script: rm -f RNTesterApp.android.bundle
+          script: rm -f ./packages/rn-tester/js/RNTesterApp.android.bundle
 
       - task: CmdLine@2
         displayName: Create RNTester bundle
         inputs:
-          script: node cli.js bundle --entry-file ./packages/rn-tester/js/RNTesterApp.android.js --bundle-output RNTesterApp.android.bundle --platform android
+          script: node cli.js bundle --entry-file ./packages/rn-tester/js/RNTesterApp.android.js --bundle-output ./packages/rn-tester/js/RNTesterApp.android.bundle --platform android
 
       - task: CmdLine@2
         displayName: gradlew installArchives
@@ -52,7 +52,7 @@ jobs:
         inputs:
           script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew :packages:rn-tester:android:app:assemble
 
-      - template: templates\prep-android-nuget.yml
+      - template: templates/prep-android-nuget.yml
 
       # Verify depenendencies can be enumerated and downloaded ..
       - task: CmdLine@2

--- a/.ado/templates/android-build-office.yml
+++ b/.ado/templates/android-build-office.yml
@@ -17,8 +17,9 @@ steps:
 
   # Install NuGet
   - task: CmdLine@2
+    displayName: Install NuGet
     inputs:
-      script: mkdir $(System.DefaultWorkingDirectory)/nuget-bin/ && curl -o $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+      script: curl -o $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe --create-dirs https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 
   - task: CmdLine@2
     displayName: "Rename package to react-native"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Trying to execute the PR steps locally (via an automatically generated script) can result in errors when invoking the generated script multiple times. This PR attempts to fix that, and also perform some additional clean up like giving a display name to a step, generating RNTesterApp.android.bundle to the expected location, and use Unix style paths instead of windows paths

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Cleaning up Android PR to allow for repeated executions without error.

## Test Plan

Running the PR pipeline and executing locally.
