### PR TITLE
Don't send events when clicking on scrollbars

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -129,6 +129,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     // The assumption here is that a RCTUIView/RCTSurfaceView will always have a superview.
     CGPoint touchLocation = [self.view.superview convertPoint:touch.locationInWindow fromView:nil];
     NSView *targetView = [self.view hitTest:touchLocation];
+    // Don't record clicks on scrollbars.
+    if ([targetView isKindOfClass:[NSScroller class]]) {
+      continue;
+    }
     // Pair the mouse down events with mouse up events so our _nativeTouches cache doesn't get stale
     if ([targetView isKindOfClass:[NSControl class]]) {
       _shouldSendMouseUpOnSystemBehalf = [(NSControl*)targetView isEnabled];
@@ -393,6 +397,11 @@ static BOOL RCTAnyTouchesChanged(NSSet *touches) // [TODO(macOS GH#774)
   // "start" has to record new touches *before* extracting the event.
   // "end"/"cancel" needs to remove the touch *after* extracting the event.
   [self _recordNewTouches:touches];
+
+  // [TODO(macOS GH#774) - Filter out touches that were ignored.
+  touches = [touches objectsPassingTest:^(id touch, BOOL *stop) {
+    return [_nativeTouches containsObject:touch];
+  }]; // ]TODO(macOS GH#774)
 
   [self _updateAndDispatchTouches:touches eventName:@"touchStart"];
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This will ignore "touches" (clicks) on `NSScroller` such that JS does not process them resulting in a press event.

## Changelog

[macOS] [Changed] - Don't send events when clicking on scrollbars

## Test Plan

Confirmed clicking scrollbar in rn-tester does not result in a click on the items underneath.

### Before
Both scrollView scroller and content clicks are processed



https://user-images.githubusercontent.com/484044/180582981-78612f6f-fc07-4dd0-b858-bb339162463a.mov


### After
Clicking onto the scrollView scroller > click is ignored
Clicking into the the scrollView > no change of behavior

https://user-images.githubusercontent.com/484044/180582997-e0e02fad-7323-44d0-a8b5-e7f3c739364c.mov


