### PR TITLE
[64] RCTShadowView: use 1x alignment (#1015)

### DIFF
--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -52,7 +52,7 @@ typedef NS_ENUM(unsigned int, meta_prop_t) {
 #if !TARGET_OS_OSX // [TODO(macOS GH#774)
     float pixelsInPoint = RCTScreenScale();
 #else
-    float pixelsInPoint = 0; // TODO(ISS#1656079): Turn off pixel rounding for macOS until we can get screen resolution passed here
+    float pixelsInPoint = 1; // TODO(ISS#1656079): Use 1x alignment for macOS until we can use backing resolution
 #endif // ]TODO(macOS GH#774)
     YGConfigSetPointScaleFactor(yogaConfig, pixelsInPoint);
     YGConfigSetUseLegacyStretchBehaviour(yogaConfig, true);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

`git cherry-pick 1a2b7fe2ea701ad5ea3e7788c19efdf3ad56d284`

Passing 0 to `YGConfigSetPointScaleFactor()` turns off layout rounding 
entirely, which makes things look blurry.  While it would be nice to 
use the backing scale factor of the window, that would be a very 
involved change.  Instead, hardcode 1x alignment.  On 2x displays, this 
just means that views cannot sit on half-point boundaries.  (They're 
still *rendered* at 2x, though.)

## Changelog

[macOS] [Bug] - Retina scaling fix

## Test Plan

Tested in main