### PR TITLE
cherry-pick: Remove setting an extra index as it is a substitution attack vulnerab…

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -57,7 +57,6 @@ jobs:
         displayName: 'Pip Authenticate to react-native-public'
         inputs:
           artifactFeeds: 'react-native/react-native-public'
-          onlyAddExtraIndex: true
 
       # Verify depenendencies can be enumerated and downloaded ..
       - task: CmdLine@2


### PR DESCRIPTION
…ility

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Using an extra index for python packages is a security vulnerability. As a result we need to remove this flag and rely on the stream to PyPI to pull in any additional packages (which isn't needed for the time being).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Remove security vulnerability

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
PR build succeeded should be sufficient. Will cherry-pick to main after confirming the issue gets resolved.
