### PR TITLE
Address compliance concerns for docker files using non-approved registries

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -14,7 +14,17 @@
 # and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
-FROM reactnativecommunity/react-native-android:5.2
+
+# For compliance reasons Microsoft cannot depend on docker hub.
+# the reactnative community image is not published to MCR (https://mcr.microsoft.com/)
+# If we need to run these validations we can clone the repo that publishes the community image
+# Patch it to use mcr for the base ubuntu image, build the community image locally
+# and then build this customized step on top of it.
+#
+# Disabeling this is okay because per (macOS GH#774) this test, which is redundant to Azure Devops test,
+# failsin the fork because of Microsoft's V8 upgrade to Android
+#
+#FROM reactnativecommunity/react-native-android:5.2
 
 LABEL Description="React Native Android Test Image"
 LABEL maintainer="Héctor Ramos <hector@fb.com>"

--- a/v8-docker-build/Dockerfile
+++ b/v8-docker-build/Dockerfile
@@ -3,7 +3,7 @@
 # Based on Ubuntu
 ############################################################
 # Set the base image to Ubuntu
-FROM ubuntu:latest
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
 # File Author / Maintainer
 MAINTAINER Example prmis@microsoft.com
 ################## BEGIN INSTALLATION ######################


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Remove the FROM line of the android docker file since we don't have that image in an approved registry.
This makes the file invalid, but the test is already disabled from the .circleCI tests. So added comments to the file
on how to make it compliant when #774 is addressed.

Updated the V8 test to use mcr.microsoft.com registry.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Change] - Message

## Test Plan

N/A