### PR TITLE
Fix resizeMode="cover" when image is resized

### DIFF
--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -128,6 +128,8 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
   // Whether the latest change of props requires the image to be reloaded
   BOOL _needsReload;
 
+  UIImage *_image; // TODO(macOS GH#774)
+
   RCTUIImageViewAnimated *_imageView;
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
@@ -211,6 +213,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 #else // [TODO(macOS GH#774)
     image.capInsets = _capInsets;
     image.resizingMode = NSImageResizingModeTile;
+  } else if (_resizeMode == RCTResizeModeCover) {
+    if (!NSEqualSizes(self.bounds.size, NSZeroSize)) {
+      image = RCTFillImagePreservingAspectRatio(image, self.bounds.size, self.window.backingScaleFactor ?: 1.0);
+    }
 #endif // ]TODO(macOS GH#774)
   } else if (!UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, _capInsets)) {
     // Applying capInsets of 0 will switch the "resizingMode" of the image to "tile" which is undesired
@@ -233,17 +239,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 {
   image = image ?: _defaultImage;
   if (image != self.image) {
-#if TARGET_OS_OSX // [TODO(macOS GH#774)
-    if (image && _resizeMode == RCTResizeModeCover && !NSEqualSizes(self.bounds.size, NSZeroSize)) {
-      image = RCTFillImagePreservingAspectRatio(image, self.bounds.size, self.window.backingScaleFactor ?: 1.0);
-    }
-#endif // ]TODO(macOS GH#774)
+    _image = image; // TODO(macOS GH#774)
     [self updateWithImage:image];
   }
 }
 
 - (UIImage *)image {
-  return _imageView.image;
+  return _image ?: _imageView.image; // TODO(macOS GH#774)
 }
 
 - (void)setBlurRadius:(CGFloat)blurRadius

--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -201,10 +201,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   if (_renderingMode != image.renderingMode) {
     image = [image imageWithRenderingMode:_renderingMode];
   }
-#else // [TODO(macOS GH#774)
-  if ((_renderingMode == UIImageRenderingModeAlwaysTemplate) != [image isTemplate]) {
-    [image setTemplate:(_renderingMode == UIImageRenderingModeAlwaysTemplate)];
-  }
 #endif // ]TODO(macOS GH#774)
 
   if (_resizeMode == RCTResizeModeRepeat) {
@@ -227,6 +223,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
     image.resizingMode = NSImageResizingModeStretch;
 #endif // ]TODO(macOS GH#774)
   }
+
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+  if ((_renderingMode == UIImageRenderingModeAlwaysTemplate) != [image isTemplate]) {
+    [image setTemplate:(_renderingMode == UIImageRenderingModeAlwaysTemplate)];
+  }
+#endif // ]TODO(macOS GH#774)
 
   // Apply trilinear filtering to smooth out mis-sized images
   _imageView.layer.minificationFilter = kCAFilterTrilinear;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

Since `RCTResizeModeCover` is implemented manually on macOS (iOS benefits from `UIViewContentModeScaleAspectFill` API), we need to reprocess the image any time the bounds of the view update. The `updateImage:` method was already called on resize, so this instead stores the original image in an ivar so it can call `RCTFillImagePreservingAspectRatio` from `updateImage:` instead.

## Changelog

[macOS] [Fixed] - Fix resizeMode="cover" when image is resized

## Test Plan

### Before

Look at the images labeled 'Cover' and observe how they don't properly resize

https://user-images.githubusercontent.com/484044/180457216-88a05f6f-3aef-40a6-af45-8e3e2f4feef7.mov

### After

https://user-images.githubusercontent.com/484044/180457246-2b09e140-1dfe-489c-8d43-56bff5e53740.mov



### Before
Another demo, done internally

https://user-images.githubusercontent.com/484044/180457315-ea46deba-a9a1-4719-bbc1-7e495a19792e.mov



### After


https://user-images.githubusercontent.com/484044/180457545-78eb1ab3-2401-48e6-b038-a225fee71c33.mov


