### PR TITLE
Pass grammarCheck to text input views for Mac

### DIFF
--- a/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -141,6 +141,7 @@ const RCTTextInputViewConfig = {
     autoCapitalize: true,
     keyboardAppearance: true,
     passwordRules: true,
+    grammarCheck: true, // TODO(macOS GH#774)
     spellCheck: true,
     selectTextOnFocus: true,
     text: true,

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -303,6 +303,14 @@ type IOSProps = $ReadOnly<{|
    */
   scrollEnabled?: ?boolean,
 
+  // [TODO(macOS GH#774)
+  /**
+   * If `false`, disables grammar-check.
+   * @platform macOS
+   */
+  grammarCheck?: ?boolean,
+  // ]TODO(macOS GH#774)
+
   /**
    * If `false`, disables spell-check style (i.e. red underlines).
    * The default value is inherited from `autoCorrect`.

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -48,6 +48,7 @@ RCT_REMAP_VIEW_PROPERTY(placeholderTextColor, backedTextInputView.placeholderCol
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(returnKeyType, backedTextInputView.returnKeyType, UIReturnKeyType) // TODO(macOS GH#774)
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(selectionColor, backedTextInputView.tintColor, UIColor) // TODO(macOS GH#774)
 RCT_REMAP_OSX_VIEW_PROPERTY(selectionColor, backedTextInputView.selectionColor, UIColor) // TODO(macOS GH#774)
+RCT_REMAP_OSX_VIEW_PROPERTY(grammarCheck, backedTextInputView.grammarCheckingEnabled, BOOL) // TODO(macOS GH#774)
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(spellCheck, backedTextInputView.spellCheckingType, UITextSpellCheckingType) // TODO(macOS GH#774)
 RCT_REMAP_OSX_VIEW_PROPERTY(spellCheck, backedTextInputView.continuousSpellCheckingEnabled, BOOL) // TODO(macOS GH#774)
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(caretHidden, backedTextInputView.caretHidden, BOOL) // TODO(macOS GH#774)

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, getter=isAutomaticTextReplacementEnabled) BOOL automaticTextReplacementEnabled;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
 @property (nonatomic, getter=isContinuousSpellCheckingEnabled) BOOL continuousSpellCheckingEnabled;
+@property (nonatomic, getter=isGrammarCheckingEnabled) BOOL grammarCheckingEnabled;
 @property (nonatomic, assign) BOOL enableFocusRing;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor;
 @property (weak, nullable) id<RCTUITextFieldDelegate> delegate;

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -27,6 +27,7 @@
 @property (nonatomic, getter=isAutomaticTextReplacementEnabled) BOOL automaticTextReplacementEnabled;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
 @property (nonatomic, getter=isContinuousSpellCheckingEnabled) BOOL continuousSpellCheckingEnabled;
+@property (nonatomic, getter=isGrammarCheckingEnabled) BOOL grammarCheckingEnabled;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor;
 
 @end
@@ -72,6 +73,7 @@
   fieldEditor.automaticSpellingCorrectionEnabled = self.isAutomaticSpellingCorrectionEnabled;
   fieldEditor.automaticTextReplacementEnabled = self.isAutomaticTextReplacementEnabled;
   fieldEditor.continuousSpellCheckingEnabled = self.isContinuousSpellCheckingEnabled;
+  fieldEditor.grammarCheckingEnabled = self.isGrammarCheckingEnabled;
   NSMutableDictionary *selectTextAttributes = fieldEditor.selectedTextAttributes.mutableCopy;
   selectTextAttributes[NSBackgroundColorAttributeName] = self.selectionColor ?: [NSColor selectedControlColor];
 	fieldEditor.selectedTextAttributes = selectTextAttributes;
@@ -206,6 +208,16 @@
 - (BOOL)isContinuousSpellCheckingEnabled
 {
   return ((RCTUITextFieldCell*)self.cell).isContinuousSpellCheckingEnabled;
+}
+
+- (void)setGrammarCheckingEnabled:(BOOL)grammarCheckingEnabled
+{
+  ((RCTUITextFieldCell*)self.cell).grammarCheckingEnabled = grammarCheckingEnabled;
+}
+
+- (BOOL)isGrammarCheckingEnabled
+{
+  return ((RCTUITextFieldCell*)self.cell).isGrammarCheckingEnabled;
 }
 
 - (void)setSelectionColor:(RCTUIColor *)selectionColor // TODO(OSS Candidate ISS#2710739)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Similar to https://github.com/microsoft/react-native-macos/pull/1292 this adds a macOS only property to toggle grammarCheck on RCTUITextField

## Changelog

[macOS] [Added] - Pass grammarCheck to text input views for Mac

## Test Plan

Using this sample
```
  {
    title: 'Auto-focus',
    render: function (): React.Node {
      return (
      <>
        <TextInput
          spellCheck={true}
          style={{backgroundColor: 'white', margin: 10}}
          accessibilityLabel="spellCheck"
        />        
        <TextInput
          grammarCheck={true}
          style={{backgroundColor: 'white', margin: 10}}
          accessibilityLabel="grammarCheck"
        />
        <TextInput
          autoCorrect={true}
          style={{backgroundColor: 'white', margin: 10}}
          accessibilityLabel="autoFocus"
        />
        <View style={{margin: 50, width:200, height:100, backgroundColor: 'red'}} />
        <TextInput
          spellCheck={false}
          style={{backgroundColor: 'white', margin: 10}}
          accessibilityLabel="spellCheck"
        />        
        <TextInput
          grammarCheck={false}
          style={{backgroundColor: 'white', margin: 10}}
          accessibilityLabel="grammarCheck"
        />
        <TextInput
          autoCorrect={false}
          style={{backgroundColor: 'white', margin: 10}}
          accessibilityLabel="autoFocus"
        />
      </>
      );
    },
  },
```
Before

https://user-images.githubusercontent.com/484044/180891078-c2a8c232-ccc5-45b9-8438-74603792650c.mov


After


https://user-images.githubusercontent.com/484044/180891096-46154fad-2dc3-427a-bfa1-7db8b0c413fc.mov


