### PR TITLE
Merge pull request #1247 from rasaha91/split-rn-tester

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -46,10 +46,16 @@ jobs:
         inputs:
           script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew installArchives -Pparam="excludeLibs"
 
+      # We have separate tasks to build rn-tester for debug and release due to a regression upstream. See https://github.com/facebook/react-native/issues/34168.
       - task: CmdLine@2
-        displayName: Build rn-tester
+        displayName: Build rn-tester debug
         inputs:
-          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew :packages:rn-tester:android:app:assemble
+          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew :packages:rn-tester:android:app:assembleDebug
+
+      - task: CmdLine@2
+        displayName: Build rn-tester release
+        inputs:
+          script: REACT_NATIVE_BOOST_PATH=$(System.DefaultWorkingDirectory)/build_deps ./gradlew :packages:rn-tester:android:app:assembleRelease
 
       - template: templates/prep-android-nuget.yml
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
There was a regression in 0.68-stable that causes building rn-tester multiple times to fail on the second attempt. I was able to verify this by trying it on facebook/react-native. I ended up filing this issue https://github.com/facebook/react-native/issues/34168 to track a proper upstream fix. It seems that the issue has to do with trying to build debug and release variants of rn-tester in the same gradle invocation. As a temporary work around, we build debug and release in separate gradle invocations.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Split rn-tester into separate debug and release builds

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Ran the build steps multiple times and ensured the build succeeded.
