### PR TITLE
[0.66] Backport SBom generation

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -92,6 +92,17 @@ jobs:
         inputs:
           script: node .ado/removeWorkspaceConfig.js
 
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 📒 Generate Manifest
+        inputs:
+          BuildDropPath: $(System.DefaultWorkingDirectory)
+
+      - task: PublishPipelineArtifact@1
+        displayName: 📒 Publish Manifest
+        inputs:
+          artifactName: SBom-RNGithubNpmJSPublish-$(System.JobAttempt)
+          targetPath: $(System.DefaultWorkingDirectory)/_manifest
+
       - script: npm publish --tag $(npmDistTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
         displayName: Publish react-native-macos to npmjs.org
 
@@ -156,6 +167,18 @@ jobs:
           script: |
             npx beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --access public
 
+      # beachball modifies the package.json files so run manifest generation after it.
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 📒 Generate Manifest
+        inputs:
+          BuildDropPath: $(System.DefaultWorkingDirectory)
+
+      - task: PublishPipelineArtifact@1
+        displayName: 📒 Publish Manifest
+        inputs:
+          artifactName: SBom-RNMacOSInitNpmJSPublish-$(System.JobAttempt)
+          targetPath: $(System.DefaultWorkingDirectory)/_manifest
+
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office
     pool: Azure-Pipelines-EO-Ubuntu18.04-Office
@@ -193,7 +216,7 @@ jobs:
 
       # Enumerate and download all dependencies ..
       - task: CmdLine@2
-        displayName: 'Verify Dependencies can be enumerated'
+        displayName: 'Verify Dependencies can be enumerated [test]'
         inputs:
           script: sudo apt-get install python3-pip && sudo apt-get install python3-setuptools && pip3 install BeautifulSoup4 && pip3 install wheel && pip3 install wget && python3 android-patches/scripts/downloadDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android
 
@@ -214,6 +237,11 @@ jobs:
           BUILD_SOURCEBRANCH: $(Build.SourceBranch)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           githubApiToken: $(githubAuthToken)
+
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 📒 Generate Manifest
+        inputs:
+          BuildDropPath: $(Build.StagingDirectory)/final
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish final artifacts'


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Backport SBOM generation and mark validation step as [test].
The pipeline is passing, and running but with warnings at the moment.

## Changelog

[Internal] [changed] - Message

## Test Plan

N/A
