### PR TITLE
Fix for appearance not working properly on a corner case

### DIFF
--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -112,7 +112,7 @@ RCT_EXPORT_MODULE(Appearance)
   return std::make_shared<NativeAppearanceSpecJSI>(params);
 }
 
-#if TARGET_OS_OSX // [TODO(macOS GH#774): on macOS don't lazy init _currentColorScheme because [NSAppearance currentAppearance] cannot be executed on background thread.
+#if TARGET_OS_OSX // [TODO(macOS GH#774): on macOS don't lazy init _currentColorScheme because [NSApp effectiveAppearance] cannot be executed on background thread.
 - (instancetype)init
 {
   if (self = [super init]) {

--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -81,11 +81,8 @@ NSString *RCTColorSchemePreference(NSAppearance *appearance)
     return RCTAppearanceColorSchemeLight;
   }
 
-	if (@available(macOS 11.0, *)) {
-		appearance = appearance ?: [NSAppearance currentDrawingAppearance];
-	} else {
-		appearance = appearance ?: [NSAppearance currentAppearance];
-	}
+  appearance = appearance ?: [NSApp effectiveAppearance];
+
   NSAppearanceName appearanceName = [appearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
   return appearances[appearanceName] ?: RCTAppearanceColorSchemeLight;
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Steps to repro the bug in RNTester:

1. Boot RNTester and navigate to the Appearance Test page under APIs
2. Switch appearance (opposite to the current appearance)
3. Reload window

![image](https://user-images.githubusercontent.com/67026167/169409434-7497ed76-1a87-412a-b299-d3176f2467ef.png)

In the screenshot above, you can see that the UI elements are shown in light mode in spite of the window background is apparently in dark mode. Before this change, we initialize currentColorScheme by calling currentDrawingAppearnace, which describes the current drawing from a view. My speculation is that since JS caches the layout of the UI elements, when the window gets reloaded nothing is being drawn hence the confusion. The fix is to use the shared instance to make appearance API calls.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Use the application instance to make appearance API calls

## Test Plan
Tested the repro steps in RNTester and ensured the bug no longer repros. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
