### PR TITLE
Fix usage of deprecated API "OSSpinLockLock"

### DIFF
--- a/React/Base/macOS/RCTPlatformDisplayLink.m
+++ b/React/Base/macOS/RCTPlatformDisplayLink.m
@@ -71,17 +71,17 @@ static CVReturn RCTPlatformDisplayLinkCallBack(__unused CVDisplayLinkRef display
 
 - (void)addToRunLoop:(NSRunLoop *)runloop forMode:(NSRunLoopMode)mode
 {
-  OSSpinLockLock(&_lock);
+  os_unfair_lock_lock(&_lock);
   _runLoop = runloop;
 
   if (_displayLink != NULL) {
     [_modes addObject:mode];
-    OSSpinLockUnlock(&_lock);
+    os_unfair_lock_unlock(&_lock);
     return;
   }
 
   _modes = @[mode].mutableCopy;
-  OSSpinLockUnlock(&_lock);
+  os_unfair_lock_lock(&_lock);
   CVReturn ret = CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
   if (ret != kCVReturnSuccess) {
     ret = CVDisplayLinkCreateWithCGDisplay(CGMainDisplayID(), &_displayLink);

--- a/React/Base/macOS/RCTPlatformDisplayLink.m
+++ b/React/Base/macOS/RCTPlatformDisplayLink.m
@@ -81,7 +81,7 @@ static CVReturn RCTPlatformDisplayLinkCallBack(__unused CVDisplayLinkRef display
   }
 
   _modes = @[mode].mutableCopy;
-  os_unfair_lock_lock(&_lock);
+  os_unfair_lock_unlock(&_lock);
   CVReturn ret = CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
   if (ret != kCVReturnSuccess) {
     ret = CVDisplayLinkCreateWithCGDisplay(CGMainDisplayID(), &_displayLink);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In #1071 , we added some usages of the API `OSSpinLockLock` and `OSSpinLockUnlock`. Xcode warns me those are deprecated, and to use `os_unfair_lock_lock` and `os_unfair_lock_unlock` instead.

![Screen Shot 2022-03-08 at 1 40 17 PM](https://user-images.githubusercontent.com/6722175/157331071-6b575606-bf7f-4954-99f0-567d492a3e0c.png)


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fix usage of deprecated API "OSSpinLockLock"

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Honestly, I have no idea how to test this 🤷🏾
