### PR TITLE
Factor out dependency download task so it can be shared across pipelines

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -51,16 +51,7 @@ jobs:
 
       - template: templates/prep-android-nuget.yml
 
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate to react-native-public'
-        inputs:
-          artifactFeeds: 'react-native/react-native-public'
-
-      # Verify depenendencies can be enumerated and downloaded ..
-      - task: CmdLine@2
-        displayName: 'Verify Dependencies can be enumerated'
-        inputs:
-          script: pip3 install maven-dependency-utils && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android
+      - template: templates/download-android-dependencies.yml
 
       # Very similar to the default pack task .. but appends 'ndk21' to the nuget pack version
       - task: CmdLine@2

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -217,14 +217,9 @@ jobs:
         inputs:
           script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
 
-      - template: templates\prep-android-nuget.yml
+      - template: templates/prep-android-nuget.yml
 
-      # Enumerate and download all dependencies ..
-      - task: CmdLine@2
-        displayName: 'Verify Dependencies can be enumerated [test]'
-        inputs:
-          script: sudo apt-get install python3-pip && sudo apt-get install python3-setuptools && pip3 install BeautifulSoup4 && pip3 install wheel && pip3 install wget && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android
-
+      - template: templates/download-android-dependencies.yml
 
       # Very similar to the default pack task .. but appends 'ndk21b' to the nuget pack version
       - task: CmdLine@2

--- a/.ado/templates/download-android-dependencies.yml
+++ b/.ado/templates/download-android-dependencies.yml
@@ -1,0 +1,11 @@
+steps:
+  - task: PipAuthenticate@1
+    displayName: 'Pip Authenticate to react-native-public'
+    inputs:
+      artifactFeeds: 'react-native/react-native-public'
+
+  # Verify depenendencies can be enumerated and downloaded ..
+  - task: CmdLine@2
+    displayName: 'Verify Dependencies can be enumerated'
+    inputs:
+      script: pip3 install maven-dependency-utils && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We have a publish pipeline on stable branches that I was unaware of, which had yaml duplicated. As a result, the publish pipeline is now failing after making changes to the download android dependencies task

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Factor out download android dependencies into a template

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

PR pipeline succeeding and publish pipeline succeed will indicate success.
