### PR TITLE
Readd test_docker to .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,23 @@ jobs:
           command: cd template/android/ && ./gradlew assembleDebug
 
   # -------------------------
+  #    JOBS: Test Docker
+  # -------------------------
+  test_docker:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Build Docker container for Android RNTester App
+          command: |
+            source ~/.bashrc
+            nvm i node
+            npm i -g yarn
+            echo y | npx envinfo@latest
+            yarn run docker-setup-android
+            yarn run docker-build-android
+
+  # -------------------------
   #    JOBS: Windows
   # -------------------------
   test_windows:


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

We're seeing some dependabot PR failures (#1167 and #1169) due to a missing job definition, so let's reintroduce that definition to make everyone happy.