### PR TITLE
Allow scrollResponderZoomTo() on macOS

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -1054,7 +1054,11 @@ class ScrollView extends React.Component<Props, State> {
     |},
     animated?: boolean, // deprecated, put this inside the rect argument instead
   ) => {
-    invariant(Platform.OS === 'ios', 'zoomToRect is not implemented');
+    invariant(
+      // [TODO(macOS GH#774)
+      Platform.OS === 'ios' || Platform.OS === 'macos',
+      'zoomToRect is not implemented',
+    ); // TODO [(macOS GH#774)
     if ('animated' in rect) {
       this._animated = rect.animated;
       delete rect.animated;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Already works on macOS (as it does on iOS).
Doesn't work on Android or Windows.

## Changelog

[macOS] [Changed] - Allow scrollResponderZoomTo() on macOS

## Test Plan

I have used the following sample in rn-tester in ScrollViewExample.js

```
const HorizontalScrollView = (props: {direction: 'ltr' | 'rtl'}) => {
  const {direction} = props;
  const scrollRef = React.useRef<?React.ElementRef<typeof ScrollView>>();
  const [scale, setScale] = useState(20);
  const [coord, setCoord] = useState(0);
  const title = direction === 'ltr' ? 'LTR Layout' : 'RTL Layout';
  return (
    <View style={{direction}}>
      <Text style={styles.text}>{title}</Text>
      <ScrollView
        ref={scrollRef}
        automaticallyAdjustContentInsets={false}
        horizontal={true}
        style={[styles.scrollView, styles.horizontalScrollView]}
        testID={'scroll_horizontal'}
      >
        {ITEMS.map(createItemRow)}
      </ScrollView>
      <Button
        label="Scroll to start"
        onPress={() => {
                setScale(scale + 20);
                setCoord(coord + 1);
                scrollRef.current?.scrollResponderZoomTo({
                  x: coord,
                  y: coord,
                  width: scale,
                  height: scale,
                  animated: true,
                });
          //nullthrows(scrollRef.current).scrollTo({x: 0});
        }}
        testID={'scroll_to_start_button'}
      />
      <Button
        label="Scroll to end"
        onPress={() => {
          nullthrows(scrollRef.current).scrollToEnd({animated: true});
        }}
        testID={'scroll_to_end_button'}
      />
    </View>
  );
};
```

https://user-images.githubusercontent.com/484044/180300762-bb9552b9-b8a5-4c14-9d7b-9bc8cb489f60.mov


Also used at Meta for Messenger Desktop.

