### PR TITLE
Run `bundle install` before running `pod install`

### DIFF
--- a/scripts/update_podfile_lock.sh
+++ b/scripts/update_podfile_lock.sh
@@ -20,6 +20,8 @@ validate_env () {
 
 update_pods () {
   cd "$RNTESTER_DIR" || exit
+  bundle config set --local path ../../vendor/bundle
+  bundle install || exit
   bundle check || exit
   bundle exec pod install
   cd "$THIS_DIR" || exit


### PR DESCRIPTION
## Summary

We've seen another failure at the `pod install` phase of our pre-publish pipeline. While we're not 100% sure why things are particularly bad here, we can mitigate it by following the instructions on [RNTester's original README](https://github.com/facebook/react-native/tree/main/packages/rn-tester#running-on-ios) a bit more closely.
