### PR TITLE
GitIgnore SBOM _manifest folder to prevent it from being pushed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ package-lock.json
 
 # Android memory profiler files
 *.hprof
+
+#SBom generation
+_manifest


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

GitIgnore SBOM _manifest  folder to prevent it from being pushed

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Git ignore SBOM Manifest folder

## Test Plan
N/!