### PR TITLE
Backport - Ignore android-patches directory for jest, metro and flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,6 +19,9 @@
 ; Flow doesn't support platforms
 .*/Libraries/Utilities/LoadingView.js
 
+; Ignore everything in android-patches
+<PROJECT_ROOT>/android-patches/.*
+
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
 

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -19,6 +19,9 @@
 ; Flow doesn't support platforms
 .*/Libraries/Utilities/LoadingView.js
 
+; Ignore everything in android-patches
+<PROJECT_ROOT>/android-patches/.*
+
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
 

--- a/.flowconfig.macos
+++ b/.flowconfig.macos
@@ -19,6 +19,9 @@
 ; Flow doesn't support platforms
 .*/Libraries/Utilities/LoadingView.js
 
+; Ignore everything in android-patches
+<PROJECT_ROOT>/android-patches/.*
+
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
     '<rootDir>/template',
     'Libraries/Renderer',
     'packages/rn-tester/e2e',
+    'android-patches',
   ],
   transformIgnorePatterns: ['node_modules/(?!@react-native/)'],
   haste: {
@@ -48,5 +49,7 @@ module.exports = {
     '/__tests__/',
     '/vendor/',
     '<rootDir>/Libraries/react-native/',
+    'android-patches',
   ],
+  modulePathIgnorePatterns: ['android-patches'],
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -25,6 +25,7 @@ const config = {
     extraNodeModules: {
       'react-native': __dirname,
     },
+    blacklistRE: [/android-patches\/.*/],
   },
   transformer: {},
 };


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The `android-patches` directory contains patches where the patch files is named as the same as the file that will be patched. This causes issues when trying to patch `package.json`, as various tools try to operate on any file that is named `package.json` unless explicitly ignored.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Ignore `android-patches` directory for `jest`, `metro` and `flow`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Ensuring all PR checks succeed is sufficient.