### PR TITLE
Add NativePerformanceNow to V8 Global objects

### DIFF
--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000000..16de96d215
 --- /dev/null
 +++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,39 @@
 +#include <jsi/jsi.h>
 +#include <V8Runtime.h>
 +#include <jsireact/JSIExecutor.h>
@@ -30,6 +30,10 @@ index 0000000000..16de96d215
 +          static_cast<void (*)(const std::string &, unsigned int)>(
 +              &reactAndroidLoggingHook);
 +      react::bindNativeLogger(runtime, androidLogger);
++      react::PerformanceNow androidNativePerformanceNow =
++          static_cast<double (*)()>(&reactAndroidNativePerformanceNowHook);
++      react::bindNativePerformanceNow(runtime, androidNativePerformanceNow);
++
 +    };
 +
 +    return folly::make_unique<JSIExecutor>(

--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
@@ -3,12 +3,13 @@ new file mode 100644
 index 0000000000..16de96d215
 --- /dev/null
 +++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/V8ExecutorFactory.cpp
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +#include <jsi/jsi.h>
 +#include <V8Runtime.h>
 +#include <jsireact/JSIExecutor.h>
 +#include <react/jni/JSLoader.h>
 +#include <react/jni/JSLogging.h>
++#include <react/jni/NativeTime.h>
 +
 +#include "V8ExecutorFactory.h"
 +


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [👍 ] I am making a change required for Microsoft usage of react-native

## Summary
The bundle evaluation of metro-built bundler fails as property nativeperformancenow is not defined in global scope by V8.
Hermes's onLoad.cpp exports this property, but in V8 this was missing. 
In this change we add the property to the global object of V8


