### PR TITLE
Ensure we have Ruby 2.7.5 installed for our ADO loops

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -67,6 +67,11 @@ jobs:
           script: yarn install --frozen-lockfile
 
       - task: CmdLine@2
+        displayName: Install Ruby 2.7.5 if needed
+        inputs:
+          script: rbenv install -s 2.7.5
+
+      - task: CmdLine@2
         displayName: bundle install
         inputs:
           script: rbenv exec bundle install


### PR DESCRIPTION
This resolves the following issue seen in one of our build loops as a result of #1216:

rbenv: version `2.7.5' is not installed (set by /Users/runner/work/1/s/.ruby-version)

This should fix that.