### PR TITLE
chore: Use node 14 for Apple test loops

### DIFF
--- a/.ado/templates/apple-node-setup.yml
+++ b/.ado/templates/apple-node-setup.yml
@@ -9,5 +9,5 @@ steps:
   - script: sudo chown -R $(whoami) /usr/local/*
     displayName: 'fix node permissions'
 
-  - script: brew link node@12 --overwrite --force
-    displayName: 'ensure node 12'
+  - script: brew link node@14 --overwrite --force
+    displayName: 'ensure node 14'


### PR DESCRIPTION
## Summary

Our "Verify react-native-macos-init" loop is failing in 0.66-stable because the latest version of react-native, 0.68, requires a minimum Node version of 14.

The main branch currently uses Node v16, but I figure that only upgrading to 14 is a more minimal change that should get everything working. 

## Test Plan

If the CI passes, we know it works :-)