### PR TITLE
Add patches to create rn-tester variants for V8, JSC and Hermes

### DIFF
--- a/android-patches/patches/V8/packages/rn-tester/android/app/build.gradle
+++ b/android-patches/patches/V8/packages/rn-tester/android/app/build.gradle
@@ -1,0 +1,14 @@
+diff --git a/packages/rn-tester/android/app/build.gradle b/packages/rn-tester/android/app/build.gradle
+index 7f04213604..aeaad944c7 100644
+--- a/packages/rn-tester/android/app/build.gradle
++++ b/packages/rn-tester/android/app/build.gradle
+@@ -151,6 +151,9 @@ android {
+         jsc {
+             dimension "vm"
+         }
++        v8 {
++            dimension "vm"
++        }
+     }
+ 
+     defaultConfig {

--- a/android-patches/patches/V8/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/android-patches/patches/V8/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -1,0 +1,56 @@
+diff --git a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+index 6d014d9dac..6c4b7663f8 100644
+--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
++++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+@@ -7,10 +7,14 @@
+ 
+ package com.facebook.react.uiapp;
+ 
++import static com.facebook.react.modules.systeminfo.AndroidInfoHelpers.getFriendlyDeviceName;
++
+ import android.app.Application;
+ import android.content.Context;
+ import androidx.annotation.Nullable;
+ import com.facebook.fbreact.specs.SampleTurboModule;
++import com.facebook.hermes.reactexecutor.HermesExecutorFactory;
++import com.facebook.react.jscexecutor.JSCExecutorFactory;
+ import com.facebook.react.ReactApplication;
+ import com.facebook.react.ReactInstanceManager;
+ import com.facebook.react.ReactNativeHost;
+@@ -22,6 +26,7 @@ import com.facebook.react.bridge.JSIModuleProvider;
+ import com.facebook.react.bridge.JSIModuleSpec;
+ import com.facebook.react.bridge.JSIModuleType;
+ import com.facebook.react.bridge.JavaScriptContextHolder;
++import com.facebook.react.bridge.JavaScriptExecutorFactory;
+ import com.facebook.react.bridge.NativeModule;
+ import com.facebook.react.bridge.ReactApplicationContext;
+ import com.facebook.react.bridge.UIManager;
+@@ -35,6 +40,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider;
+ import com.facebook.react.shell.MainReactPackage;
+ import com.facebook.react.uimanager.ViewManagerRegistry;
+ import com.facebook.react.views.text.ReactFontManager;
++import com.facebook.react.v8executor.V8ExecutorFactory;
+ import com.facebook.soloader.SoLoader;
+ import java.lang.reflect.InvocationTargetException;
+ import java.util.ArrayList;
+@@ -47,6 +53,20 @@ public class RNTesterApplication extends Application implements ReactApplication
+ 
+   private final ReactNativeHost mReactNativeHost =
+       new ReactNativeHost(this) {
++        @Override
++        public JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
++          if (BuildConfig.FLAVOR.equals("hermes")) {
++            return new HermesExecutorFactory();
++          } else if (BuildConfig.FLAVOR.equals("v8")) {
++            return new V8ExecutorFactory(getApplication().getPackageName(), getFriendlyDeviceName());
++          } else if (BuildConfig.FLAVOR.equals("jsc")) {
++            SoLoader.loadLibrary("jscexecutor");
++            return new JSCExecutorFactory(getApplication().getPackageName(), getFriendlyDeviceName());
++          } else {
++            throw new IllegalArgumentException("Missing handler in getJavaScriptExecutorFactory for build flavor: " + BuildConfig.FLAVOR);
++          }
++        }
++
+         @Override
+         public String getJSMainModuleName() {
+           return "packages/rn-tester/js/RNTesterApp.android";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The current set of android patches results in the hermes variant of rn-tester working incorrectly, due to the default js engine being set to v8. The patches here will ensure the appropriate executor is used, and also creates a variant for V8 so that it is easy to test across all 3 executors.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Add patches for V8 rn-tester variant

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Tested each built apk and verified the appropriate executor was being used
