### PR TITLE
Add undo/redo support for TextInput

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -263,6 +263,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   UITextRange *_previousSelectedTextRange;
 #else // [TODO(macOS GH#774)
   NSRange _previousSelectedTextRange;
+  NSUndoManager *_undoManager;
 #endif // ]TODO(macOS GH#774)
 }
 
@@ -426,6 +427,13 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   }
 
   return commandHandled;
+}
+
+- (NSUndoManager *)undoManagerForTextView:(NSTextView *)textView {
+  if (!_undoManager) {
+    _undoManager = [NSUndoManager new];
+  }
+  return _undoManager;
 }
 
 #endif // ]TODO(macOS GH#774)

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -144,7 +144,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   BOOL textNeedsUpdate = NO;
   // Remove tag attribute to ensure correct attributed string comparison.
   NSMutableAttributedString *const backedTextInputViewTextCopy = [self.backedTextInputView.attributedText mutableCopy];
-  NSMutableAttributedString *const attributedTextCopy = [attributedText mutableCopy];
+  NSMutableAttributedString *const attributedTextCopy = [attributedText mutableCopy] ?: [NSMutableAttributedString new];
 
   [backedTextInputViewTextCopy removeAttribute:RCTTextAttributesTagAttributeName
                                          range:NSMakeRange(0, backedTextInputViewTextCopy.length)];
@@ -160,7 +160,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 #else // [TODO(macOS GH#774)
     NSRange selection = [self.backedTextInputView selectedTextRange];
 #endif // ]TODO(macOS GH#774)
-    NSInteger oldTextLength = self.backedTextInputView.attributedText.string.length;
+    NSAttributedString *oldAttributedText = [self.backedTextInputView.attributedText copy];
+    NSInteger oldTextLength = oldAttributedText.string.length;
+
+    [self.backedTextInputView.undoManager registerUndoWithTarget:self handler:^(RCTBaseTextInputView *strongSelf) {
+      strongSelf.attributedText = oldAttributedText;
+      [strongSelf textInputDidChange];
+    }];
 
     self.backedTextInputView.attributedText = attributedText;
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

Setting `allowsUndo = YES` and having the `NSTextView` delegate return a stable `NSUndoManager` mostly makes undo/redo work, but we also need to register an undo action whenever the input contents was changed to something unexpected by JS.

This also breaks undo coalescing in a couple key places to make the input behave naturally like other apps.

## Changelog

[macOS] [Added] - Add undo/redo support for TextInput

## Test Plan

### Before

Note: Bottom left corner casts key strokes from my keyboard

https://user-images.githubusercontent.com/484044/180468578-a70a072c-1926-4350-9c49-1c2d2c22aa60.mov



### After


https://user-images.githubusercontent.com/484044/180468667-23f92c9d-e4de-4218-84f4-bbb7e5eb51dd.mov


