### PR TITLE
Rearrange the logic in AccessibilityInfo.js to ensure it works nicely with macOS

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -125,6 +125,7 @@ const AccessibilityInfo = {
   /**
    * macOS only
    */
+  // [TODO(macOS GH#774)
   isHighContrastEnabled: function(): Promise<boolean> {
     if (Platform.OS === 'macos') {
       return new Promise((resolve, reject) => {
@@ -141,6 +142,7 @@ const AccessibilityInfo = {
       return Promise.resolve(false);
     }
   },
+  // ]TODO(macOS GH#774)
 
   /**
    * Query whether inverted colors are currently enabled.

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -77,9 +77,8 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo.html#isBoldTextEnabled
    */
   isBoldTextEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return Promise.resolve(false);
-    } else {
+    // [TODO(macOS GH#774) - rework logic to return Promise.resolve(false) on macOS
+    if (Platform.OS === 'ios') {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentBoldTextState(
@@ -90,7 +89,10 @@ const AccessibilityInfo = {
           reject(null);
         }
       });
+    } else {
+      return Promise.resolve(false);
     }
+    // ]TODO(macOS GH#774)
   },
 
   /**
@@ -102,9 +104,8 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo.html#isGrayscaleEnabled
    */
   isGrayscaleEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return Promise.resolve(false);
-    } else {
+    // [TODO(macOS GH#774) - rework logic to return Promise.resolve(false) on macOS
+    if (Platform.OS === 'ios') {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentGrayscaleState(
@@ -115,7 +116,10 @@ const AccessibilityInfo = {
           reject(null);
         }
       });
+    } else {
+      return Promise.resolve(false);
     }
+    // ]TODO(macOS GH#774)
   },
 
   /**
@@ -147,9 +151,8 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo.html#isInvertColorsEnabled
    */
   isInvertColorsEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return Promise.resolve(false);
-    } else {
+    // [TODO(macOS GH#774) - rework logic to return Promise.resolve(false) on macOS
+    if (Platform.OS === 'ios') {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentInvertColorsState(
@@ -160,7 +163,10 @@ const AccessibilityInfo = {
           reject(null);
         }
       });
+    } else {
+      return Promise.resolve(false);
     }
+    // ]TODO(macOS GH#774)
   },
 
   /**
@@ -201,9 +207,8 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo.html#isReduceTransparencyEnabled
    */
   isReduceTransparencyEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return Promise.resolve(false);
-    } else {
+    // [TODO(macOS GH#774) - rework logic to return Promise.resolve(false) on macOS
+    if (Platform.OS === 'ios') {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentReduceTransparencyState(
@@ -214,7 +219,10 @@ const AccessibilityInfo = {
           reject(null);
         }
       });
+    } else {
+      return Promise.resolve(false);
     }
+    // ]TODO(macOS GH#774)
   },
 
   /**


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Adjust the logic in AccessibilityInfo.js so it behaves nicely on macOS.

We received a bug report saying that trying to check for an iOS-only accessibility feature results in a rejected promise. It's much more elegant to just fulfill the promise and return `false`, just like we would do on Android.

Upstream, it doesn't matter whether we check for `Platform.OS === 'android'` or `Platform.OS === 'ios'`, since the platform is limited to these two options. But when we add a third platform into the mix, it makes things more complicated. This is something we could theoretically push upstream.

While we're here, we might as well add macOS tags to `isHighContrastEnabled`, a macOS-only accessibility feature.

## Changelog

[macOS] [Fix] - Improve macOS logic for iOS-only accessibility features
