### PR TITLE
Use `rbenv` when running `bundle install`

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -69,7 +69,7 @@ jobs:
       - task: CmdLine@2
         displayName: bundle install
         inputs:
-          script: bundle install
+          script: rbenv exec bundle install
 
       - task: CmdLine@2
         displayName: Bump stable package version

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew "node@16"
+brew "rbenv"
 brew "watchman"


### PR DESCRIPTION
Our publishing pipeline for 0.68 ran into [a failure](https://office.visualstudio.com/ISS/_build/results?buildId=14025019&view=logs&j=6bb1d585-fe16-5108-3aa2-8096d3b89a29&t=724b1392-3080-5f36-5e5f-8aef20dce6a9&l=14) due to conflicting Ruby versions. Our solution is to use `rbenv` in our pipelines to ensure that we use the right version.