### PR TITLE
Add nil checks to `+[RCTInspectorDevServerHelper connectWithBundleURL:]`

### DIFF
--- a/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -110,9 +110,21 @@ static void sendEventToAllConnections(NSString *event)
   }
 
   NSString *key = [inspectorURL absoluteString];
+  // [TODO(macOS GH#774) - safety check to avoid a crash
+  if (key == nil) {
+    RCTLogError(@"failed to get inspector URL");
+    return nil;
+  }
+  // ]TODO(macOS GH#774)
   RCTInspectorPackagerConnection *connection = socketConnections[key];
   if (!connection || !connection.isConnected) {
     connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];
+    // [TODO(macOS GH#774) - safety check to avoid a crash
+    if (connection == nil) {
+      RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
+      return nil;
+    }
+    // ]TODO(macOS GH#774)
     socketConnections[key] = connection;
     [connection connect];
   }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

We saw a downstream ASan crash in `+[RCTInspectorDevServerHelper connectWithBundleURL:]`.

It's not clear exactly what's causing the crash, but the stack trace includes a reference to `-[__NSDictionaryM setObject:forKeyedSubscript:]` along with the message "Hint: address points to the zero page." Since `NSDictionary` is known to misbehave when we try passing in `nil` as a key or value, one easy fix we can do is to add some `nil` checks and bail out in case we're about to do something sketchy.

## Changelog

[Internal] [Fix] - bug fixes
