### PR TITLE
Add files to .gitignore to get NPM publish pipeline fully working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ package-lock.json
 # Ruby Gems (Bundler)
 /vendor
 /template/vendor
+/packages/rn-tester/.bundle/
 
 # iOS / CocoaPods
 /template/ios/build/
@@ -126,3 +127,6 @@ package-lock.json
 
 # Android memory profiler files
 *.hprof
+
+# SBoM manifest
+/_manifest/


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Our latest publish pipeline fails to tag new versions on GitHub because we're trying to commit a large file that we don't need.

The solution is to adjust our .gitignore file to account for new changes to the repo and the publish pipeline:

* Add any files that are part of the SBoM manifest to .gitignore. We don't have a reason to keep these under version control.
* Add any residual files created as a result of #1233 to .gitignore.
