### PR TITLE
Add debug logging to -[RCTSRWebSocket _connect]

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -540,9 +540,32 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     // ]TODO(macOS ISS#2323203)
   }
 
+  // [TODO(macOS GH#774)
+  // We've seen a rare ASan crash where _inputStream seems to be invalid. This is just a safety check.
+#if DEBUG
+  [self _validateStream:_outputStream name:@"_outputStream"];
+  [self _validateStream:_inputStream name:@"_inputStream"];
+#endif
+  // ]TODO(macOS GH#774)
+
   [_outputStream open];
   [_inputStream open];
 }
+
+// [TODO(macOS GH#774)
+#if DEBUG
+- (void)_validateStream:(NSStream *)stream name:(NSString *)name {
+  NSStreamStatus status = stream.streamStatus;
+  if (status != NSStreamStatusNotOpen) {
+    RCTLogWarn(@"%@ was already opened, why are we opening it again? status=%@", name, @(status));
+  }
+
+  if (stream.delegate == nil) {
+    RCTLogError(@"%@'s delegate is nil, did we clean it up too early?", name);
+  }
+}
+#endif
+// ]TODO(macOS GH#774)
 
 - (void)scheduleInRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

We've gotten reports of an uncommon crash in `RCTSRWebSocket`. While we're not sure what exactly is causing it, we can at least add some logging to help better see when certain problems might come up.

## Changelog

[Internal]

## Validation

RNTester still compiles on macOS and iOS.