### PR TITLE
Fix RCTDevLoadingView never actually closing

### DIFF
--- a/React/CoreModules/RCTDevLoadingView.mm
+++ b/React/CoreModules/RCTDevLoadingView.mm
@@ -226,7 +226,7 @@ RCT_EXPORT_METHOD(hide)
       [NSAnimationContext runAnimationGroup:^(__unused NSAnimationContext *context) {
         self->_window.animator.alphaValue = 0.0;
       } completionHandler:^{
-        [self->_window orderFront:self];
+        [self->_window close];
         self->_window = nil;
       }];
     });


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes a copy/paste mistake where the loading panel is being shown after it fades out instead of being closed. This manifested as app exposé showing a transparent window and these panels showing up in the UI debugger (thus leaking).

## Changelog

[macOS] [Fixed] - Fix RCTDevLoadingView never actually closing

## Test Plan
Confirmed the loading panels actually now go away and app exposé behaves reasonably now.

### Before

<img width="1659" alt="b" src="https://user-images.githubusercontent.com/484044/180580209-11ab1628-1c37-4581-bc7a-403c1ad854de.png">

<img width="1473" alt="b2" src="https://user-images.githubusercontent.com/484044/180580220-49b7ea9a-5562-4e93-a57d-8bcc1cd0eae1.png">

### After


<img width="1672" alt="after" src="https://user-images.githubusercontent.com/484044/180580227-364c1951-af85-4001-85d6-79f9adf75d6f.png">

