### PR TITLE
chore(android-patches): use new name for patching tool for android

### DIFF
--- a/.ado/templates/apple-droid-node-patching.yml
+++ b/.ado/templates/apple-droid-node-patching.yml
@@ -5,4 +5,4 @@ steps:
   - task: CmdLine@2
     displayName: Apply Android specific patches for Office consumption
     inputs:
-      script: npm_config_yes=true npx @rnx-kit/draft-patch-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor JniUtils RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}
+      script: npm_config_yes=true npx @rnx-kit/patcher-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor JniUtils RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}

--- a/android-patches/README.md
+++ b/android-patches/README.md
@@ -9,6 +9,6 @@ This is how it happens:
 * That when used invokes `.ado/templates/apple-droid-node-patching.yml` passing the parameter `apply_office_patches` as `true`
 * This last file is the one that *actually* triggers the patching script
 
-## The patching tool
+## Patching tool
 
-As you can see from above, we use the tool [`draft-patch-rnmacos`](https://github.com/microsoft/rnx-kit/tree/main/packages/draft-patch-rnmacos) that is hosted in the `rnx-kit` repo, via `npx`. Please refer to the README of the package for details on how it works.
+We use the tool [`patcher-rnmacos`](https://github.com/microsoft/rnx-kit/tree/main/incubator/patcher-rnmacos) that is hosted in the `rnx-kit` repo, via `npx`. Please refer to the README of the package for details on how it works.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

As part of some follow up work in rnx-kit https://github.com/microsoft/rnx-kit/pull/1189 we changed the name of the patcher tool to be less misleading, from `draft-patch-rnmacos` to `patcher-rnmacos`.

This PR updates macos to use the new name. I don't think we'll have to cherry pick this into 0.66 branch.

## Test Plan

Commands run fine locally, CI should be ✅
