### PR TITLE
Fix missing autorelease pool in RCTPlatformDisplayLink

### DIFF
--- a/React/Base/macOS/RCTPlatformDisplayLink.m
+++ b/React/Base/macOS/RCTPlatformDisplayLink.m
@@ -51,7 +51,9 @@ static CVReturn RCTPlatformDisplayLinkCallBack(__unused CVDisplayLinkRef display
     if (rctDisplayLink->_runLoop != nil) {
       CFRunLoopRef cfRunLoop = [rctDisplayLink->_runLoop getCFRunLoop];
       CFRunLoopPerformBlock(cfRunLoop, (__bridge CFArrayRef)rctDisplayLink->_modes, ^{
-        [rctDisplayLink tick];
+        @autoreleasepool {
+          [rctDisplayLink tick];
+        }
       });
       CFRunLoopWakeUp(cfRunLoop);
     }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes leaking `_RCTTimer` instances. The runloop does not push/pop autorelease pools for you with `CFRunLoopPerformBlock`. A similar autorelease pool is setup for the same reason in `RCTMessageThread`.

https://github.com/facebook/react-native/commit/948cbfdacc42f8d2640e69f61df55f6adb823fcf

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fix missing autorelease pool in RCTPlatformDisplayLink

## Test Plan

Confirmed expected number of `_RCTTimer` instances in Xcode memory graph.
