### PR TITLE
Do all `update_pods` actions in `bash`

### DIFF
--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -207,7 +207,10 @@ exec(`node scripts/set-rn-template-version.js ${version}`);
 // [TODO(macOS GH#774)
 if (updatePodfileLock) {
   echo('Updating RNTester Podfile.lock...');
-  if (exec('. scripts/update_podfile_lock.sh && update_pods', {shell: 'bash'}).code) {
+  if (
+    exec('. scripts/update_podfile_lock.sh && update_pods', {shell: 'bash'})
+      .code
+  ) {
     echo('Failed to update RNTester Podfile.lock.');
     echo('Fix the issue, revert and try again.');
     exit(1);
@@ -258,7 +261,10 @@ if (!nightlyBuild) {
   // Update Podfile.lock only on release builds, not nightlies.
   // Nightly builds don't need it as the main branch will already be up-to-date.
   echo('Updating RNTester Podfile.lock...');
-  if (exec('. scripts/update_podfile_lock.sh && update_pods', {shell: 'bash'}).code) {
+  if (
+    exec('. scripts/update_podfile_lock.sh && update_pods', {shell: 'bash'})
+      .code
+  ) {
     echo('Failed to update RNTester Podfile.lock.');
     echo('Fix the issue, revert and try again.');
     exit(1);

--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -207,7 +207,7 @@ exec(`node scripts/set-rn-template-version.js ${version}`);
 // [TODO(macOS GH#774)
 if (updatePodfileLock) {
   echo('Updating RNTester Podfile.lock...');
-  if (exec('. scripts/update_podfile_lock.sh && update_pods').code) {
+  if (exec('. scripts/update_podfile_lock.sh && update_pods', {shell: 'bash'}).code) {
     echo('Failed to update RNTester Podfile.lock.');
     echo('Fix the issue, revert and try again.');
     exit(1);
@@ -258,7 +258,7 @@ if (!nightlyBuild) {
   // Update Podfile.lock only on release builds, not nightlies.
   // Nightly builds don't need it as the main branch will already be up-to-date.
   echo('Updating RNTester Podfile.lock...');
-  if (exec('. scripts/update_podfile_lock.sh && update_pods').code) {
+  if (exec('. scripts/update_podfile_lock.sh && update_pods', {shell: 'bash'}).code) {
     echo('Failed to update RNTester Podfile.lock.');
     echo('Fix the issue, revert and try again.');
     exit(1);


### PR DESCRIPTION
Our invocation of `update_pods` depends on `bash` to determine where RNTester lives (due to the presence of `BASH_SOURCE`), so let's make sure we're using `bash` whenever we try to run `update_pods`.