### PR TITLE
ci: disable Ccache in integration pipeline (#1043)

### DIFF
--- a/.ado/apple-integration.yml
+++ b/.ado/apple-integration.yml
@@ -92,9 +92,13 @@ jobs:
           ../scripts/xcodebuild.sh macos/Example.xcworkspace build
         displayName: Build Intel
         workingDirectory: react-native-test-app/example
+        env:
+          CCACHE_DISABLE: 1
       - bash: |
           set -eo pipefail
           ../scripts/xcodebuild.sh macos/Example.xcworkspace clean
           ../scripts/xcodebuild.sh macos/Example.xcworkspace build ARCHS=arm64
         displayName: Build ARM
         workingDirectory: react-native-test-app/example
+        env:
+          CCACHE_DISABLE: 1


### PR DESCRIPTION
## Summary

Ccache is interfering with how Xcode finds `libclang_rt.ubsan_osx_dynamic.dylib` in the integration pipeline.

Cherry-picks #1043

## Changelog

[Internal] [Fixed] - Disable Ccache to fix Xcode not being able to find `libclang_rt.ubsan_osx_dynamic.dylib`

## Test Plan

Integration pipeline should be green.