### PR TITLE
Install bundler as part of Office publish pipeline

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -207,6 +207,18 @@ jobs:
 
       - template: templates/android-build-office.yml
 
+      - template: templates/apple-node-setup.yml
+
+      - task: CmdLine@2
+        displayName: Fix permissions for gem
+        inputs:
+          script: sudo chown -R $(whoami) /var/lib/gems/*
+
+      - task: CmdLine@2
+        displayName: Install bundler
+        inputs:
+          script: gem install bundler
+
       - task: CmdLine@2
         displayName: Bump package version
         inputs:


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

This adds the installation of Bundler to one of our publishing pipelines, since `set-rn-version.js` depends on it.

An equivalent change was tested in a separate branch, and it seems to work, so here's hoping it translates well! 🙏
