### PR TITLE
Adding auto retry of Apple tests

### DIFF
--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -59,6 +59,7 @@ steps:
       xcode_actions: ${{ parameters.xcode_actions_debug }}
       xcode_useXcpretty: true
       xcode_destination: ${{ parameters.xcode_destination }}
+      xcode_extraArgs: -retry-tests-on-failure -test-iterations 2
 
   - template: apple-xcode-build.yml
     parameters:


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Apple tests are currently flakey, which leads to PR checks failing often. Ideally, these tests are fixed up to be more robust, but in the interim, adding a retry on failure will help with engineering velocity.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Added] - Adding retry of Apple tests in PR pipeline.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Will rely on running the pipeline from this PR.
