### PR TITLE
Fix AccessibilityRole of MenuItem

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1423,7 +1423,7 @@ RCT_ENUM_CONVERTER(
       @"link": NSAccessibilityLinkRole, // also a legacy iOS accessibilityTraits
       @"menu": NSAccessibilityMenuRole,
       @"menubar": NSAccessibilityMenuBarRole,
-      @"menuitem": NSAccessibilityMenuBarItemRole,
+      @"menuitem": NSAccessibilityMenuItemRole,
       @"none": NSAccessibilityUnknownRole,
       @"progressbar": NSAccessibilityProgressIndicatorRole,
       @"radio": NSAccessibilityRadioButtonRole,


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This looks like a simple typo. It just changes what voiceover reads out "You are on a menu _bar_ item" vs "you are on a menu item". In both cases you can press Contol+Option+Space to interact with the element. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fixed Menu Item accessibility role

## Test Plan

Tested locally in FluentUI React Native's test app
