### PR TITLE
Incorporate a more rigorous version of `bundle install` in our publishing pipeline

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -66,15 +66,10 @@ jobs:
         inputs:
           script: yarn install --frozen-lockfile
 
-      - task: CmdLine@2
-        displayName: Install Ruby 2.7.5 if needed
-        inputs:
-          script: rbenv install -s 2.7.5
-
-      - task: CmdLine@2
+     - task: CmdLine@2
         displayName: bundle install
         inputs:
-          script: rbenv exec bundle install
+          script: node .ado/rigorousBundleInstall.js
 
       - task: CmdLine@2
         displayName: Bump stable package version

--- a/.ado/rigorousBundleInstall.js
+++ b/.ado/rigorousBundleInstall.js
@@ -1,0 +1,61 @@
+// @ts-check
+const chalk = require('chalk');
+const child_process = require('child_process');
+const fs = require('fs');
+
+/** Run a shell command and return any relevant error that comes up. */
+function exec(command) {
+  console.log(chalk.grey(`$ ${command}`))
+  try {
+    child_process.execSync(command, {stdio: ['pipe', 'inherit', 'pipe']});
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+function logError(error) {
+  console.error(error.stderr.toString());
+}
+
+console.log('Attempting `bundle install` on its own...')
+const plainResultError = exec('bundle install');
+if (plainResultError === undefined) {
+  process.exit(0);
+} else {
+  logError(plainResultError);
+}
+
+// Try to find the version error
+const errorMessage = plainResultError.stderr.toString();
+const versionErrorMatch = errorMessage.match(/Your Ruby version is ([\d\.]+), but your Gemfile specified ([\d\.]+)/);
+if (versionErrorMatch === undefined) {
+  console.error('Unrecognized error, bailing out');
+  process.exit(1);
+}
+
+let systemRubyVersion = versionErrorMatch[1];
+let gemfileRubyVersion = versionErrorMatch[2];
+
+console.log(`Attempting to install Ruby ${gemfileRubyVersion}...`);
+const rubyInstallError = exec(`rbenv install -s ${gemfileRubyVersion}`);
+if (rubyInstallError !== undefined) {
+  logError(rubyInstallError);
+
+  console.log(`Attempting to use system version of Ruby ${systemRubyVersion}...`);
+
+  const gemfileContents = fs.readFileSync('Gemfile').toString();
+  const newGemfileContents = gemfileContents.split('\n').filter(line => {
+    return line.match(/^ruby\s+'(.+)$'/) === null;
+  }).join('\n');
+  fs.writeFileSync('Gemfile', newGemfileContents);
+
+  fs.rmSync('.ruby-version');
+}
+
+console.log('Trying again with `rbenv`...');
+const rbenvError = exec('rbenv exec bundle install');
+if (rbenvError !== undefined) {
+  logError(rbenvError);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

With the latest publishing pipeline changes, we're still seeing problems installing the right version of Ruby. Therefore, our solution is to introduce a script that runs `bundle install` in a way that handles all of the errors we've seen so far.

The logic is as follows:
* If an initial run of `bundle install` fails due to a Ruby mismatch version, attempt to install the correct version using `rbenv`.
* If `rbenv install` succeeds, great. If it doesn't, remove the dependency on a specific version of Ruby so `rbenv` will default to the system version of Ruby.
* Try running `bundle install` under `rbenv`, which will either point to the correctly installed version or the system version, depending what happened in the last bullet point.
