### PR TITLE
[Cherry-pick] Hardcoding the version of maven-dependency-utils to avoid accidental regression

### DIFF
--- a/.ado/templates/download-android-dependencies.yml
+++ b/.ado/templates/download-android-dependencies.yml
@@ -11,4 +11,4 @@ steps:
   - task: CmdLine@2
     displayName: 'Verify Dependencies can be enumerated'
     inputs:
-      script: pip3 install maven-dependency-utils && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android
+      script: pip3 install maven-dependency-utils==1.15.0 && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android


### PR DESCRIPTION
Cherry-picking the change from main. Hardcoding the version of maven-dependency-utils to avoid accidental regression
 
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Hardcoding the version of maven-dependency-utils to avoid accidental regression

## Changelog

Hardcoding the version of maven-dependency-utils to avoid accidental regression

[CATEGORY] [TYPE] - Message

## Test Plan
Verified builds
