### PR TITLE
Workaround to open file handles for loaded assets

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -905,9 +905,12 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
       }
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
       image = [UIImage imageWithContentsOfFile:filePath];
-#else // TODO(macOS GH#774)
-      image = [[NSImage alloc] initWithContentsOfFile:filePath]; // TODO(macOS GH#774)
-#endif // TODO(macOS GH#774)
+#else // [TODO(macOS GH#774)
+      // macOS keeps file handles in open state for lifetime of image if "initWithContentsOfFile:" is used with path inside app bundle
+      // Workaround is to load file in data and then convert data to image
+      NSData *data = [NSData dataWithContentsOfFile:filePath];
+      image = [[NSImage alloc] initWithData:data];
+#endif // ]TODO(macOS GH#774)
     }
   }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

We ran into an issue that our production app was crashing on certain devices as we opened too many file descriptors (> 256). See some details here: https://wilsonmar.github.io/maximum-limits/

We found that macOS will keep image files handles open for `NSImage` lifetime in some cases:
```
  // this will keep file open only if image is loaded from app bundle
  NSString *path = [[NSBundle mainBundle] pathForResource:@"slider" ofType:@"png" inDirectory:@"assets"];
  _image = [[NSImage alloc] initWithContentsOfFile:path];

  // this will not keep file open
  _image = [[NSImage alloc] initWithContentsOfFile:@"/Users/theUser/Downloads/slider.png"];

  // this will not keep file open
  NSData *data = [NSData dataWithContentsOfFile:path];
  _image = [[NSImage alloc] initWithData:data];
```
This can be documented behavior, but I didn't find any reference in documentation or headers.

## Changelog

[macOS] [Fixed] - Workaround to open file handles for loaded assets

## Test Plan

- build and run prod version of app
- explore open files for Messenger process in Activity Monitor
- confirm no assets are open
