### PR TITLE
macos: Add support for deeplink initial URL

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -16,6 +16,7 @@
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
 + (void)getUrlEventHandler:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
 + (void)setAlwaysForegroundLastWindow:(BOOL)alwaysForeground;
++ (void)setInitialUrl:(NSURL *)url;
 #else // ]TODO(macOS GH#774)
 + (BOOL)application:(nonnull UIApplication *)app
             openURL:(nonnull NSURL *)URL

--- a/Libraries/LinkingIOS/macos/RCTLinkingManager.mm
+++ b/Libraries/LinkingIOS/macos/RCTLinkingManager.mm
@@ -19,7 +19,7 @@
 
 NSString *const RCTOpenURLNotification = @"RCTOpenURLNotification";
 
-static NSString *initialURL = nil;
+static NSURL *initialURL = nil;
 static BOOL moduleInitalized = NO;
 static BOOL alwaysForegroundLastWindow = YES;
 
@@ -71,13 +71,14 @@ RCT_EXPORT_MODULE()
     // extract url value from the event
     NSString* url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
 
-    // If the application was launched via URL, this handler will be called before
-    // the module is initialized by the bridge. Store the initial URL, becase we are not listening to the notification yet.
-    if (!moduleInitalized && initialURL == nil) {
-        initialURL = url;
-    }
-
     postNotificationWithURL(url, self);
+}
+
++ (void)setInitialUrl:(NSURL *)url
+{
+    // If the application was launched via URL, the app wouldn't have started listening for URLs yet.
+    // So we instead store the URL to be retrieved by getInitialURL.
+    initialURL = url;
 }
 
 - (void)handleOpenURLNotification:(NSNotification *)notification
@@ -114,7 +115,7 @@ RCT_EXPORT_METHOD(canOpenURL:(NSURL *)URL
 RCT_EXPORT_METHOD(getInitialURL:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)
 {
-    resolve(RCTNullIfNil(initialURL));
+    resolve(RCTNullIfNil(initialURL.absoluteString));
 }
 @end
 

--- a/local-cli/generator-macos/templates/macos/HelloWorld-macOS/AppDelegate.m
+++ b/local-cli/generator-macos/templates/macos/HelloWorld-macOS/AppDelegate.m
@@ -2,6 +2,7 @@
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTLinkingManager.h>
 
 @interface AppDelegate () <RCTBridgeDelegate>
 
@@ -15,8 +16,21 @@
   _bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:nil];
 }
 
+- (void)application:(NSApplication *)application openURLs:(NSArray<NSURL *> *)urls {
+  [RCTLinkingManager setInitialUrl:urls[0]];
+}
+
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+  [[NSAppleEventManager sharedAppleEventManager]
+   setEventHandler:self
+   andSelector:@selector(getURL:withReplyEvent:)
+   forEventClass:kInternetEventClass andEventID:kAEGetURL
+  ];
   // Insert code here to initialize your application
+}
+
+- (void)getURL:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)reply {
+  [RCTLinkingManager getUrlEventHandler:event withReplyEvent:reply];
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {


### PR DESCRIPTION
Hi.
Currently it seems to be very convoluted (if not impossible) to get initial deeplink url to work.
This is because of interfaces differences between when the macOS app is started together with an URL and when an URL is passed to it when it has already been started.

To address this, this PR adds a new function to `RCTLinkingManager` called `setInitialURL` which is supposed to work together with  react-native's `getInitialURL`.

The standard template has also been updated with deeplink support so one doesn't have to figure out how it should be accomplished (the way to do it differs heavily from iOS).

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - `Linking.getInitialURL` support 

Fixes #1128