### PR TITLE
Fix a bad regex in rigorousBundleInstall.js

### DIFF
--- a/.ado/rigorousBundleInstall.js
+++ b/.ado/rigorousBundleInstall.js
@@ -44,6 +44,7 @@ if (rubyInstallError !== undefined) {
 
   console.log(`Attempting to use system version of Ruby ${systemRubyVersion}...`);
 
+  // Remove ruby version from Gemfile
   const gemfileContents = fs.readFileSync('Gemfile').toString();
   const newGemfileContents = gemfileContents.split('\n').filter(line => {
     return line.match(/^ruby\s+'(.+)'$/) === null;

--- a/.ado/rigorousBundleInstall.js
+++ b/.ado/rigorousBundleInstall.js
@@ -46,7 +46,7 @@ if (rubyInstallError !== undefined) {
 
   const gemfileContents = fs.readFileSync('Gemfile').toString();
   const newGemfileContents = gemfileContents.split('\n').filter(line => {
-    return line.match(/^ruby\s+'(.+)$'/) === null;
+    return line.match(/^ruby\s+'(.+)'$/) === null;
   }).join('\n');
   fs.writeFileSync('Gemfile', newGemfileContents);
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

I made a small mistake in the regex to get rid of the ruby version in the Gemfile. This should fix it.
