### PR TITLE
[0.66-stable] feat: pruning unused methods from shared libraries

### DIFF
--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/Android.mk
@@ -1,0 +1,13 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/Android.mk
+index 651168243e..369b6414ae 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/Android.mk
+@@ -12,6 +12,8 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_MODULE := jsijniprofiler
+ 
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections
++
+ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+ 
+ LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(call find-node-module,$(LOCAL_PATH),hermes-engine)/android/include

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
@@ -1,0 +1,22 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
+index 7716394c31..2815b73724 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
+@@ -15,6 +15,8 @@ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+ 
+ LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(call find-node-module,$(LOCAL_PATH),hermes-engine)/android/include
+ 
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections
++
+ LOCAL_CPP_FEATURES := exceptions
+ 
+ LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-release
+@@ -32,6 +34,8 @@ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+ 
+ LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(call find-node-module,$(LOCAL_PATH),hermes-engine)/android/include
+ 
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections
++
+ LOCAL_CPP_FEATURES := exceptions
+ 
+ LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-debug libhermes-inspector

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/Android.mk
@@ -1,0 +1,13 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/Android.mk
+index f29eb0137c..c4fc9732ea 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/Android.mk
+@@ -22,7 +22,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/
+ LOCAL_CFLAGS := \
+   -DLOG_TAG=\"Fabric\"
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -std=c++17 -Wall
+ 
+ include $(BUILD_SHARED_LIBRARY)
+ 

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/react/common/mapbuffer/ReadableMapBuffer.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/react/common/mapbuffer/ReadableMapBuffer.h
@@ -1,0 +1,24 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/react/common/mapbuffer/ReadableMapBuffer.h b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/react/common/mapbuffer/ReadableMapBuffer.h
+index b3f753a67b..60382c9501 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/react/common/mapbuffer/ReadableMapBuffer.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/jni/react/common/mapbuffer/ReadableMapBuffer.h
+@@ -13,6 +13,10 @@
+ 
+ #include <fbjni/ByteBuffer.h>
+ 
++#ifndef RN_EXPORT
++#define RN_EXPORT __attribute__((visibility("default")))
++#endif
++
+ namespace facebook {
+ namespace react {
+ 
+@@ -23,7 +27,7 @@ class ReadableMapBuffer : public jni::HybridClass<ReadableMapBuffer> {
+ 
+   static void registerNatives();
+ 
+-  static jni::local_ref<jhybridobject> createWithContents(MapBuffer &&map);
++  RN_EXPORT static jni::local_ref<jhybridobject> createWithContents(MapBuffer &&map);
+ 
+   jni::local_ref<jni::JByteBuffer> importByteBufferAllocateDirect();
+ 

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
@@ -1,0 +1,13 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
+index 253cdb24bb..04cec34bc4 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
+@@ -22,7 +22,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/
+ LOCAL_CFLAGS := \
+   -DLOG_TAG=\"Fabric\"
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -std=c++17 -Wall
+ 
+ include $(BUILD_SHARED_LIBRARY)
+ 

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/Android.mk
@@ -1,0 +1,14 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/Android.mk
+index 19a28eee5a..19141aba7d 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/Android.mk
+@@ -13,8 +13,7 @@ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+ 
+ LOCAL_C_INCLUDES := $(LOCAL_PATH)
+ 
+-LOCAL_CFLAGS += -fvisibility=hidden -fexceptions -frtti
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti
+ LOCAL_STATIC_LIBRARIES :=  libjsireact jscruntime
+ LOCAL_SHARED_LIBRARIES := libfolly_json libfb libfbjni libreactnativejni libjsi
+ 

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk
@@ -1,0 +1,14 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk
+index 6c5a7224c7..dbd54e8b08 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk
+@@ -13,8 +13,7 @@ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+ 
+ LOCAL_C_INCLUDES := $(LOCAL_PATH)
+ 
+-LOCAL_CFLAGS += -fvisibility=hidden -fexceptions -frtti
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti
+ LOCAL_STATIC_LIBRARIES :=  libjsireact
+ LOCAL_SHARED_LIBRARIES := libfolly_json libfb libfbjni libreactnativejni libjsi
+ 

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/jni/Android.mk
@@ -1,0 +1,14 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/jni/Android.mk
+index fd0ff0d7fd..7a83b3a80f 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/jni/Android.mk
+@@ -13,8 +13,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/reactperflogger
+ # Header search path for modules that depend on this module
+ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -std=c++17 -Wall
+ LOCAL_LDLIBS += -landroid
+ 
+ LOCAL_STATIC_LIBRARIES = libreactperflogger

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/runtimescheduler/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/runtimescheduler/jni/Android.mk
@@ -1,0 +1,14 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/runtimescheduler/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/runtimescheduler/jni/Android.mk
+index bb4e320112..56c47819e8 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/runtimescheduler/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/runtimescheduler/jni/Android.mk
+@@ -22,8 +22,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/
+ LOCAL_CFLAGS := \
+   -DLOG_TAG=\"ReacTNative\"
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -std=c++17 -Wall
+ include $(BUILD_SHARED_LIBRARY)
+ 
+ $(call import-module,fbgloginit)

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
@@ -1,0 +1,14 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
+index 758713238e..d957bfe1aa 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
+@@ -48,8 +48,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/ReactCommon
+ # Header search path for modules that depend on this module
+ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -std=c++17 -Wall
+ LOCAL_SHARED_LIBRARIES = libfb libfbjni libreact_nativemodule_core
+ 
+ LOCAL_STATIC_LIBRARIES = libcallinvokerholder libreactperfloggerjni

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/uimanager/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/uimanager/jni/Android.mk
@@ -1,0 +1,14 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/uimanager/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/uimanager/jni/Android.mk
+index a4085b466b..392d4fcefc 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/uimanager/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/uimanager/jni/Android.mk
+@@ -22,8 +22,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/
+ LOCAL_CFLAGS := \
+   -DLOG_TAG=\"ReacTNative\"
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -std=c++17 -Wall
+ include $(BUILD_SHARED_LIBRARY)
+ 
+ $(call import-module,fbgloginit)

--- a/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
@@ -1,0 +1,13 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
+index 8e28a3ddfd..0110af1d2a 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
+@@ -13,7 +13,7 @@ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+ 
+ LOCAL_C_INCLUDES := $(LOCAL_PATH) $(THIRD_PARTY_NDK_DIR)/..
+ 
+-LOCAL_CFLAGS += -fvisibility=hidden -fexceptions -frtti
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti
+ 
+ LOCAL_STATIC_LIBRARIES := libjsi libjsireact
+ LOCAL_SHARED_LIBRARIES := libfolly_json libfb libfbjni libreactnativejni v8jsi

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -1,0 +1,24 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/Android.mk b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/Android.mk
+index 17eb40f3a0..722af07f44 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/Android.mk
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/Android.mk
+@@ -22,8 +22,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)
+ #   ./../ == react
+ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../..
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -Wno-unused-lambda-capture
+ LOCAL_LDLIBS += -landroid
+ 
+ # The dynamic libraries (.so files) that this module depends on.
+@@ -72,8 +71,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)
+ #   ./../ == react
+ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../..
+ 
+-LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
+-
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti -Wno-unused-lambda-capture
+ LOCAL_LDLIBS += -landroid
+ 
+ # The dynamic libraries (.so files) that this module depends on.

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.h
@@ -1,0 +1,24 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.h b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.h
+index ef76632dfa..519a1cd2d9 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.h
+@@ -12,6 +12,10 @@
+ #include <cxxreact/MessageQueueThread.h>
+ #include <fbjni/fbjni.h>
+ 
++#ifndef RN_EXPORT
++#define RN_EXPORT __attribute__((visibility("default")))
++#endif
++
+ using namespace facebook::jni;
+ 
+ namespace facebook {
+@@ -23,7 +27,7 @@ class JavaMessageQueueThread : public jni::JavaClass<JavaMessageQueueThread> {
+       "Lcom/facebook/react/bridge/queue/MessageQueueThread;";
+ };
+ 
+-class JMessageQueueThread : public MessageQueueThread {
++class RN_EXPORT JMessageQueueThread : public MessageQueueThread {
+  public:
+   JMessageQueueThread(alias_ref<JavaMessageQueueThread::javaobject> jobj);
+ 

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
@@ -1,0 +1,24 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JReactMarker.h b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+index d495daf9ec..5da80bbc1d 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+@@ -12,6 +12,10 @@
+ 
+ #include <cxxreact/ReactMarker.h>
+ 
++#ifndef RN_EXPORT
++#define RN_EXPORT __attribute__((visibility("default")))
++#endif
++
+ namespace facebook {
+ namespace react {
+ 
+@@ -19,7 +23,7 @@ class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
+  public:
+   static constexpr auto kJavaDescriptor =
+       "Lcom/facebook/react/bridge/ReactMarker;";
+-  static void setLogPerfMarkerIfNeeded();
++  RN_EXPORT static void setLogPerfMarkerIfNeeded();
+ 
+  private:
+   static void logMarker(const std::string &marker);

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h
@@ -1,0 +1,24 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h
+index 1a250d7a86..dc678232e3 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h
+@@ -10,6 +10,10 @@
+ #include <ReactCommon/RuntimeExecutor.h>
+ #include <fbjni/fbjni.h>
+ 
++#ifndef RN_EXPORT
++#define RN_EXPORT __attribute__((visibility("default")))
++#endif
++
+ namespace facebook {
+ namespace react {
+ 
+@@ -18,7 +22,7 @@ class JRuntimeExecutor : public jni::HybridClass<JRuntimeExecutor> {
+   static auto constexpr kJavaDescriptor =
+       "Lcom/facebook/react/bridge/RuntimeExecutor;";
+ 
+-  RuntimeExecutor get();
++  RN_EXPORT RuntimeExecutor get();
+ 
+  private:
+   friend HybridBase;

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JSLogging.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/JSLogging.h
@@ -1,0 +1,24 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JSLogging.h b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JSLogging.h
+index 3d853200fb..d168ef3658 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/JSLogging.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/JSLogging.h
+@@ -10,13 +10,17 @@
+ #include <android/log.h>
+ #include <string>
+ 
++#ifndef RN_EXPORT
++#define RN_EXPORT __attribute__((visibility("default")))
++#endif
++
+ namespace facebook {
+ namespace react {
+ 
+-void reactAndroidLoggingHook(
++RN_EXPORT void reactAndroidLoggingHook(
+     const std::string &message,
+     android_LogPriority logLevel);
+-void reactAndroidLoggingHook(const std::string &message, unsigned int logLevel);
++RN_EXPORT void reactAndroidLoggingHook(const std::string &message, unsigned int logLevel);
+ 
+ } // namespace react
+ } // namespace facebook

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/NativeArray.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/NativeArray.h
@@ -1,0 +1,15 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeArray.h b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeArray.h
+index 8c7c879ac2..958f26f142 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeArray.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeArray.h
+@@ -12,6 +12,10 @@
+ 
+ #include "NativeCommon.h"
+ 
++#ifndef RN_EXPORT
++#define RN_EXPORT __attribute__((visibility("default")))
++#endif
++
+ namespace facebook {
+ namespace react {
+ 

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/NativeTime.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/NativeTime.h
@@ -1,0 +1,20 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeTime.h b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeTime.h
+index b4d028dd88..ce768cb7ec 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeTime.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/NativeTime.h
+@@ -7,10 +7,14 @@
+ 
+ #pragma once
+ 
++#ifndef RN_EXPORT
++#define RN_EXPORT __attribute__((visibility("default")))
++#endif
++
+ namespace facebook {
+ namespace react {
+ 
+-double reactAndroidNativePerformanceNowHook();
++RN_EXPORT double reactAndroidNativePerformanceNowHook();
+ 
+ } // namespace react
+ } // namespace facebook

--- a/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
+++ b/android-patches/patches/Build/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
@@ -1,0 +1,13 @@
+diff --git a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
+index 282082c39a..39ee6aa3ee 100644
+--- a/home/dev/rnm_clean_0.66/react-native-macos/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
++++ b/home/dev/react-native-macos/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
+@@ -39,7 +39,7 @@ struct ReadableNativeMap : jni::HybridClass<ReadableNativeMap, NativeMap> {
+   jni::local_ref<jni::JArrayClass<jobject>> importValues();
+   jni::local_ref<jni::JArrayClass<jobject>> importTypes();
+   folly::Optional<folly::dynamic> keys_;
+-  static jni::local_ref<jhybridobject> createWithContents(folly::dynamic &&map);
++  RN_EXPORT static jni::local_ref<jhybridobject> createWithContents(folly::dynamic &&map);
+ 
+   static void mapException(const std::exception &ex);
+ 

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/Android.mk
@@ -19,7 +19,7 @@ index 0000000000..8e28a3ddfd
 +
 +LOCAL_C_INCLUDES := $(LOCAL_PATH) $(THIRD_PARTY_NDK_DIR)/..
 +
-+LOCAL_CFLAGS += -fvisibility=hidden -fexceptions -frtti
++LOCAL_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -fexceptions -frtti
 +
 +LOCAL_STATIC_LIBRARIES := libjsi libjsireact
 +LOCAL_SHARED_LIBRARIES := libfolly_json libfb libfbjni libreactnativejni v8jsi

--- a/packages/rn-tester/android/app/src/main/jni/Android.mk
+++ b/packages/rn-tester/android/app/src/main/jni/Android.mk
@@ -22,5 +22,5 @@ LOCAL_SHARED_LIBRARIES := libfbjni libglog libfolly_json libyoga libreact_native
 LOCAL_STATIC_LIBRARIES := libsampleturbomodule
 LOCAL_CFLAGS := \
   -DLOG_TAG=\"ReactNative\"
-LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+LOCAL_CFLAGS += -fexceptions -fvisibility=hidden -ffunction-sections -fdata-sections -frtti -std=c++17 -Wall
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Many of the shared libraries built in RNM used in React Android export methods that are neither referenced nor linked to. This change sets the default visibility of the exported methods to hidden, and ensures that only the methods being referenced are public. 

Size improvements:

libmapbufferjni.so: -12 KB
libhermes-executor-release.so: -24 KB
libhermes-executor-debug.so: -24 KB
libturbomodulejsijni.so: -28 KB
librntester_appmodules.so: -56 KB
libreactnativeutilsjni.so: -204 KB
libreactnativejni.so: -204 KB
libfabricjni.so: -408 KB

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Pruned unused methods from shared libraries
