### PR TITLE
Manually bump to 0.68.3

### DIFF
--- a/Libraries/Core/ReactNativeVersion.js
+++ b/Libraries/Core/ReactNativeVersion.js
@@ -17,6 +17,6 @@
 exports.version = {
   major: 0,
   minor: 68,
-  patch: 2,
+  patch: 3,
   prerelease: null,
 };

--- a/React/Base/RCTVersion.m
+++ b/React/Base/RCTVersion.m
@@ -26,7 +26,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(68),
-                  RCTVersionPatch: @(2),
+                  RCTVersionPatch: @(3),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.68.2
+VERSION_NAME=0.68.3
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -21,6 +21,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 68,
-      "patch", 2,
+      "patch", 3,
       "prerelease", null);
 }

--- a/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -21,7 +21,7 @@ namespace facebook::react {
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 68;
-  int32_t Patch = 2;
+  int32_t Patch = 3;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-macos",
   "private": true,
-  "version": "0.68.2",
+  "version": "0.68.3",
   "bin": "./cli.js",
   "description": "React Native for macOS",
   "license": "MIT",

--- a/scripts/set-rn-template-version.js
+++ b/scripts/set-rn-template-version.js
@@ -22,7 +22,7 @@ if (!version) {
 const jsonPath = path.join(__dirname, '../template/package.json');
 
 let templatePackageJson = require(jsonPath);
-templatePackageJson.dependencies['react-native'] = version;
+templatePackageJson.dependencies['react-native-macos'] = version; // TODO(macOS GH#774)
 fs.writeFileSync(
   jsonPath,
   JSON.stringify(templatePackageJson, null, 2) + '\n',

--- a/template/package.json
+++ b/template/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "17.0.2",
-    "react-native-macos": "0.68.2"
+    "react-native-macos": "0.68.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
Due to some pipeline issues, we were able to publish 0.68.3 to NPM, but we weren't able to commit the version bump to GitHub. This manual version bump should do the trick, so the next time we try to bump the version number, we'll proceed to 0.68.4.

We also adjust our script to set the template version number, since 7100756bb8b0b1ac85ccaa32c0ce5c1cc70d524f changed our template package.json file to use `react-native-macos` instead of `react-native`. This shouldn't have too much of an impact since we basically use the template from upstream as our baseline, but we might as well adjust this for the sake of completeness.
