### PR TITLE
AB#5839699 - Repeated application of android patches should not duplicate changes

### DIFF
--- a/android-patches/patches/Build/ReactAndroid/NuGet.Config
+++ b/android-patches/patches/Build/ReactAndroid/NuGet.Config
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/Build/ReactAndroid/NuGet.Config	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/NuGet.Config b/ReactAndroid/NuGet.Config
+new file mode 100644
+index 0000000000..5d6eee562c
+--- /dev/null
++++ b/ReactAndroid/NuGet.Config
 @@ -0,0 +1,13 @@
 +﻿<?xml version="1.0" encoding="utf-8"?>
 +<configuration>

--- a/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
@@ -1,5 +1,8 @@
---- /dev/ReactAndroid/ReactAndroid.nuspec	1969-12-31 16:00:00.000000000 -0800
-+++ /dev/ReactAndroid/ReactAndroid.nuspec	2022-02-13 23:24:19.927074747 -0800
+diff --git a/ReactAndroid/ReactAndroid.nuspec b/ReactAndroid/ReactAndroid.nuspec
+new file mode 100644
+index 0000000000..87a89816c7
+--- /dev/null
++++ b/ReactAndroid/ReactAndroid.nuspec
 @@ -0,0 +1,262 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">

--- a/android-patches/patches/Build/ReactAndroid/packages.config
+++ b/android-patches/patches/Build/ReactAndroid/packages.config
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/Build/ReactAndroid/packages.config	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/packages.config b/ReactAndroid/packages.config
+new file mode 100644
+index 0000000000..dcaed5f4d0
+--- /dev/null
++++ b/ReactAndroid/packages.config
 @@ -0,0 +1,5 @@
 +﻿<?xml version="1.0" encoding="utf-8"?>
 +<packages>

--- a/android-patches/patches/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
+++ b/android-patches/patches/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
+new file mode 100644
+index 0000000000..87364957dc
+--- /dev/null
++++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
 @@ -0,0 +1,49 @@
 +/**
 + * Copyright (c) 2015-present, Facebook, Inc.

--- a/android-patches/patches/OfficeRNHost/ReactCommon/cxxreact/PlatformBundleInfo.h
+++ b/android-patches/patches/OfficeRNHost/ReactCommon/cxxreact/PlatformBundleInfo.h
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/OfficeRNHost/ReactCommon/cxxreact/PlatformBundleInfo.h	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactCommon/cxxreact/PlatformBundleInfo.h b/ReactCommon/cxxreact/PlatformBundleInfo.h
+new file mode 100644
+index 0000000000..84fb4a2aa6
+--- /dev/null
++++ b/ReactCommon/cxxreact/PlatformBundleInfo.h
 @@ -0,0 +1,15 @@
 +#pragma once
 +

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk b/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
+new file mode 100644
+index 0000000000..8e28a3ddfd
+--- /dev/null
++++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
 @@ -0,0 +1,21 @@
 +# Copyright (c) Facebook, Inc. and its affiliates.
 +#

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp b/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
+new file mode 100644
+index 0000000000..dbfcd275ec
+--- /dev/null
++++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
 @@ -0,0 +1,51 @@
 +//  Copyright (c) Facebook, Inc. and its affiliates.
 +//

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8Executor.java
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8Executor.java
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8Executor.java	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8Executor.java b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8Executor.java
+new file mode 100644
+index 0000000000..c28186d613
+--- /dev/null
++++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8Executor.java
 @@ -0,0 +1,32 @@
 +/**
 + * Copyright (c) 2015-present, Facebook, Inc.

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
+new file mode 100644
+index 0000000000..16de96d215
+--- /dev/null
++++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
 @@ -0,0 +1,35 @@
 +#include <jsi/jsi.h>
 +#include <jsi/V8Runtime.h>

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.h
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.h
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.h	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.h b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.h
+new file mode 100644
+index 0000000000..0606103d3a
+--- /dev/null
++++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.h
 @@ -0,0 +1,17 @@
 +#include <folly/dynamic.h>
 +#include <jsiexecutor/jsireact/JSIExecutor.h>

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.java
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.java
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.java	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.java b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.java
+new file mode 100644
+index 0000000000..04447562c7
+--- /dev/null
++++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.java
 @@ -0,0 +1,93 @@
 +/*
 + * Copyright (c) 2015-present, Facebook, Inc.

--- a/android-patches/patches/V8/ReactAndroid/src/main/jni/third-party/v8jsi/Android.mk
+++ b/android-patches/patches/V8/ReactAndroid/src/main/jni/third-party/v8jsi/Android.mk
@@ -1,5 +1,8 @@
---- /dev/null	2022-01-12 17:14:59.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/jni/third-party/v8jsi/Android.mk	2022-01-12 15:04:31.000000000 -0800
+diff --git a/ReactAndroid/src/main/jni/third-party/v8jsi/Android.mk b/ReactAndroid/src/main/jni/third-party/v8jsi/Android.mk
+new file mode 100644
+index 0000000000..ca299e0278
+--- /dev/null
++++ b/ReactAndroid/src/main/jni/third-party/v8jsi/Android.mk
 @@ -0,0 +1,17 @@
 +LOCAL_PATH:= $(call my-dir)
 +include $(CLEAR_VARS)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This change regenerates some of the android specific patches related to newly created files. Currently, if we were to reapply patching, this would result in content being duplicated, due to how the patch was generated. With the new patches, content is not repeated on subsequent applies. The main advantage of this is that it avoids cryptic build errors in the scenario that a developer applies the patches multiple times (for instance through use of an auto generated script).
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Allow patches to be applied multiple times without issue.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Built locally and was able to build successfully after applying the patches multiple times. 