### PR TITLE
AB#5845915 Adding a yaml-to-script script to convert pr yaml files into local sc…

### DIFF
--- a/scripts/yaml-to-script.sh
+++ b/scripts/yaml-to-script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# First check that the bundle has been built
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+if [[ ! -f "$SCRIPT_DIR"/yaml-to-script/build/index.js ]]; then
+	echo "yaml-to-script hasn't been built yet. Building now."
+	$( cd "$SCRIPT_DIR"/yaml-to-script && eval "npm install" && eval "npx tsc" )
+fi
+
+eval "node "$SCRIPT_DIR"/yaml-to-script/build/index.js "$@""

--- a/scripts/yaml-to-script/package.json
+++ b/scripts/yaml-to-script/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "yaml-to-script",
+  "version": "1.0.0",
+  "description": "Generates a script that can be run locally to replicate the steps performed in an ADO PR pipeline.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/node": "^17.0.21",
+    "commander": "^9.0.0",
+    "js-yaml": "^4.1.0",
+    "readline-sync": "^1.4.10"
+  },
+  "devDependencies": {
+    "typescript": "^4.5.5"
+  }
+}

--- a/scripts/yaml-to-script/src/AskUser.ts
+++ b/scripts/yaml-to-script/src/AskUser.ts
@@ -1,0 +1,200 @@
+'use strict'
+
+// Local modules
+import { ConsoleOutputColor, ColorizeText } from './ConsoleUtils';
+
+// Community modules
+import * as ReadlineSync from 'readline-sync';
+
+enum ResponseType
+{
+    Yes             = 1 << 0,
+    No              = 1 << 1,
+    AcceptRemaining = 1 << 2,
+    SkipRemaining   = 1 << 3,
+    Quit            = 1 << 4,
+    String          = 1 << 5,
+    Invalid         = 1 << 6
+}
+
+class Response
+{
+    type:ResponseType;
+    value:string;
+
+    constructor(typeIn:ResponseType, valueIn:string)
+    {
+        this.type = typeIn;
+        this.value = valueIn;
+    }
+}
+
+namespace ResponseType
+{
+    export function ToKeyInValue(responseType: ResponseType):string
+    {
+        switch (responseType)
+        {
+            case ResponseType.Yes: return 'y';
+            case ResponseType.No: return 'n';
+            case ResponseType.AcceptRemaining: return 'a';
+            case ResponseType.SkipRemaining: return 's';
+            case ResponseType.Quit: return 'q';
+            case ResponseType.String: return '';
+        }
+
+        // TODO: switch to different error reporting
+        console.error(`Missing key in value for ResponseType: ${responseType}`);
+        process.exit(1);
+    }
+
+    export function ToString(responseType: ResponseType): string
+    {
+        switch (responseType)
+        {
+            case ResponseType.Yes: return 'Yes';
+            case ResponseType.No: return 'No';
+            case ResponseType.AcceptRemaining: return 'Accept remaining';
+            case ResponseType.SkipRemaining: return 'Skip remaining';
+            case ResponseType.Quit: return 'Quit';
+            case ResponseType.String: return '';
+        }
+
+        // TODO: switch to different error reporting
+        console.error(`Missing string value for ResponseType: ${responseType}`);
+        process.exit(1);
+    }
+
+    export function IsSingleResponseType(responseTypeIn: ResponseType): boolean
+    {
+        let numResponseTypes = 0;
+        for (const value of Object.values(ResponseType))
+        {
+            const responseType: ResponseType = value as ResponseType;
+            if (responseTypeIn & responseType)
+            {
+                numResponseTypes++;
+                if (numResponseTypes > 1)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    export function FormatValidResponses(responseTypesIn: ResponseType, defaultResponse?:ResponseType, stringBoilerplate?:string): string
+    {
+        if (responseTypesIn === ResponseType.String)
+        {
+            return '';
+        }
+
+        let responseOptionsMessage:string[] = [];
+        for (const value of Object.values(ResponseType))
+        {
+            const responseType: ResponseType = value as ResponseType;
+            if (responseTypesIn & responseType && responseType !== ResponseType.String)
+            {
+                const stringValue = ResponseType.ToString(responseType);
+                const keyInValue = ResponseType.ToKeyInValue(responseType);
+                responseOptionsMessage.push(`${stringValue}(${keyInValue})`);
+            }
+        }
+
+        if (stringBoilerplate !== undefined)
+        {
+            responseOptionsMessage.push('|');
+            responseOptionsMessage.push(`<${stringBoilerplate}>`);
+        }
+    
+        if (defaultResponse !== undefined)
+        {
+            // Validate that only one value was chosen
+            if (!IsSingleResponseType(defaultResponse))
+            {
+                // TODO: Replace with other error reporting
+                console.error(`Default response should be limited to only one response type!`);
+                process.exit(1);
+            }
+
+            const defaultKeyInValue:string = ResponseType.ToKeyInValue(defaultResponse);
+            responseOptionsMessage.push(`[${defaultKeyInValue}]`);
+        }
+    
+        return responseOptionsMessage.join(' ') + ': ';
+    }
+
+    export function GetResponse(responseTypeIn: ResponseType, valueIn: string): Response
+    {
+        for (const value of Object.values(ResponseType))
+        {
+            const responseType:ResponseType = value as ResponseType;
+            if (responseTypeIn & responseType)
+            {
+                if (responseType === ResponseType.String ||
+                    valueIn.toUpperCase() === ResponseType.ToKeyInValue(responseType).toUpperCase())
+                {
+                    return { type:responseType, value:valueIn }
+                }
+            }
+        }
+
+        return { type:ResponseType.Invalid, value: '' };
+    }
+}
+
+class QuestionParams
+{
+    // Optional message to present before asking a question, to provide necessary context
+    // The context message is presented on a line before the question.
+    contextMessage?: string;
+
+    // The actual question to ask.
+    question: string = '';
+
+    // Set of allowed responses. Can be or'd together
+    responseType: ResponseType = ResponseType.Yes | ResponseType.No;
+
+    // Specifies a default response if the user decides to press enter without any input
+    defaultResponse?: ResponseType;
+
+    color: ConsoleOutputColor = ConsoleOutputColor.Reset;
+
+    stringBoilerplate?: string;
+}
+
+function AskQuestion(params: QuestionParams) : Response
+{
+    // Display the context message, if any, before asking the question
+    if (params.contextMessage !== undefined)
+    {
+        console.log(ColorizeText(params.contextMessage, params.color));
+    }
+
+    // Ask the question
+    console.log(ColorizeText(params.question, params.color));
+
+    // Present valid responses
+    while (true)
+    {
+        const responseValue:string = ReadlineSync.question(ResponseType.FormatValidResponses(params.responseType, params.defaultResponse, params.stringBoilerplate));
+        if (responseValue === '' && params.defaultResponse !== undefined)
+        {
+            console.log('');
+            return { type:params.defaultResponse, value:ResponseType.ToKeyInValue(params.defaultResponse) };
+        }
+
+        const response:Response = ResponseType.GetResponse(params.responseType, responseValue);
+        if (response.type !== ResponseType.Invalid)
+        {
+            console.log('');
+            return { type:response.type, value:responseValue };
+        }
+
+        console.log(ColorizeText('Invalid response! Please enter a valid response:', ConsoleOutputColor.Red));
+    }
+}
+
+export { AskQuestion, Response, ResponseType };

--- a/scripts/yaml-to-script/src/ConsoleUtils.ts
+++ b/scripts/yaml-to-script/src/ConsoleUtils.ts
@@ -1,0 +1,32 @@
+'use strict'
+
+// Color escape codes which will be used to generate colorized text output.
+const enum ConsoleOutputColor
+{
+    Reset   = '\x1b[0m',
+    Black   = '\x1b[30m',
+    Red     = '\x1b[31m',
+    Green   = '\x1b[32m',
+    Yellow  = '\x1b[33m',
+    Blue    = '\x1b[34m',
+    Magenta = '\x1b[35m',
+    Cyan    = '\x1b[36m',
+    White   = '\x1b[37m',
+}
+
+// Wraps text with the appropriate color escape codes, so that when the returned text is written to the console,
+// it will be colored and subsequent text will be returned to the previous color. This does NOT write to the console.
+// Callers are responsible for writing the returned text to the console.
+function ColorizeText(text: String, color: ConsoleOutputColor) : String
+{
+    if (color === ConsoleOutputColor.Reset)
+    {
+        // No need to wrap the text with escape codes, as the net effect is the same as
+        // printing the text with the current console foreground color.
+        return text;
+    }
+
+    return color + text + ConsoleOutputColor.Reset;
+}
+
+export { ConsoleOutputColor, ColorizeText};

--- a/scripts/yaml-to-script/src/ProcessYaml.ts
+++ b/scripts/yaml-to-script/src/ProcessYaml.ts
@@ -1,0 +1,241 @@
+'use strict';
+
+// Local Modules
+import { ScriptBuilder } from './ScriptBuilder';
+import { ColorizeText, ConsoleOutputColor } from './ConsoleUtils';
+import { AskQuestion, ResponseType } from './AskUser';
+
+// Community modules
+import * as YAML from 'js-yaml';
+
+// Node modules
+import * as FS from 'fs';
+import * as Path from 'path';
+
+const enum YAMLKeys
+{
+    Jobs        = 'jobs',
+    Job         = 'job',
+    Steps       = 'steps',
+    Template    = 'template',
+    Parameters  = 'parameters',
+    Inputs      = 'inputs',
+    Script      = 'script',
+    DisplayName = 'displayName',
+    Task        = 'task'
+}
+
+// Not all task types are supported as of yet.
+const supportedTasks: string[] = ['CmdLine@2'];
+
+class YAMLProcessorOptions
+{
+    echo: boolean = true;
+    errorCheck: boolean = true;
+    interactive: boolean = false;
+    summary: boolean = true;
+
+    constructor(options: { echo: boolean,  errorCheck: boolean, interactive: boolean, summary: boolean })
+    {
+       Object.assign(this, options);
+    }
+}
+
+class YAMLProcessor
+{
+    inputFilePath: string;
+    outputFilePath: string;
+    defaultWorkingDirectory: string;
+    options: YAMLProcessorOptions;
+    scriptBuilder: ScriptBuilder;
+    acceptRemaining: boolean = false;
+    skipRemaining: boolean = false;
+
+    constructor(inputFilePath: string, outputFilePath: string, defaultWorkingDirectory: string, options: YAMLProcessorOptions)
+    {
+        this.inputFilePath = inputFilePath;
+        this.outputFilePath = outputFilePath;
+        this.defaultWorkingDirectory = defaultWorkingDirectory
+        this.options = options;
+        this.scriptBuilder = new ScriptBuilder(this.outputFilePath, {echo: this.options.echo, errorCheck: this.options.errorCheck, summary: this.options.summary} );
+    }
+
+    SanitizeCommand(command: string, parameters: object) : string
+    {
+        // Update the working directory environment variable to point to the repo root
+        let sanitizedCommand = command.replace(/\$\(System\.DefaultWorkingDirectory\)/g, this.defaultWorkingDirectory);
+
+        // Update any parameters with the parameters that were passed in with the template
+        const parameterMatches = sanitizedCommand.matchAll(/\$\{\{\s*parameters\.(\S*)\s*\}\}/g);
+        for (const match of parameterMatches)
+        {
+            // The 0th index of match contains the full regex match, wheras the 1st index of match contains the first capture group
+            // which in the case of the regex above, is the name of the parameter. We don't have to check that the passed in parameters 
+            // object contains a key corresponding to the matched parameter, since we validated this in ProcessTemplate.
+            sanitizedCommand = sanitizedCommand.replace(match[0], parameters[match[1]]);
+        }
+
+        return sanitizedCommand;
+    }
+
+    ProcessTemplate(templatePath: string, passedInParameters: Object) : void
+    {
+        const templateYAML = YAML.load(FS.readFileSync(templatePath, 'utf-8'));
+        if (YAMLKeys.Parameters in templateYAML)
+        {
+            // Verify the correct parameters were read in
+            for (const parameter in templateYAML[YAMLKeys.Parameters])
+            {
+                if (!(parameter in passedInParameters))
+                {
+                    const templateName: string = Path.basename(templatePath);
+                    // Give user an opportunity to supply a parameter value
+                    const response = 
+                        AskQuestion({contextMessage:`Error: Missing parameter '${parameter}' for template '${templateName}.`,
+                                    question: 'Provide a value now?',
+                                    defaultResponse: ResponseType.Quit,
+                                    stringBoilerplate: `${parameter}`,
+                                    responseType: ResponseType.Quit | ResponseType.String,
+                                    color: ConsoleOutputColor.Red});
+                    
+                    if (response.type === ResponseType.Quit)
+                    {
+                        console.log('Terminating script termination');
+                        process.exit(1);
+                    }
+                    else
+                    {
+                        passedInParameters[parameter] = response.value
+                    }
+                }
+            }
+        }
+    
+        if (YAMLKeys.Steps in templateYAML)
+        {
+            this.ProcessSteps(templateYAML[YAMLKeys.Steps], Path.dirname(templatePath), passedInParameters);
+        }
+    }
+
+    ProcessSteps(steps: Object, currentDirectory: string, parameters: Object) : void
+    {
+        for (const stepIndex in steps)
+        {
+            const step = steps[stepIndex];
+            if (YAMLKeys.Template in step)
+            {
+                let parameters = {};
+                if (YAMLKeys.Parameters in step)
+                {
+                    parameters = step[YAMLKeys.Parameters];
+                }
+
+                // Expand the template and process it
+                this.ProcessTemplate(Path.join(currentDirectory, step[YAMLKeys.Template]), parameters);
+            }
+
+            if (YAMLKeys.Inputs in step && YAMLKeys.Script in step[YAMLKeys.Inputs])
+            {
+                const displayName = YAMLKeys.DisplayName in step ? step[YAMLKeys.DisplayName] : 'Command without display name';
+
+                if (YAMLKeys.Task in step)
+                {
+                    const taskType = step[YAMLKeys.Task];
+                    if (!this.skipRemaining && !supportedTasks.includes(taskType))
+                    {
+                        console.log(ColorizeText(`Warning: Unsupported task type '${taskType}' for command '${displayName}'. Skipping command.\n`, ConsoleOutputColor.Yellow));
+                        continue;
+                    }
+                }
+
+                const santizedCommand = this.SanitizeCommand(step[YAMLKeys.Inputs].script, parameters);
+                let skipCommand:boolean = this.skipRemaining;
+
+                if (this.options.interactive && !this.skipRemaining && !this.acceptRemaining)
+                {
+                    const response = 
+                        AskQuestion({contextMessage: `Processing command: ${displayName}:\n${santizedCommand}\n`,
+                                    question: `Add \'${displayName}\' to your script?`,
+                                    responseType: ResponseType.Yes | ResponseType.No | ResponseType.AcceptRemaining | ResponseType.SkipRemaining | ResponseType.Quit,
+                                    defaultResponse: ResponseType.Yes,
+                                    color: ConsoleOutputColor.Reset});
+
+                    switch (response.type)
+                    {
+                        case ResponseType.AcceptRemaining:
+                        {
+                            this.acceptRemaining = true;
+                            console.log(ColorizeText('Accepting all subsequent commands.\n', ConsoleOutputColor.Yellow));
+                            break;
+                        } 
+                        case ResponseType.SkipRemaining:
+                        {
+                            this.skipRemaining = true;
+                            skipCommand = true;
+                            console.log(ColorizeText('Skipping all subsequent commands.\n', ConsoleOutputColor.Yellow));
+                            break;
+                        }
+                        case ResponseType.No:
+                        {
+                            skipCommand = true;
+                            break;
+                        }
+                        case ResponseType.Yes:
+                        {
+                            break;
+                        }
+                        case ResponseType.Quit:
+                        {
+                            console.log('Terminating script generation.');
+                            process.exit(0);
+                        }
+                    }
+                }
+
+                if (skipCommand)
+                {
+                    continue;
+                }
+
+                this.scriptBuilder.AddCommand(displayName, santizedCommand);
+            }
+        }
+    }
+
+    ProcessJob(jobYAML: object, currentDirectory: string) : void
+    {
+        // Start the script section with the name of the job, for reference
+        if (!(YAMLKeys.Steps in jobYAML))
+        {
+            // For whatever reason, this job doesn't have any steps, so ignore it
+            return;
+        }
+
+        this.scriptBuilder.AddComment('Job: ' + jobYAML[YAMLKeys.Job]);
+        this.scriptBuilder.AddLine('');
+        this.ProcessSteps(jobYAML[YAMLKeys.Steps], currentDirectory, {});
+    }
+
+    Process(): void
+    {
+        // Load the YAML located at the path
+        const prYAML = YAML.load(FS.readFileSync(this.inputFilePath, 'utf-8'));
+
+        // Verify there is at least one job in the YAML file, and report an error otherwise
+        if (!(YAMLKeys.Jobs in prYAML))
+        {
+            console.error(`No jobs found in the YAML file located at ${this.inputFilePath}! Not a valid PR YAML file.`);
+            process.exit(1);
+        }
+
+        for (const jobIndex in prYAML.jobs)
+        {
+            this.ProcessJob(prYAML.jobs[jobIndex], Path.dirname(this.inputFilePath));
+        }
+
+        this.scriptBuilder.WriteFile();
+        console.log(ColorizeText(`Script generated successfully to ${this.outputFilePath}`, ConsoleOutputColor.Green));
+    }
+}
+
+export { YAMLProcessor };

--- a/scripts/yaml-to-script/src/ScriptBuilder.ts
+++ b/scripts/yaml-to-script/src/ScriptBuilder.ts
@@ -1,0 +1,184 @@
+"use strict"
+
+// Local modules
+import { ColorizeText, ConsoleOutputColor } from "./ConsoleUtils";
+
+// Node modules
+import * as FS from 'fs';
+import * as OS from 'os';
+
+class ScriptBuilderOptions
+{
+    echo: boolean = true;
+    errorCheck: boolean = true;
+    summary: boolean = true;
+
+    constructor(options: { echo: boolean, errorCheck: boolean, summary: boolean })
+    {
+       Object.assign(this, options);
+    }
+}
+
+class ScriptBuilder
+{
+    buffer: string;
+    filepath: string;
+    options: ScriptBuilderOptions;
+
+    constructor(filepath: string, options: ScriptBuilderOptions)
+    {
+        this.filepath = filepath;
+        this.buffer = '';
+        this.options = options;
+
+        // shebang to use bash as the interpreter
+        this.AddLine('#!/bin/bash');
+
+        // Initialize a bash array for storing the summaries of the commands invoked
+        if (options.summary)
+        {
+            this.AddSummaryPrinter();
+        }
+
+        this.AddCallWrapper();
+    }
+
+    AddCallWrapper()
+    {
+        this.AddLine('CallWrapper()');
+        this.AddLine('{');
+        if (this.options.summary)
+        {
+            this.AddLine('\tstartTime=`date +"%s"`')
+            const startMessage = ColorizeText('$1 : START \`date +\"%b %d %T\"\`', ConsoleOutputColor.Magenta);
+            this.AddLine(`\techo -e ${startMessage}`);
+        }
+        if (this.options.echo)
+        {
+            this.AddLine('\techo $2');
+        }
+
+        this.AddLine('\teval $2');
+        if (this.options.errorCheck)
+        {
+            this.AddLine('\texitCode=$?');
+        }
+
+        if (this.options.summary)
+        {
+            this.AddLine('\tendTimePretty=`date +\"%b %d %T\"`')
+            const endMessage = ColorizeText('$1 : END $endTimePretty - \`date -d @$duration -u +%M:%S\`', ConsoleOutputColor.Magenta);
+            this.AddLine('\tendTime=`date +"%s"`')
+            this.AddLine('\tduration=$((endTime-startTime))')
+            this.AddLine(`\techo -e ${endMessage}`);
+        }
+
+        this.AddLine(`\techo ""`);
+        
+        if (this.options.errorCheck)
+        {
+            this.AddLine('\tif [ $exitCode -ne 0 ]')
+            this.AddLine('\tthen')
+            const commandFailedMessage = ColorizeText('$2\\nfailed with error code $exitCode. Stopping execution early.', ConsoleOutputColor.Red);
+            this.AddLine(`\t\techo -e \"${commandFailedMessage}\"`);
+        
+            if (this.options.summary)
+            {
+                const commandFailedSummaryMessage = ColorizeText('$1 : Failed', ConsoleOutputColor.Red);
+                this.AddLine(`\t\tcommandSummaries+=( \"${commandFailedSummaryMessage}|$endTimePretty    - \`date -d @$duration -u +%M:%S\`\" )`)
+                this.AddLine('\t\teval SummaryPrinter $exitCode');
+            }
+
+            this.AddLine('\tfi')
+        }
+       
+        if (this.options.summary)
+        {
+            this.AddLine('\tcommandSummaries+=( \"$1|$endTimePretty  - \`date -d @$duration -u +%M:%S\`\" )');
+        }
+
+        this.AddLine('}');
+        this.AddLine('');
+    }
+
+    AddSummaryPrinter()
+    {
+        const summaryPrinterFunction: string = 
+`
+commandSummaries=()
+
+SummaryPrinter()
+{
+        headerString=" Summary "
+        headerStringLength=\${#headerString}
+        maxSummaryLength=100;
+        for i in \${!commandSummaries[@]}; do
+                # Remove colors to count length properly
+                decolorizedSummary=$(sed 's/\x1b\[[0-9;]*m//g' <<< \${commandSummaries[$i]})
+                summaryLength=\${#decolorizedSummary}
+                maxSummaryLength=$((maxSummaryLength > summaryLength ? maxSummaryLength : summaryLength))
+        done
+
+        if [ \`expr $((maxSummaryLength - headerStringLength)) % 2\` == 1 ]
+        then
+                maxSummaryLength=$((maxSummaryLength + 1))
+        fi
+        numEqualSigns=$(((maxSummaryLength - headerStringLength)/2))
+        echo ""
+        printf '=%.0s' $(seq 1 $numEqualSigns)
+        printf "$headerString"
+        printf '=%.0s' $(seq 1 $numEqualSigns)
+        echo ""
+        for i in \${!commandSummaries[@]}; do
+                summary=\${commandSummaries[$i]}
+                # Remove colors to count length properly
+                decolorizedSummary=$(sed 's/\x1b\[[0-9;]*m//g' <<< \$summary)
+                decolorizedCommand=\${decolorizedSummary%|*}
+                decolorizedTimestamp=\${decolorizedSummary#*|}
+                commandLength=\${#decolorizedCommand}
+                timestampLength=\${#decolorizedTimestamp}
+                numSpaces=$((maxSummaryLength - commandLength - timestampLength))
+                command=\${summary%|*}
+                timestamp=\${summary#*|}
+                printf "$command"
+                printf ' %.0s' $(seq 1 $numSpaces)
+                printf "$timestamp"
+                echo ""
+        done
+        exit $1
+}
+`;
+
+        this.AddLine(summaryPrinterFunction);
+    }
+
+    AddCommand(displayName: string, command: string)
+    {
+        this.AddComment(displayName);
+        this.AddLine(`CallWrapper \'${displayName}\' \'${command}\'`);
+        this.AddLine('');
+    }
+
+    AddComment(comment: string)
+    {
+        this.buffer += '# ' + comment + OS.EOL; 
+    }
+
+    AddLine(line: string)
+    {
+        this.buffer +=  line + OS.EOL;
+    }
+
+    WriteFile()
+    {
+        if (this.options.summary)
+        {
+            this.AddLine('eval SummaryPrinter 0');
+        }
+
+        FS.writeFileSync(this.filepath, this.buffer);
+        FS.chmodSync(this.filepath, FS.statSync(this.filepath).mode | 0o100); // set to executable for user
+    }
+}
+
+export { ScriptBuilder };

--- a/scripts/yaml-to-script/src/ValidateOptions.ts
+++ b/scripts/yaml-to-script/src/ValidateOptions.ts
@@ -1,0 +1,132 @@
+'use strict'
+
+// Local modules
+import { ColorizeText, ConsoleOutputColor } from './ConsoleUtils';
+import { AskQuestion, ResponseType } from './AskUser';
+
+// Node modules
+import * as FS from 'fs';
+import * as Path from 'path';
+
+function ValidateInputFilePath(inputFilePathIn: string): string
+{
+    let inputPath: string = Path.resolve(inputFilePathIn);
+    while (!FS.existsSync(inputPath))
+    {
+        const response = 
+            AskQuestion({contextMessage: `Error: input file at path ${inputPath} is invalid!`,
+                        question: 'Please specify a new one:',
+                        color: ConsoleOutputColor.Red,
+                        responseType: ResponseType.String | ResponseType.Quit,
+                        stringBoilerplate: 'Path to input file',
+                        defaultResponse: ResponseType.Quit});
+        
+        switch (response.type)
+        {
+            case ResponseType.Quit:
+            {
+                // Abort the process
+                console.log('Terminating script generation');
+                process.exit(0);
+            }
+            case ResponseType.String:
+            {
+                inputPath = Path.resolve(response.value);
+                break;
+            }
+        }
+    }
+
+    return inputPath;
+}
+
+function ValidateDefaultWorkingDirectory(defaultWorkingDirectoryIn: string): string
+{
+    // Validate default working directory
+    let defaultWorkingDirectory: string = Path.resolve(defaultWorkingDirectoryIn);
+    let wasDefaultWorkingDirectoryInvalid: boolean = false;
+    while (!FS.existsSync(defaultWorkingDirectory) || !FS.lstatSync(defaultWorkingDirectory).isDirectory())
+    {
+        wasDefaultWorkingDirectoryInvalid = true;
+        // The specified working directory either does not exist or it is not actually a directory, so prompt the user for a new one
+        const response = 
+            AskQuestion({contextMessage: `Error: working directory at path ${defaultWorkingDirectory} is invalid!`,
+                        question: 'Please specify a new one:',
+                        color: ConsoleOutputColor.Red,
+                        responseType: ResponseType.String | ResponseType.Quit,
+                        stringBoilerplate: 'Path to directory',
+                        defaultResponse: ResponseType.Quit});
+
+        switch (response.type)
+        {
+            case ResponseType.Quit:
+            {
+                // Abort the process
+                console.log('Terminating script generation');
+                process.exit(0);
+            }
+            case ResponseType.String:
+            {
+                // Prompt the user for another filepath to write to
+                defaultWorkingDirectory = Path.resolve(response.value);
+                break;
+            }
+        }
+    } 
+
+    if (wasDefaultWorkingDirectoryInvalid)
+    {
+        console.log(ColorizeText(`${defaultWorkingDirectory} set as the default working directory`, ConsoleOutputColor.Green));
+        console.log('');
+    }
+
+    return defaultWorkingDirectory;
+}
+
+function ValidateOutputFilepath(outputFilePathIn: string): string
+{
+    // Validate output filepath
+    let outputFilePath: string = Path.resolve(outputFilePathIn);
+    let overwriteAllowed: boolean = false;
+
+    while (FS.existsSync(outputFilePath) && !overwriteAllowed)
+    {
+        const response = 
+            AskQuestion({contextMessage: `Warning: File at path ${outputFilePath} already exists.`,
+                        question: 'Are you sure you want to overwrite it?',
+                        color: ConsoleOutputColor.Yellow,
+                        responseType: ResponseType.Yes | ResponseType.No | ResponseType.Quit,
+                        defaultResponse: ResponseType.Yes});
+
+        switch (response.type)
+        {
+            case ResponseType.Quit:
+            {
+                // Abort the process
+                console.log('Terminating script generation');
+                process.exit(0);
+            }
+            case ResponseType.No:
+            {
+                // Prompt the user for another filepath to write to
+                const pathResponse =
+                    AskQuestion({question:'Please enter the filepath to generate the output script to:',
+                                responseType: ResponseType.String,
+                                color: ConsoleOutputColor.Reset});
+
+                outputFilePath = pathResponse.value;
+                break;
+            }
+            case ResponseType.Yes:
+            {
+                // Proceed
+                overwriteAllowed = true;
+                break;
+            }
+        }
+    }
+
+    return outputFilePath;
+}
+
+export { ValidateDefaultWorkingDirectory, ValidateOutputFilepath, ValidateInputFilePath };

--- a/scripts/yaml-to-script/src/index.ts
+++ b/scripts/yaml-to-script/src/index.ts
@@ -1,0 +1,40 @@
+'use strict'
+
+// Local modules
+import { YAMLProcessor } from './ProcessYaml';
+import { ValidateDefaultWorkingDirectory, ValidateOutputFilepath, ValidateInputFilePath } from './ValidateOptions';
+
+// Community modules
+import { Command } from 'commander';
+
+const program = new Command();
+
+// Add a banner to explain what the point of this script is.
+program.addHelpText('beforeAll', 'yaml-to-script\n\nThis script is used to read in YAML files used for ADO pipeline configurations and generates a build script to replicate the steps locally. This script will automatically expand any templates, and explicitly add parameter values if they are specified in the YAML.\n\nOnce the script is generated, give the generated file executable permissions via chmod +x <path to generated file>\n\n');
+
+// Define options. Expected values following an option are represented using the angle brackets, or square brackets if they are optional. Variadic options are represented with ...
+program.requiredOption('-p, --path <path>', 'Paths to YAML files representing an ADO PR pipelines. Paths may be absolute or relative.');
+program.requiredOption('-o, --output <output>', 'Path to save the generated build script to. Path may be absolute or relative.');
+program.requiredOption('-d, --defaultworkingdir <defaultworkingdir>', 'Working directory the generated script will be run from. Path to directory can be absolute or relative');
+program.option('-i, --interactive', 'Interactive mode. If set, each step will be presented and the user will have the option to accept or skip the step for their script.');
+program.option('--no-errorcheck', 'By default, individual steps will be wrapped with a check for the exit code, and upon failure, abort running the remaining steps. Set this flag if you prefer to execute subsequent commands regardless of the success of the previous command.')
+program.option('--no-echo', 'By default, the generated script will echo the command it will execute. Set this flag if you wish to avoid that.');
+program.option('--no-summary', 'By default, the generated script will print a summary of the commands executed. Set this flag if you wish to avoid that.')
+
+// Alert the user if the option is invalid, pointing them to the usage, or a reasonable suggestion for what they meant.
+program.showHelpAfterError('(run with --help for additional information)');
+program.showSuggestionAfterError();
+
+program.addHelpText('after', '\nExample Usage:\n yaml-to-script -p .ado/android-pr.yml -o ./build.sh -d . -i');
+
+// Read the user's options
+program.parse();
+const options = program.opts();
+
+// Validate paths
+const inputPath : string = ValidateInputFilePath(options.path);
+const outputFilePath: string = ValidateOutputFilepath(options.output);
+const defaultWorkingDirectory: string = ValidateDefaultWorkingDirectory(options.defaultworkingdir);
+
+const yamlProcesor = new YAMLProcessor(inputPath, outputFilePath, defaultWorkingDirectory, { echo: options.echo, errorCheck: options.errorcheck, interactive: options.interactive, summary: options.summary });
+yamlProcesor.Process();

--- a/scripts/yaml-to-script/tsconfig.json
+++ b/scripts/yaml-to-script/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "target": "es2017",                          
+      "module": "commonjs",                    
+      "lib": ["es6"],                     
+      "allowJs": true,
+      "outDir": "build",                          
+      "rootDir": "src",
+      "strict": true,         
+      "noImplicitAny": true,
+      "esModuleInterop": true,
+      "resolveJsonModule": true,
+      "noImplicitAny": false,
+      "downlevelIteration": true
+    }
+  }


### PR DESCRIPTION
…ripts

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Trying to build for Android locally is cumbersome because it involves copying the steps from android-pr.yml to a local script and executing commands one at a time, substituting template parameter values and working directories appropriately. To make things less annoying, I wrote a small CLI to generate this script for you, performing the necessary substitutions as needed. The user is also allowed to select which commands they wish to keep in the script.

Run `scripts/yaml-to-script.sh --help` for usage details. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Added] - Adding a script to convert a yaml pr file to a local script

## Test Plan

This doesn't affect ReactNative, and instead helps improve the inner dev loop for those working on Android. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
