### PR TITLE
Two improvements to our CI scripts

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -67,6 +67,11 @@ jobs:
           script: yarn install --frozen-lockfile
 
       - task: CmdLine@2
+        displayName: bundle install
+        inputs:
+          script: bundle install
+
+      - task: CmdLine@2
         displayName: Bump stable package version
         inputs:
           script: node .ado/bumpFileVersions.js

--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -77,12 +77,12 @@ if (!nightlyBuild) {
   if (process.env.BUILD_SOURCEBRANCH) {
     console.log(`BUILD_SOURCEBRANCH: ${process.env.BUILD_SOURCEBRANCH}`);
     branch = process.env.BUILD_SOURCEBRANCH.match(/refs\/heads\/(.*)/)[1];
-    console.log(`Identified branch: ${branch}`);
   } else {
     branch = exec('git symbolic-ref --short HEAD', {
       silent: true,
     }).stdout.trim();
   }
+  console.log(`Identified branch: "${branch}"`);
 
   if (branch.indexOf('-stable') === -1) {
     echo('You must be in 0.XX-stable branch to bump a version');


### PR DESCRIPTION
This makes two improvements to our CI scripts:
* Always print the branch we're in if we're trying to update it. We've seen [a CI failure](https://app.circleci.com/pipelines/github/microsoft/react-native-macos/4317/workflows/7d64d001-1b13-4135-b62d-d03fd0324c7c/jobs/24972) where we weren't doing this, so the terminal output was somewhat useless. This should help a little bit at least.
* Run `bundle install` as part of our publish CI script. We need this now that we're using gem to handle Ruby dependencies for us.