### PR TITLE
bump Node references from 12/14 to 14/16 (#32980)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ jobs:
       - run:
           name: Configure Environment Variables
           command: |
-            echo 'export PATH=/usr/local/opt/node@12/bin:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/local/opt/node@16/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
 
       - with_brew_cache_span:
@@ -406,6 +406,12 @@ jobs:
                 command: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
             - brew_install:
                 package: applesimutils
+
+      - run:
+          name: Configure Node
+          # Sourcing find-node.sh will ensure nvm is set up.
+          # It also helps future invocation of find-node.sh prevent permission issue with nvm.sh.
+          command: source scripts/find-node.sh && nvm install 16 && nvm alias default 16
 
       - run:
           name: Configure Watchman
@@ -622,8 +628,8 @@ jobs:
           name: Install Node
           # Note: Version set separately for non-Windows builds, see above.
           command: |
-            nvm install 14.17.0
-            nvm use 14.17.0
+            nvm install 16
+            nvm use 16
 
       # Setup Dependencies
       - run:

--- a/scripts/validate-ios-test-env.sh
+++ b/scripts/validate-ios-test-env.sh
@@ -23,7 +23,7 @@ fi
 # Check that the correct version of node is installed
 NODE_VERSION="$(command node --version | sed 's/[-/a-zA-Z]//g' |sed 's/.\{2\}$//')"
 
-if (( $(echo "${NODE_VERSION} < 12.0" | bc -l) )); then
+if (( $(echo "${NODE_VERSION} < 14.0" | bc -l) )); then
   echo "Node ${NODE_VERSION} detected. This version of Node is not supported."
   echo "See https://reactnative.dev/docs/getting-started.html for instructions."
   exit 1


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry-pick of f1488db109d13e748b071c02b40e90cdca1cc79d into microsoft/react-native-macos. Note that package.json was already updated with 26a7c3e9d430ebb58b9c9e2aa220fe9019ae1e1f.

# Original commit

Summary:
Node 16 has been the LTS for quite some time now ([Oct 2021](https://nodejs.org/en/blog/release/v16.13.0/)), so this PR just wants to bring the RN OSS CI up to speed.

(I realized that this was needed while doing the same for macos https://github.com/microsoft/react-native-macos/pull/997)

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - CI moved to Node 16.

Pull Request resolved: https://github.com/facebook/react-native/pull/32980

Test Plan: CI itself is the test � locally no significant changes were experienced.

Reviewed By: cortinico

Differential Revision: D33821288

Pulled By: ShikaSD

fbshipit-source-id: 4480ae1cb909e2b8d0b6abba4db76bbe71f0193e