### PR TITLE
Update maven-dependency-utils to 1.17.0 and use new flags

### DIFF
--- a/.ado/downloadAndroidDependencies.py
+++ b/.ado/downloadAndroidDependencies.py
@@ -164,7 +164,7 @@ def main():
 
     # Download a transitive dependency closure of the ReactAndroid project
     dependencies = get_dependencies(react_native_dir);
-    maven_dependency_utils.download_transitive_closure(dependencies, dependency_dir_maven, 'gradlew')
+    maven_dependency_utils.download_transitive_closure(artifacts=dependencies, output_directory_path=dependency_dir_maven, gradle_path='gradlew', ignore_metadata_redirection=True, resolve_to_single_version=False)
 
     # Extract the native libraries from maven packages
     extract_sos(dependency_dir_maven, dependency_dir_native)

--- a/.ado/templates/download-android-dependencies.yml
+++ b/.ado/templates/download-android-dependencies.yml
@@ -11,4 +11,4 @@ steps:
   - task: CmdLine@2
     displayName: 'Verify Dependencies can be enumerated'
     inputs:
-      script: pip3 install maven-dependency-utils==1.15.0 && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android
+      script: pip3 install maven-dependency-utils==1.17.0 && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Square has incorrectly published their module metadata for okio 2.9.0 which leads to pulling the wrong artifact. To get around this we need it ignore grade's metadata redirection annotations in the pom file. Furthermore, for office consumption, we need to avoid resolving all dependencies to a single version, in order to build libraries. This change updates maven-dependency-utils to a version that supports both features and updates the consumption here to make use of them.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Update maven-dependency-utils

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
PR succeeds