### PR TITLE
Fix blurry text on non-retina displays

### DIFF
--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -55,6 +55,8 @@
     self.accessibilityTraits |= UIAccessibilityTraitStaticText;
 #else // [TODO(macOS GH#774)
     self.accessibilityRole = NSAccessibilityStaticTextRole;
+    // Fix blurry text on non-retina displays.
+    self.canDrawSubviewsIntoLayer = YES;
 #endif // ]TODO(macOS GH#774)
     self.opaque = NO;
     RCTUIViewSetContentModeRedraw(self); // TODO(macOS GH#774) and TODO(macOS ISS#3536887)

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -49,6 +49,8 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
     NSTextCheckingTypes checkingTypes = 0;
     self.enabledTextCheckingTypes = checkingTypes;
     self.insertionPointColor = [NSColor selectedControlColor];
+    // Fix blurry text on non-retina displays.
+    self.canDrawSubviewsIntoLayer = YES;
 #endif // ]TODO(macOS GH#774)
 
     _textInputDelegateAdapter = [[RCTBackedTextViewDelegateAdapter alloc] initWithTextView:self];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Since React Native macOS relies entirely on layer-backed views, there's unfortunately a bit of dark magic (setting `canDrawSubviewsIntoLayer` in the right places) required for getting text to render clearly on non-retina displays.

See: https://stackoverflow.com/questions/3917871/creating-a-label-using-nstextfield-is-blurry

Co-authored-by: Scott Kyle <skyle@fb.com>

## Changelog

[macOS] [Fixed] - Fix blurry text on non-retina displays

## Test Plan
Before
![b1](https://user-images.githubusercontent.com/484044/156860210-c991cf7c-4d3a-4262-92c1-129523c15374.png)
After
![a1](https://user-images.githubusercontent.com/484044/156860239-f93188ad-0008-453f-8569-72ed61d06932.png)

Before
![b2](https://user-images.githubusercontent.com/484044/156860244-14902ee7-6ee1-4a80-9fa6-ef2707532f94.png)

After
![a2](https://user-images.githubusercontent.com/484044/156860251-f8e5c187-f30f-42ec-b874-72f8fae0ca23.png)

Before
![b3](https://user-images.githubusercontent.com/484044/156860261-e6ba396e-1bc4-4325-b744-a7633f275ca0.png)
After
![a3](https://user-images.githubusercontent.com/484044/156860268-f0e49910-1491-46d1-ac9c-67a474cc3211.png)



