### PR TITLE
Escape semi-colon in bash command

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -31,21 +31,11 @@ jobs:
 
       - template: templates/android-build-office.yml
 
-      - template: templates/prep-android-nuget.yml
-
       - template: templates/download-android-dependencies.yml
         parameters:
           artifact_feed: react-native/react-native-public
 
-      # Very similar to the default pack task .. but appends 'ndk21' to the nuget pack version
-      - task: CmdLine@2
-        displayName: 'Verify NuGet can be packed'
-        inputs:
-          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)
-
-      # Android CI doesn't create a nuget now, but this check is failing builds. Quickest fix to unblock builds is to disable the check... but we need to find the root cause and fix it and enable this again.
-      # - script: '[ -f $(System.DefaultWorkingDirectory)/*.nupkg ]'
-      #   displayName: Verify that NuGet was actually created
+      - template: templates/android-nuget-pack.yml
 
       - task: CmdLine@2
         displayName: 'Npm pack'

--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -41,7 +41,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'Verify NuGet can be packed'
         inputs:
-          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
+          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)
 
       # Android CI doesn't create a nuget now, but this check is failing builds. Quickest fix to unblock builds is to disable the check... but we need to find the root cause and fix it and enable this again.
       # - script: '[ -f $(System.DefaultWorkingDirectory)/*.nupkg ]'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -230,18 +230,12 @@ jobs:
         inputs:
           script: node .ado/removeWorkspaceConfig.js
 
-      - template: templates/prep-android-nuget.yml
-
       # Enumerate and download all dependencies ..
       - template: templates/download-android-dependencies.yml
         parameters:
           artifact_feed: Office
 
-      # Very similar to the default pack task .. but appends 'ndk21b' to the nuget pack version
-      - task: CmdLine@2
-        displayName: 'NuGet pack'
-        inputs:
-          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)
+      - template: templates/android-nuget-pack.yml
 
       - task: CmdLine@2
         displayName: 'Npm pack'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -241,7 +241,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'NuGet pack'
         inputs:
-          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK;commitId=$(Build.SourceVersion)
+          script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)
 
       - task: CmdLine@2
         displayName: 'Npm pack'

--- a/.ado/templates/android-nuget-pack.yml
+++ b/.ado/templates/android-nuget-pack.yml
@@ -1,0 +1,15 @@
+steps:
+  - task: PowerShell@2
+    displayName: Extract version from package.json, and put it in `buildNumber` variable
+    inputs:
+      targetType: inline # filePath | inline
+      script: |
+        $lines = Get-Content package.json | Where {$_ -match '^\s*"version":.*'} 
+        $npmVersion = $lines.Trim().Split()[1].Trim('",');
+        echo "##vso[task.setvariable variable=buildNumber]$npmVersion"
+
+  # Very similar to the default pack task .. but appends 'ndk21b' to the nuget pack version
+  - task: CmdLine@2
+    displayName: 'NuGet pack'
+    inputs:
+      script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Trying to perform a nuget pack can result in a failure if a specified path doesn't exist. This should result in the nuget pack task failing. However, due to the use of a semi-colon delimited list for the properties, the command is incorrectly broken up, leading to the exit code not reflecting that of the nuget pack command.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Escape semi-colon in bash command

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Will verify that the pipeline fails, where it was succeeding before. I will then submit this after submitting a fix to the failing pack task.
