### PR TITLE
remove references to RCTDynamicColor

### DIFF
--- a/packages/rn-tester/RNTesterUnitTests/RCTConvert_NSColorTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTConvert_NSColorTests.m
@@ -11,7 +11,6 @@
 #import <XCTest/XCTest.h>
 
 #import <React/RCTConvert.h>
-#import <React/RCTDynamicColor.h>
 
 @interface RCTConvert_NSColorTests : XCTestCase
 
@@ -85,7 +84,6 @@
   // 16777215 == 0x00FFFFFF == white
   id json = RCTJSONParse(@"{ \"dynamic\": { \"light\":0, \"dark\":16777215 } }", nil);
   NSColor *value = [RCTConvert UIColor:json];
-  XCTAssertTrue([value isKindOfClass:[RCTDynamicColor class]]);
   CGFloat r, g, b, a;
 
   [NSAppearance setCurrentAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
@@ -109,7 +107,6 @@
 {
   id json = RCTJSONParse(@"{ \"dynamic\": { \"light\": { \"semantic\": \"systemRedColor\" }, \"dark\":{ \"semantic\": \"systemBlueColor\" } } }", nil);
   NSColor *value = [RCTConvert UIColor:json];
-  XCTAssertTrue([value isKindOfClass:[RCTDynamicColor class]]);
   CGFloat r1, g1, b1, a1;
   CGFloat r2, g2, b2, a2;
 


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In #1028 I removed RCTDynamicColor.h/.m . There was still an explicit reference to the class in our unit tests. I'm not sure why that wasn't caught. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Removed reference to RCTDynamicColor in our unit tests. 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

CI should pass. 
