### PR TITLE
Fix RCTImageCache on macOS

### DIFF
--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -38,10 +38,10 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
 {
   if (self = [super init]) {
     _decodedImageCache = [NSCache new];
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
     _decodedImageCache.totalCostLimit = 20 * 1024 * 1024; // 20 MB
     _cacheStaleTimes = [NSMutableDictionary new];
 
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(clearCache)
                                                  name:UIApplicationDidReceiveMemoryWarningNotification


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The cache's `totalCostLimit` and the `_cacheStaleTimes` ivar were not getting set for Mac, presumably due to a merge mistake. I'm not sure what (if any) positive impact this will realistically have on memory consumption.

## Changelog

[macOS] [Fixed] - Fix RCTImageCache on macOS

## Test Plan

Tested rn-tester scrolling through several threads with lots of images. Everything works well.