### PR TITLE
Update template bundler version to 2.3.14

### DIFF
--- a/template/Gemfile.lock
+++ b/template/Gemfile.lock
@@ -99,4 +99,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.29
+   2.3.14


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

This updates the `bundler` version in the template to its latest version as of now. The version previously recorded here has [a security vulnerability](https://security.snyk.io/vuln/SNYK-RUBY-BUNDLER-2313646), so this removes that.
