### PR TITLE
Ensure we use 0.68 for testing new apps, not 0.69 or later

### DIFF
--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -82,14 +82,9 @@ steps:
     displayName: Publish react-native-macos-init to verdaccio
 
   - task: CmdLine@2
-    displayName: Install react-native cli
-    inputs:
-      script: npm install -g react-native-cli
-
-  - task: CmdLine@2
     displayName: Init new project
     inputs:
-      script: npx react-native init testcli
+      script: npx --yes react-native@0.68.2 init testcli --template react-native@0.68.2
       workingDirectory: $(Agent.BuildDirectory)
 
   - task: CmdLine@2


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Cherry-pick of c45fb1b834522a0ca8283923463e0ea960d0256d as seen in #1212.

The release of RN 0.69 seems to have broken our pipeline that validates `react-native-macos-init`, so for now we'll explicitly specify the RN version number we try to grab for this.
