### PR TITLE
Support inverted ScrollView on macOS

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -500,6 +500,10 @@ export type Props = $ReadOnly<{|
    */
   invertStickyHeaders?: ?boolean,
   /**
+   * Reverses the direction of scroll. Uses native inversion on macOS and scale transforms of -1 elsewhere
+   */
+  inverted?: ?boolean, // TODO(macOS GH#774)
+  /**
    * Determines whether the keyboard gets dismissed in response to a drag.
    *
    * *Cross platform*
@@ -1192,6 +1196,11 @@ class ScrollView extends React.Component<Props, State> {
     this.setState({contentKey: this.state.contentKey + 1});
   }; // ]TODO(macOS GH#774)
 
+  // [TODO(macOS GH#774)
+  _handleInvertedDidChange = () => {
+    this.setState({contentKey: this.state.contentKey + 1});
+  }; // ]TODO(macOS GH#774)
+
   _handleScroll = (e: ScrollEvent) => {
     if (__DEV__) {
       if (
@@ -1716,6 +1725,7 @@ class ScrollView extends React.Component<Props, State> {
             : this.props.removeClippedSubviews
         }
         key={this.state.contentKey} // TODO(macOS GH#774)
+        inverted={this.props.inverted} // TODO(macOS GH#774)
         collapsable={false}>
         {children}
       </NativeDirectionalScrollContentView>
@@ -1743,6 +1753,7 @@ class ScrollView extends React.Component<Props, State> {
       // Override the onContentSizeChange from props, since this event can
       // bubble up from TextInputs
       onContentSizeChange: null,
+      onInvertedDidChange: this._handleInvertedDidChange, // TODO macOS GH#774
       onPreferredScrollerStyleDidChange:
         this._handlePreferredScrollerStyleDidChange, // TODO(macOS GH#774)
       onLayout: this._handleLayout,

--- a/Libraries/Components/ScrollView/__tests__/__snapshots__/ScrollView-test.js.snap
+++ b/Libraries/Components/ScrollView/__tests__/__snapshots__/ScrollView-test.js.snap
@@ -16,6 +16,7 @@ exports[`<ScrollView /> should render as expected: should deep render when not m
 <RCTScrollView
   alwaysBounceVertical={true}
   onContentSizeChange={null}
+  onInvertedDidChange={[Function]}
   onLayout={[Function]}
   onMomentumScrollBegin={[Function]}
   onMomentumScrollEnd={[Function]}

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -71,6 +71,12 @@ type DirectEventProps = $ReadOnly<{|
   onDoubleClick?: ?(event: SyntheticEvent<{}>) => mixed, // TODO(macOS GH#774)
 
   /**
+   * This event is fired when the scrollView's inverted property changes.
+   * @platform macos
+   */
+  onInvertedDidChange?: ?() => mixed, // TODO(macOS GH#774)
+
+  /**
    * This event is fired when the system's preferred scroller style changes.
    * The `preferredScrollerStyle` key will be `legacy` or `overlay`.
    */
@@ -414,6 +420,10 @@ type IOSViewProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/view#accessibilityElementsHidden
    */
   accessibilityElementsHidden?: ?boolean,
+  /**
+   * Reverses the direction of scroll. Uses native inversion on macOS and scale transforms of -1 elsewhere
+   */
+  inverted?: ?boolean, // TODO(macOS GH#774)
 
   onDoubleClick?: ?(event: SyntheticEvent<{}>) => mixed, // TODO(macOS GH#774)
 

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -136,7 +136,7 @@ type OptionalProps<ItemT> = {|
   initialSelectedIndex?: ?number,
   // ]TODO(macOS GH#774)
   /**
-   * Reverses the direction of scroll. Uses scale transforms of -1.
+   * Reverses the direction of scroll. Uses native inversion on macOS and scale transforms of -1 elsewhere
    */
   inverted?: ?boolean,
   /**

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -979,11 +979,13 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       this.props;
     const {data, horizontal} = this.props;
     const isVirtualizationDisabled = this._isVirtualizationDisabled();
-    const inversionStyle = this.props.inverted
-      ? horizontalOrDefault(this.props.horizontal)
-        ? styles.horizontallyInverted
-        : styles.verticallyInverted
-      : null;
+    // macOS natively supports inverted lists, thus not needing an inversion style
+    const inversionStyle =
+      this.props.inverted && Platform.OS !== 'macos' // TODO(macOS GH#774)
+        ? horizontalOrDefault(this.props.horizontal)
+          ? styles.horizontallyInverted
+          : styles.verticallyInverted
+        : null;
     const cells = [];
     const stickyIndicesFromProps = new Set(this.props.stickyHeaderIndices);
     const stickyHeaderIndices = [];
@@ -1330,6 +1332,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     // [TODO(macOS GH#774)
     const preferredScrollerStyleDidChangeHandler =
       this.props.onPreferredScrollerStyleDidChange;
+    const invertedDidChange = this.props.onInvertedDidChange;
 
     const keyboardNavigationProps = {
       focusable: true,
@@ -1353,6 +1356,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         <ScrollView
           // [TODO(macOS GH#774)
           {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
+          onInvertedDidChange={invertedDidChange}
           onPreferredScrollerStyleDidChange={
             preferredScrollerStyleDidChangeHandler
           } // TODO(macOS GH#774)]
@@ -1376,6 +1380,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         <ScrollView
           // [TODO(macOS GH#774)
           {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
+          onInvertedDidChange={invertedDidChange}
           onPreferredScrollerStyleDidChange={
             preferredScrollerStyleDidChangeHandler
           } // TODO(macOS GH#774)]

--- a/React/Views/ScrollView/RCTScrollContentView.h
+++ b/React/Views/ScrollView/RCTScrollContentView.h
@@ -11,4 +11,8 @@
 
 @interface RCTScrollContentView : RCTView
 
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+@property (nonatomic, assign, getter=isInverted) BOOL inverted;
+#endif // ]TODO(macOS GH#774)
+
 @end

--- a/React/Views/ScrollView/RCTScrollContentView.m
+++ b/React/Views/ScrollView/RCTScrollContentView.m
@@ -18,6 +18,12 @@
 #import "RCTScrollView.h"
 
 @implementation RCTScrollContentView
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+- (BOOL)isFlipped
+{
+  return !self.inverted;
+}
+#endif // ]TODO(macOS GH#774)
 
 - (void)reactSetFrame:(CGRect)frame
 {

--- a/React/Views/ScrollView/RCTScrollContentViewManager.m
+++ b/React/Views/ScrollView/RCTScrollContentViewManager.m
@@ -14,6 +14,8 @@
 
 RCT_EXPORT_MODULE()
 
+RCT_EXPORT_OSX_VIEW_PROPERTY(inverted, BOOL) // TODO(macOS GH#774)
+
 - (RCTScrollContentView *)view
 {
   return [RCTScrollContentView new];

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -67,6 +67,8 @@
 @property (nonatomic, copy) RCTDirectEventBlock onMomentumScrollEnd;
 @property (nonatomic, copy) RCTDirectEventBlock onPreferredScrollerStyleDidChange; // TODO(macOS GH#774)
 
+@property (nonatomic, copy) RCTDirectEventBlock onInvertedDidChange; // TODO(macOS GH#774)
+
 - (void)flashScrollIndicators; // TODO(macOS GH#774)
 
 @end

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -45,6 +45,7 @@
 @property (nonatomic, assign) BOOL pinchGestureEnabled;
 #else // [TODO(macOS GH#774)
 + (BOOL)isCompatibleWithResponsiveScrolling;
+@property (nonatomic, assign, getter=isInverted) BOOL inverted;
 @property (nonatomic, assign, getter=isScrollEnabled) BOOL scrollEnabled;
 @property (nonatomic, strong) NSPanGestureRecognizer *panGestureRecognizer;
 #endif // ]TODO(macOS GH#774)
@@ -106,6 +107,11 @@
 + (BOOL)isCompatibleWithResponsiveScrolling
 {
   return YES;
+}
+
+- (BOOL)isFlipped
+{
+  return !self.inverted;
 }
 
 - (void)scrollWheel:(NSEvent *)theEvent
@@ -555,6 +561,15 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 - (void)setAccessibilityRole:(NSAccessibilityRole)accessibilityRole
 {
   [_scrollView setAccessibilityRole:accessibilityRole];
+}
+
+- (void)setInverted:(BOOL)inverted
+{
+  BOOL changed = _inverted != inverted;
+  _inverted = inverted;  
+  if (changed && _onInvertedDidChange) {
+    _onInvertedDidChange(@{});
+  }
 }
 #endif // ]TODO(macOS GH#774)
 

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -99,6 +99,7 @@ RCT_EXPORT_VIEW_PROPERTY(onScrollToTop, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScrollEndDrag, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollBegin, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
+RCT_EXPORT_OSX_VIEW_PROPERTY(onInvertedDidChange, RCTDirectEventBlock) // TODO(macOS GH#774)
 RCT_EXPORT_OSX_VIEW_PROPERTY(onPreferredScrollerStyleDidChange, RCTDirectEventBlock) // TODO(macOS GH#774)
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -491,6 +491,48 @@ if (Platform.OS === 'ios') {
 }
 exports.examples = examples;
 
+// TODO [(macOS GH#774)
+if (Platform.OS === 'macos') {
+  examples.push({
+    title: '<ScrollView> (inverted = true/false)\n',
+    description:
+      "You can display <ScrollView>'s child components in inverted order",
+    render: function (): React.Node {
+      return <InvertedContentExample />;
+    },
+  });
+}
+
+const InvertedContentExample = () => {
+  const [inverted, setInverted] = useState(true);
+  const [items, setItems] = useState(ITEMS);
+  return (
+    <>
+      <ScrollView
+        style={[styles.scrollView, {height: 200}]}
+        inverted={inverted}>
+        {items.map(createItemRow)}
+      </ScrollView>
+      <Text style={{paddingTop: 10, paddingBottom: 10}}>
+        Same example as above, but with the opposite inverted option
+      </Text>
+      <ScrollView
+        style={[styles.scrollView, {height: 200}]}
+        inverted={!inverted}>
+        {items.map(createItemRow)}
+      </ScrollView>
+      <Button
+        label={'toggle inverted'}
+        onPress={() => {
+          setInverted(!inverted);
+          setItems([...Array(14)].map((_, i) => `Item ${i}`));
+        }}
+      />
+    </>
+  );
+};
+// ]TODO(macOS GH#774)
+
 const AndroidScrollBarOptions = () => {
   const [persistentScrollBar, setPersistentScrollBar] = useState(false);
   return (


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Allow to render a scrollView's content in inverted order which is especially helpful in messaging applications.

Co-authored-by: Scott Kyle [skyle@fb.com](mailto:skyle@fb.com)

## Changelog

[macOS] [Added] - Support inverted ScrollView on macOS

## Test Plan

Added RNTester example

https://user-images.githubusercontent.com/484044/180100444-ca02296a-6e12-4374-b348-6c4fde63d96c.mov

Default, non-inverted example

https://user-images.githubusercontent.com/484044/180100638-503d98ea-9a00-4efe-8f09-56ef483c1ab6.mov


