### PR TITLE
AB#5902056 - Upgrade hermes to 0.11 for Android only

### DIFF
--- a/.ado/templates/apple-droid-node-patching.yml
+++ b/.ado/templates/apple-droid-node-patching.yml
@@ -5,4 +5,4 @@ steps:
   - task: CmdLine@2
     displayName: Apply Android specific patches for Office consumption
     inputs:
-      script: npm_config_yes=true npx @rnx-kit/draft-patch-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor JniUtils RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}
+      script: npm_config_yes=true npx @rnx-kit/draft-patch-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC ImageColor JniUtils RootViewAttach Hermes --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}

--- a/android-patches/patches/Hermes/package.json
+++ b/android-patches/patches/Hermes/package.json
@@ -1,0 +1,20 @@
+diff --git a/package.json b/package.json
+index 6fc4c801f1..3ad2acfd1c 100644
+--- a/package.json
++++ b/package.json
+@@ -106,7 +106,7 @@
+     "anser": "^1.4.9",
+     "base64-js": "^1.1.2",
+     "event-target-shim": "^5.0.1",
+-    "hermes-engine": "~0.9.0",
++    "hermes-engine": "~0.11.0",
+     "invariant": "^2.2.4",
+     "jsc-android": "^250230.2.1",
+     "metro-babel-register": "0.66.2",
+@@ -211,4 +211,4 @@
+   "beachball": {
+     "shouldPublish": false
+   }
+-}
+\ No newline at end of file
++}

--- a/android-patches/patches/Hermes/yarn.lock
+++ b/android-patches/patches/Hermes/yarn.lock
@@ -1,0 +1,19 @@
+diff --git a/yarn.lock b/yarn.lock
+index 7342133570..6bf71f3051 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -4324,10 +4324,10 @@ has@^1.0.3:
+   dependencies:
+     function-bind "^1.1.1"
+ 
+-hermes-engine@~0.9.0:
+-  version "0.9.0"
+-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.9.0.tgz#84d9cfe84e8f6b1b2020d6e71b350cec84ed982f"
+-  integrity sha512-r7U+Y4P2Qg/igFVZN+DpT7JFfXUn1MM4dFne8aW+cCrF6RRymof+VqrUHs1kl07j8h8V2CNesU19RKgWbr3qPw==
++hermes-engine@~0.11.0:
++  version "0.11.0"
++  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.11.0.tgz#bb224730d230a02a5af02c4e090d1f52d57dd3db"
++  integrity sha512-7aMUlZja2IyLYAcZ69NBnwJAR5ZOYlSllj0oMpx08a8HzxHOys0eKCzfphrf6D0vX1JGO1QQvVsQKe6TkYherw==
+ 
+ hermes-parser@0.4.7:
+   version "0.4.7"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In order to consume Hermes in Office for Android, we need a fix that made it into version 0.10. Due to an issue in 0.10, we decided to bump to 0.11 as there wouldn't be any breaking API changes. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Added] - Upgrade Hermes to 0.11 for android only via a patch

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Tested via the Hermes variant of RN tester.
