### PR TITLE
Honor enableFocusRing flag for multiline textFields

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -95,7 +95,7 @@
 - (void)setEnableFocusRing:(BOOL)enableFocusRing {
   [super setEnableFocusRing:enableFocusRing];
   if ([_scrollView respondsToSelector:@selector(setEnableFocusRing:)]) {
-    [_scrollView setEnableFocusRing:YES];
+    [_scrollView setEnableFocusRing:enableFocusRing];
   }
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes a regression introduced in https://github.com/microsoft/react-native-macos/pull/1276
We should respect the boolean flag sent from JS to enable/disable the focusRing

## Changelog

[macOS] [Fixed] - Honor enableFocusRing flag for multiline textFields

## Test Plan

Used this example
```
  {
    title: 'Multiline true',
    render: function(): React.Node {
      return (
        <TextInput
          multiline={true}
          accessibilityLabel="I am the accessibility label for text input"
        />
      );
    },
  },
  {
    title: 'Multiline true, enableFocusRing true',
    render: function(): React.Node {
      return (
        <TextInput
          multiline={true}
          enableFocusRing={true}
          accessibilityLabel="I am the accessibility label for text input"
        />
      );
    },
  },    
  {
    title: 'Multiline true, enableFocusRing false',
    render: function(): React.Node {
      return (
        <TextInput
          multiline={true}
          enableFocusRing={false}
          accessibilityLabel="I am the accessibility label for text input"
        />
      );
    },
  }, 
```

Before


https://user-images.githubusercontent.com/484044/181436683-66662c35-51c4-45ae-830a-311aebf5d23d.mov


After

https://user-images.githubusercontent.com/484044/181436636-bbbee197-05b3-4c4e-b2f4-6399b6d152d5.mov


