### PR TITLE
cherry-pick - switch to extract_native_modules

### DIFF
--- a/.ado/downloadAndroidDependencies.py
+++ b/.ado/downloadAndroidDependencies.py
@@ -7,12 +7,11 @@ import shutil
 import subprocess
 import sys
 import time
-import zipfile
 
 
 desired_sdk = os.getenv("ANDROID_SDK_ROOT")
 if not desired_sdk:
-    logging.error("Envrionment variable ANDROID_SDK_ROOT must be set.")
+    logging.error("Environment variable ANDROID_SDK_ROOT must be set.")
     exit(-1)
 
 if os.getenv("ANDROID_NDK"):
@@ -22,28 +21,13 @@ elif os.path.exists(os.path.join(desired_sdk, "ndk-bundle")):
 elif os.path.exists(os.path.join(desired_sdk, "ndk")):
     desired_ndk = os.path.join(desired_sdk, "ndk")
 else:
-    logging.error("Envrionment variable ANDROID_NDK must be set.")
+    logging.error("Environment variable ANDROID_NDK must be set.")
     exit(-1)
 
 desired_jdk = os.getenv("JAVA_HOME")
 if not desired_jdk:  
-    logging.error("Envrionment variable JAVA_HOME must be set.")
+    logging.error("Environment variable JAVA_HOME must be set.")
     exit(-1)
-
-
-def create_folder(folder_path):
-    """Create folder if it does not exist
-
-        Parameters
-        ----------
-        folder_path : str
-            folder path to be checked
-    """
-    if not os.path.exists(folder_path):
-        try:
-            os.makedirs(folder_path)
-        except Exception as inst:
-            logging.error("Error while creating directory: " + inst)
 
 def ensure_output_dir(output_dir_path):
     # Move out if already exists.
@@ -56,66 +40,6 @@ def ensure_output_dir(output_dir_path):
     if os.path.exists(output_dir_path):
         logging.error("Unable to cleanup existing dependency directory: " + output_dir_path)
         logging.error("Move it away manually and rerun the script.")
