### PR TITLE
Fix buggy styling of placeholder in TextInput

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -159,6 +159,12 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
   self.string = text;
 }
 
+- (void)setTypingAttributes:(__unused NSDictionary *)typingAttributes
+{
+  // Prevent NSTextView from changing its own typing attributes out from under us.
+  [super setTypingAttributes:_defaultTextAttributes];
+}
+
 - (NSAttributedString*)attributedText
 {
   return self.textStorage;
@@ -307,13 +313,7 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
   if (self.placeholder == nil) {
     return nil;
   }
-  NSMutableDictionary *placeholderAttributes = [self.typingAttributes mutableCopy];
-  if (placeholderAttributes == nil) {
-    placeholderAttributes = [NSMutableDictionary dictionary];
-  }
-  placeholderAttributes[NSForegroundColorAttributeName] = self.placeholderColor ?: defaultPlaceholderColor();
-  placeholderAttributes[NSFontAttributeName] = self.font ?: defaultPlaceholderFont();
-  return [[NSAttributedString alloc] initWithString:self.placeholder attributes:placeholderAttributes];
+  return [[NSAttributedString alloc] initWithString:self.placeholder attributes:[self _placeholderTextAttributes]];
 }
 
 - (void)drawRect:(NSRect)dirtyRect
@@ -388,7 +388,7 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
   placeholderSize = CGSizeMake(RCTCeilPixelValue(placeholderSize.width), RCTCeilPixelValue(placeholderSize.height));
 #else // [TODO(macOS GH#774)
   CGFloat scale = self.window.backingScaleFactor;
-  CGSize placeholderSize = [placeholder sizeWithAttributes:@{NSFontAttributeName: self.font ?: defaultPlaceholderFont()}];
+  CGSize placeholderSize = [placeholder sizeWithAttributes:[self _placeholderTextAttributes]];
   placeholderSize = CGSizeMake(RCTCeilPixelValue(placeholderSize.width, scale), RCTCeilPixelValue(placeholderSize.height, scale));
 #endif // ]TODO(macOS GH#774)
   placeholderSize.width += textContainerInset.left + textContainerInset.right;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Calling `self.font` would report `AppleColorEmojiUI` after entering an emoji, which would mess up placeholder drawing. This changes the macOS implementation to use the `_placeholderTextAttributes` method. This also prevents `NSTextView` from overriding `typingAttributes` to a value other than what we want (`_defaultTextAttributes`), which fixes an issue where the font would change after inserting an emoji.

Reviewed By: ackchiu

Differential Revision: D27443488

Co-authored-by: Scott Kyle skyle@fb.com

## Changelog

[macOS] [Fixed] - Fix buggy styling of placeholder in TextInput

## Test Plan

https://user-images.githubusercontent.com/484044/156862523-fa0af232-d4eb-49ef-a437-c52df788e189.mov


