### PR TITLE
Fix text replacement not working in multiline TextInput

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -46,8 +46,6 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
     _placeholderView.numberOfLines = 0;
     [self addSubview:_placeholderView];
 #else // [TODO(macOS GH#774)
-    NSTextCheckingTypes checkingTypes = 0;
-    self.enabledTextCheckingTypes = checkingTypes;
     self.insertionPointColor = [NSColor selectedControlColor];
     // Fix blurry text on non-retina displays.
     self.canDrawSubviewsIntoLayer = YES;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This bug was due to some code in multiline TextInput which disabled all text checking types by default.
We now match the system default instead.

## Changelog

[macOS] [Fixed] - Fix text replacement not working in multiline TextInput

## Test Plan

Before

https://user-images.githubusercontent.com/484044/180833106-5f84f672-46e8-4970-bdbf-366c73b31e61.mov


After

https://user-images.githubusercontent.com/484044/180833087-4224b1d1-fa20-4894-98fc-4ebc084f4178.mov


