### PR TITLE
Single line TextInput fixes (prevent newLines, support horizontal overflow)

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
@@ -28,6 +28,10 @@
 
     _backedTextInputView = [[RCTUITextField alloc] initWithFrame:self.bounds];
     _backedTextInputView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+    _backedTextInputView.cell.scrollable = YES;
+    _backedTextInputView.cell.usesSingleLineMode = YES;
+#endif // ]TODO(macOS GH#774)
     _backedTextInputView.textInputDelegate = self;
 
     [self addSubview:_backedTextInputView];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This diff fixes 2 bugs with TextInput:
1. The default macOS behavior for single line text inputs is that they scroll horizontally when they overflow. react-native-macOS was making it paginate instead
2. Single line text input allowed pressing Ctrl+Enter to insert a new line

## Changelog

[macOS] [Fixe] - Single line TextInput fixes (prevent newLines, support horizontal overflow)

## Test Plan

### Before
CTRL + W > adds new line
Text paginates

https://user-images.githubusercontent.com/484044/180829204-a9cc5ceb-c0bf-41ab-9b3b-f938a88bec34.mov


### After
No new lines
Text overflows


https://user-images.githubusercontent.com/484044/180829238-b55318fc-957e-425f-8dc8-35b540b2b9c8.mov



