### PR TITLE
Fix VoiceOver for single-line TextInput

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -105,7 +105,6 @@
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
     [self setBordered:NO];
     [self setAllowsEditingTextAttributes:YES];
-    [self setAccessibilityRole:NSAccessibilityTextFieldRole];
     [self setBackgroundColor:[NSColor clearColor]];
 #endif // ]TODO(macOS GH#774)
 
@@ -127,7 +126,11 @@
 
 #pragma mark - Accessibility
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 - (void)setIsAccessibilityElement:(BOOL)isAccessibilityElement
+#else
+- (void)setAccessibilityElement:(BOOL)isAccessibilityElement
+#endif // ]TODO(macOS GH#774)
 {
   // UITextField is accessible by default (some nested views are) and disabling that is not supported.
   // On iOS accessible elements cannot be nested, therefore enabling accessibility for some container view


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This adds the appropriate override for AppKit (`setAccessibilityElement:`) so that the `NSTextField` will not get set to be accessible, since its cell instead is already accessible and performs the correct VoiceOver behaviors.

VoiceOver now reads as you type in a single-line `TextInput`

## Changelog

[macOS] [Fixed] - Fix VoiceOver for single-line TextInput

## Test Plan

### Focus field
Didn't announce the search field 
`Search...`
instead
`You are currently on a text field`
was shown

BEFORE

https://user-images.githubusercontent.com/484044/180339597-035d5f21-0567-4e5f-91f2-d9f60722ffdf.mov

AFTER


https://user-images.githubusercontent.com/484044/180339668-e566278c-b59c-4a90-b44d-3a1ab7a9613a.mov

### Enter searchTerm
Didn't announce the search term

BEFORE

https://user-images.githubusercontent.com/484044/180339728-d9cf208f-0826-4998-a67e-3c0ea3c45363.mov

AFTER



https://user-images.githubusercontent.com/484044/180339920-59d9627e-a177-4c30-b531-7b524d3fdc03.mov



