### PR TITLE
Avoid RCTUnsafeExecuteOnMainQueueSync from RCTUIManager

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -354,6 +354,8 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
     return name;
   }
 
+// Re-enable componentViewName_DO_NOT_USE_THIS_IS_BROKEN once macOS uses Fabric
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   __block RCTPlatformView *view; // TODO(macOS GH#774)
   RCTUnsafeExecuteOnMainQueueSync(^{
     view = self->_viewRegistry[reactTag];
@@ -367,6 +369,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   }
 
 #pragma clang diagnostic pop
+#endif // ]TODO(macOS GH#774)
   return nil;
 }
 
@@ -1135,6 +1138,8 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand
   RCTShadowView *shadowView = _shadowViewRegistry[reactTag];
   RCTComponentData *componentData = _componentDataByName[shadowView.viewName];
 
+// Re-enable componentViewName_DO_NOT_USE_THIS_IS_BROKEN once macOS uses Fabric
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   // Achtung! Achtung!
   // This is a remarkably hacky and ugly workaround.
   // We need this only temporary for some testing. We need this hack until Fabric fully implements command-execution
@@ -1152,6 +1157,7 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand
     }
   }
 #pragma clang diagnostic pop
+#endif // ]TODO(macOS GH#774)
 
   Class managerClass = componentData.managerClass;
   RCTModuleData *moduleData = [_bridge moduleDataForName:RCTBridgeModuleNameForClass(managerClass)];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

These calls are only needed for a temporary Fabric workaround and would result in a deadlock since we also call `RCTUnsafeExecuteOnUIManagerQueueSync` from the main thread during window resize.

This is needed for now in Fabric only to call the temporary `componentViewName_DO_NOT_USE_THIS_IS_BROKEN` workaround on views, which we don't have on desktop since we're a way off from using Fabric (and hopefully this workaround will be gone then).

It was originally added here https://github.com/facebook/react-native/commit/ffc7ec992c66417039b0fa14f1afd54a9cd2f882

At Meta we have disabled these lines since May 2021 to fix crashes in production.

## Changelog

[macOS] [Fixed] - Avoid RCTUnsafeExecuteOnMainQueueSync from RCTUIManager

## Test Plan

Ran rn-tester.
Crash no longer observed
