### PR TITLE
[0.66-stable] Add nil checks to `+[RCTInspectorDevServerHelper connectWithBundleURL:]`, and bump Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ jobs:
       - run:
           name: Configure Environment Variables
           command: |
-            echo 'export PATH=/usr/local/opt/node@12/bin:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/local/opt/node@16/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
 
       - with_brew_cache_span:
@@ -406,6 +406,12 @@ jobs:
                 command: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
             - brew_install:
                 package: applesimutils
+
+      - run:
+          name: Configure Node
+          # Sourcing find-node.sh will ensure nvm is set up.
+          # It also helps future invocation of find-node.sh prevent permission issue with nvm.sh.
+          command: source scripts/find-node.sh && nvm install 16 && nvm alias default 16
 
       - run:
           name: Configure Watchman
@@ -622,8 +628,8 @@ jobs:
           name: Install Node
           # Note: Version set separately for non-Windows builds, see above.
           command: |
-            nvm install 14.17.0
-            nvm use 14.17.0
+            nvm install 16
+            nvm use 16
 
       # Setup Dependencies
       - run:

--- a/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -110,9 +110,21 @@ static void sendEventToAllConnections(NSString *event)
   }
 
   NSString *key = [inspectorURL absoluteString];
+  // [TODO(macOS GH#774) - safety check to avoid a crash
+  if (key == nil) {
+    RCTLogError(@"failed to get inspector URL");
+    return nil;
+  }
+  // ]TODO(macOS GH#774)
   RCTInspectorPackagerConnection *connection = socketConnections[key];
   if (!connection || !connection.isConnected) {
     connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];
+    // [TODO(macOS GH#774) - safety check to avoid a crash
+    if (connection == nil) {
+      RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
+      return nil;
+    }
+    // ]TODO(macOS GH#774)
     socketConnections[key] = connection;
     [connection connect];
   }

--- a/scripts/validate-ios-test-env.sh
+++ b/scripts/validate-ios-test-env.sh
@@ -23,7 +23,7 @@ fi
 # Check that the correct version of node is installed
 NODE_VERSION="$(command node --version | sed 's/[-/a-zA-Z]//g' |sed 's/.\{2\}$//')"
 
-if (( $(echo "${NODE_VERSION} < 12.0" | bc -l) )); then
+if (( $(echo "${NODE_VERSION} < 14.0" | bc -l) )); then
   echo "Node ${NODE_VERSION} detected. This version of Node is not supported."
   echo "See https://reactnative.dev/docs/getting-started.html for instructions."
   exit 1


### PR DESCRIPTION
Cherry-pick of the commits in #1124 and #1125.