### PR TITLE
Fix nested Text components not inheriting foreground color from parent

### DIFF
--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -17,6 +17,17 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
 
 @implementation RCTTextAttributes
 
+// [TODO(macOS GH#774)
++ (RCTUIColor *)defaultForegroundColor
+{
+  if (@available(iOS 13.0, *)) {
+    return [RCTUIColor labelColor];
+  } else {
+    return [RCTUIColor blackColor];
+  }
+}
+// ]TODO(macOS GH#774)
+
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -31,13 +42,9 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
     _textShadowRadius = NAN;
     _opacity = NAN;
     _textTransform = RCTTextTransformUndefined;
-    // [TODO(OSS Candidate ISS#2710739)
-    if (@available(iOS 13.0, *)) {
-      _foregroundColor = [RCTUIColor labelColor];
-    } else {
-      _foregroundColor = [RCTUIColor blackColor];
-    }
-    // ]TODO(OSS Candidate ISS#2710739)
+    // [TODO(macOS GH#774)
+    _foregroundColor = [RCTTextAttributes defaultForegroundColor];
+    // ]TODO(macOS GH#774)
   }
 
   return self;
@@ -50,7 +57,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   // We will address this in the future.
 
   // Color
-  _foregroundColor = textAttributes->_foregroundColor ?: _foregroundColor;
+  _foregroundColor = textAttributes->_foregroundColor == [RCTTextAttributes defaultForegroundColor] ? _foregroundColor : textAttributes->_foregroundColor;
   _backgroundColor = textAttributes->_backgroundColor ?: _backgroundColor;
   _opacity = !isnan(textAttributes->_opacity) ? (isnan(_opacity) ? 1.0 : _opacity) * textAttributes->_opacity : _opacity;
 

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1264,4 +1264,17 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'Text components inheriting color from parent',
+    render: function(): React.Node {
+      return (
+        <View style={{marginTop: 10, marginBottom: 10}}>
+          <Text style={{color: 'red'}}>
+            Outer&nbsp;
+            <Text>Inner</Text>
+          </Text>
+        </View>
+      );
+    },
+  },
 ];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

This seems to due RN Mac commits that fix text colors for dark mode:
- https://github.com/microsoft/react-native-macos/commit/8ed55a866a7a71b696da6de464f7a32d99065153
- https://github.com/microsoft/react-native-macos/commit/731a535dca3b16d09ce0288c5cd804ecaba29c98

It works on iOS, web .... so it should behave the same on macOS as well

## Changelog

[macOS] [Fixed] - Fix nested Text components not inheriting foreground color from parent

## Test Plan

Before
<img width="983" alt="before" src="https://user-images.githubusercontent.com/484044/180825829-c3f7f8ee-0c20-4a8f-abc3-d7c9292b945c.png">

After
<img width="989" alt="after" src="https://user-images.githubusercontent.com/484044/180825842-737b8e90-f5c3-4f66-8296-5160bb753bea.png">

iOS - as reference
<img width="764" alt="Screen Shot 2022-07-25 at 9 21 58 AM" src="https://user-images.githubusercontent.com/484044/180827140-e63013e0-6734-46ce-bb86-bc47b7fb76f3.png">


