### PR TITLE
Add inline comments to suppress a security analysis (bandit) rule for…

### DIFF
--- a/Folly/build/fbcode_builder/utils.py
+++ b/Folly/build/fbcode_builder/utils.py
@@ -62,7 +62,11 @@ def read_fbcode_builder_config(filename):
     scope = {'read_fbcode_builder_config': _inner_read_config}
     with open(filename) as config_file:
         code = compile(config_file.read(), filename, mode='exec')
-    exec(code, scope)
+    # Exec is generally unsafe. See B102 (exec_used). https://bandit.readthedocs.io/en/latest/plugins/b102_exec_used.html
+    # This is not shipping code, but build code that is part of folly.
+    # After reviewing the code in tis repo, this is only called with config files that are part of this repo, 
+    # so no 3rd party code is evaluated.
+    exec(code, scope) # nosec
     return scope['config']
 
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

The release pipeline is running static analysis for Python scripts.
It is flagging exec as an unsafe api. After reviewing the code it is not shipped to customers, it is used as a build script and only evaluates files checked in the repo, so it is safe.
I therefore added the annotation # nosec and a comment that explains the justification.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Add suppression for Python static analysis security rule.

## Test Plan

N/A