### PR TITLE
fix(ci): change "React-Native GitHub Publish to Office" to only run on stable branches, not main

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -33,7 +33,7 @@ jobs:
         value: true
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-    dependsOn: 
+    dependsOn:
       - Compliance
     steps:
       - checkout: self # self represents the repo where the initial Pipelines YAML file was found
@@ -130,7 +130,7 @@ jobs:
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     condition: eq(variables['Build.SourceBranchName'], 'main')
-    dependsOn: 
+    dependsOn:
       - Compliance
     steps:
       - checkout: self # self represents the repo where the initial Pipelines YAML file was found
@@ -184,7 +184,8 @@ jobs:
     pool: Azure-Pipelines-EO-Ubuntu20.04-Office
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-    dependsOn: 
+    condition: eq(contains(variables['Build.SourceBranchName'], '-stable'))
+    dependsOn:
       - Compliance
     steps:
       - checkout: self # self represents the repo where the initial Pipelines YAML file was found


### PR DESCRIPTION
<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

On main branch https://github.com/microsoft/react-native-macos/commits/main , there's a job that always fails CI `microsoft.react-native-macos` on ADO. This is because it fails on `React-Native GitHub Publish to Office` on the task `Bump package version`. This happens because by definition, this task is only meant to run *not* on main:
<img width="502" alt="Screenshot 2022-03-28 at 15 22 17" src="https://user-images.githubusercontent.com/16104054/160419396-aca11187-401b-4d24-8749-976366caa782.png">

This error is caused by `scripts/bump-oss-version.js` at L86->89

So basically we have a failing CI on main branch that is meant to be red by definition because it's main branch.
To address this, it sounds like it'd be just easier to prevent this entire job from running (and saving CI resources) by adding a filter to only run on `-stable` branches. I discussed this option with @acoates-ms and he gave me the 👍 since it's only for the RN publish to office so it's not affecting `react-native-macos`'s releases.

## Test Plan

There's not really an easy way to test the specific line, but given how other jobs have similar conditions (see for example `RNMacOSInitNpmJSPublish` I think we can merge and verify its correctness).