### PR TITLE
Skip unnecessary auto layout pass

### DIFF
--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -410,6 +410,12 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
   self.needsDisplay = YES;
 }
 
+- (void)setNeedsUpdateConstraints:(BOOL)flag
+{
+  // Since we use Yoga instead of autolayout, skip this expensive super
+  // implementation that traverses up the tree and posts notifications.
+}
+
 @synthesize clipsToBounds = _clipsToBounds;
 
 @synthesize backgroundColor = _backgroundColor;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The `[NSView setNeedsUpdateConstraints:]` method actually traverses up the view hierarchy calling the same method and ultimately posts an notification from the window to trigger an autolayout pass. This method would be called from any frame change, which is very frequent, and since we don't rely on autolayout we can safely avoid this overhead.

## Changelog

[macOS] [Changed] - Skip unnecessary auto layout pass

## Test Plan

rn-tester UI still looks correct.