-
-def get_office_platform(platform):
-    switcher = {'arm64-v8a':'droidarm64', 'armeabi-v7a':'droidarm', 'x86':'droidx86','x86_64':'droidx64'}
-    return switcher.get(platform,"")
-
-def extract_so(original_file_root, native_dir, original_file_name):
-    logging.info("Attempting to extract native libraries from " + original_file_name)
-    archive_filename_without_ext, archive_file_extension = os.path.splitext(original_file_name)
-    original_file_path = os.path.join(original_file_root, original_file_name)
-    zip_filepath = os.path.join(original_file_root, original_file_name + ".zip")
-    shutil.move(original_file_path, zip_filepath)
-
-    # Extract the archive
-    with zipfile.ZipFile(zip_filepath) as zip_file:
-        zip_target_folder = os.path.join(original_file_root, archive_filename_without_ext)
-        zip_file.extractall(zip_target_folder)
-                
-    # Extract native libraries.
-    for candidate_so_root, dirsi, candidate_so_files in os.walk(zip_target_folder):
-                    for candidate_so_file in candidate_so_files:
-                        if candidate_so_file.endswith(".so"):
-                            logging.info("Found native library " + candidate_so_file)
-                            so_path = os.path.join(candidate_so_root, candidate_so_file)
-                            
-                            lib_platform = os.path.basename(candidate_so_root)
-                            lib_office_platform = get_office_platform(lib_platform)
-                            if not lib_office_platform:
-                                logging.error("Invalid platform for native library: " + candidate_so_file)
-                                exit(1)
-
-                            so_target_dir = os.path.join(native_dir, lib_office_platform)
-                            create_folder(so_target_dir)
-                            shutil.move(so_path, so_target_dir)
-
-    # Re-zip back to original file name.
-    new_zip_filepath = os.path.join(original_file_root, archive_filename_without_ext + "_rezipped.zip")
-    with zipfile.ZipFile(new_zip_filepath, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-        for rootz, dirsz, filesz in os.walk(zip_target_folder):
-            for filez in filesz:
-                dest_path = os.path.join(rootz, filez)
-                # rel_path = os.path.relpath(dest_path, os.path.join(zip_target_folder, '..'))
-                rel_path = os.path.relpath(dest_path, zip_target_folder)
-                zip_file.write(dest_path, rel_path)
-
-    # Rename the rezipped file to original file name.
-    shutil.move(new_zip_filepath, os.path.join(original_file_root, original_file_name))
-    
-    # Remove the originally renamed archive and extracted folder.
-    shutil.rmtree(zip_target_folder)
-    os.remove(zip_filepath)
-
-def extract_sos(maven_dir, native_dir):
-    logging.debug("Attempting to extract native libraries")
-
-    for original_file_root, dirs, original_files in os.walk(maven_dir):
-        for original_file_name in original_files:
-            archive_filename_without_ext, archive_file_extension = os.path.splitext(original_file_name)
-            if(archive_file_extension in ['.jar', '.aar']):
-                extract_so(original_file_root, native_dir, original_file_name)
-
 
 ## Returns a list of strings, where the strings correspond to standard maven artifacts, i.e. groupId:artifactId:version
 def get_dependencies(react_native_dir):
@@ -167,7 +91,8 @@ def main():
     maven_dependency_utils.download_transitive_closure(artifacts=dependencies, output_directory_path=dependency_dir_maven, gradle_path='gradlew', ignore_metadata_redirection=True, resolve_to_single_version=False)
 
     # Extract the native libraries from maven packages
-    extract_sos(dependency_dir_maven, dependency_dir_native)
+    office_abi_mappings = {'arm64-v8a':'droidarm64', 'armeabi-v7a':'droidarm', 'x86':'droidx86','x86_64':'droidx64'}
+    maven_dependency_utils.extract_native_modules(dependency_dir_maven, dependency_dir_native, office_abi_mappings)
 
     # Copy and extract hermes.
     dependency_dir_hermes_android_aar_path = os.path.join(dependency_dir_hermes, "android")
@@ -180,11 +105,11 @@ def main():
 
     dependency_dir_hermes_android_native_debug = os.path.join(dependency_dir_hermes_android_aar_path, "debug")
     dependency_dir_hermes_android_native_release = os.path.join(dependency_dir_hermes_android_aar_path, "ship")
-    extract_so(dependency_dir_hermes_android_aar_path, dependency_dir_hermes_android_native_debug, "hermes-debug.aar")
-    extract_so(dependency_dir_hermes_android_aar_path, dependency_dir_hermes_android_native_debug, "hermes-cppruntime-debug.aar")
+    maven_dependency_utils.extract_native_modules_from_archive(os.path.join(dependency_dir_hermes_android_aar_path, "hermes-debug.aar"), dependency_dir_hermes_android_native_debug, office_abi_mappings)
+    maven_dependency_utils.extract_native_modules_from_archive(os.path.join(dependency_dir_hermes_android_aar_path, "hermes-cppruntime-debug.aar"), dependency_dir_hermes_android_native_debug, office_abi_mappings)
 
-    extract_so(dependency_dir_hermes_android_aar_path, dependency_dir_hermes_android_native_release, "hermes-release.aar")
-    extract_so(dependency_dir_hermes_android_aar_path, dependency_dir_hermes_android_native_release, "hermes-cppruntime-release.aar")
+    maven_dependency_utils.extract_native_modules_from_archive(os.path.join(dependency_dir_hermes_android_aar_path, "hermes-release.aar"), dependency_dir_hermes_android_native_release, office_abi_mappings)
+    maven_dependency_utils.extract_native_modules_from_archive(os.path.join(dependency_dir_hermes_android_aar_path, "hermes-cppruntime-release.aar"), dependency_dir_hermes_android_native_release, office_abi_mappings)
  
     # Copy log file into the dependency root folder.
     shutil.copy(log_file_path, os.path.join(dependency_dir_root))

--- a/.ado/templates/download-android-dependencies.yml
+++ b/.ado/templates/download-android-dependencies.yml
@@ -11,4 +11,4 @@ steps:
   - task: CmdLine@2
     displayName: 'Verify Dependencies can be enumerated'
     inputs:
-      script: pip3 install maven-dependency-utils==1.17.0 && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android
+      script: pip3 install maven-dependency-utils==1.22.0 && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This is just some refactoring, where the original code has been moved to maven-dependency-utils.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Use maven-dependency-utils native extraction module

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Will use the built nupkg to try a local build and ensure it succeeds.