### PR TITLE
Fix event.locationX/Y to be in view's coordinate space

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -221,7 +221,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
   NSEvent *nativeTouch = _nativeTouches[touchIndex];
   CGPoint location = nativeTouch.locationInWindow;
   CGPoint rootViewLocation = CGPointMake(location.x, CGRectGetHeight(self.view.window.frame) - location.y);
-  CGPoint touchViewLocation = rootViewLocation;
+  NSView *touchView = _touchViews[touchIndex];
+  CGPoint touchViewLocation = [touchView convertPoint:location fromView:nil];
 #endif // ]TODO(macOS GH#774)
 
   NSMutableDictionary *reactTouch = _reactTouches[touchIndex];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes an issue on macOS where the `locationX`/`Y` properties would incorrectly match `pageX`/`Y` unlike iOS (see lines 218/219 in the same file) and other platforms.

## Changelog

[macOS] [Fixed] - Fix event.locationX/Y to be in view's coordinate space

## Test Plan

Confirmed `locationX`/`Y` is now correctly reported in the view's coordinate space.

Before
<img width="950" alt="before" src="https://user-images.githubusercontent.com/484044/180836079-1295cb52-7d9f-4db3-bbe0-2ab3c762370f.png">


After
<img width="836" alt="after" src="https://user-images.githubusercontent.com/484044/180836106-2bc44098-138d-4596-bc81-37ddda61d9f6.png">

