### PR TITLE
[RN][macos] Enable Hermes for RNTester

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -86,7 +86,7 @@ end
 
 target 'RNTester-macOS' do
   platform :osx, '10.15'
-  pods(:hermes_enabled => false)
+  pods()
 end
 
 target 'RNTester-macOSUnitTests' do

--- a/packages/rn-tester/RNTester-macOS/AppDelegate.mm
+++ b/packages/rn-tester/RNTester-macOS/AppDelegate.mm
@@ -8,8 +8,21 @@
 
 #import "AppDelegate.h"
 
-#import <React/CoreModulesPlugins.h>
+#ifndef RCT_USE_HERMES
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#define RCT_USE_HERMES 1
+#else
+#define RCT_USE_HERMES 0
+#endif
+#endif
+
+#if RCT_USE_HERMES
+#import <reacthermes/HermesExecutorFactory.h>
+#else
 #import <React/JSCExecutorFactory.h>
+#endif
+
+#import <React/CoreModulesPlugins.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTCxxBridgeDelegate.h>
@@ -106,7 +119,11 @@ NSString *kBundleNameJS = @"RNTesterApp";
 #endif
 
   __weak __typeof(self) weakSelf = self;
+#if RCT_USE_HERMES
+  return std::make_unique<facebook::react::HermesExecutorFactory>(
+#else
   return std::make_unique<facebook::react::JSCExecutorFactory>(
+#endif
       facebook::react::RCTJSIExecutorRuntimeInstaller([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
         if (!bridge) {
           return;


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

On RN Core, Hermes for iOS can be enabled by setting a flag in the Podfile & running `pod install`
https://reactnative.dev/docs/hermes#ios
> Since React Native 0.64, Hermes also runs on iOS. To enable Hermes for iOS, edit your ios/Podfile file and make the change illustrated below:
```
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods
     # By default, Hermes is disabled on Old Architecture, and enabled on New Architecture.
     # You can enable/disable it manually by replacing `flags[:hermes_enabled]` with `true` or `false`.
     :hermes_enabled => true
   )
```
In Core RNTester for iOS, ~~Hermes is enabled by default~~ 
Not until 0.70 - https://github.com/facebook/react-native/blob/0.70-stable/scripts/react_native_pods.rb#L41
```
def use_react_native! (
  path: "../node_modules/react-native",
  fabric_enabled: false,
  new_arch_enabled: ENV['RCT_NEW_ARCH_ENABLED'] == '1',
  production: ENV['PRODUCTION'] == '1',
  hermes_enabled: true,
  flipper_configuration: FlipperConfiguration.disabled,
  app_path: '..',
  config_file_dir: '')
```
This will build & install the Hermes runtime & enable the `RCT_USE_HERMES` macro.
https://github.com/microsoft/react-native-macos/blob/main/packages/rn-tester/RNTester/AppDelegate.mm#L10-L16

In 0.69 Hermes is disabled by default - https://github.com/facebook/react-native/blob/0.69-stable/scripts/react_native_pods.rb#L31

---

On RN Desktop, the Hermes flag was disabled #780 due to M1 build reasons which have since been resolved. #952 #781 

Curiously, the `RNTester-macOS` target AppDelegate was never updated to use Hermes once the Pod was added. 
Only the `RNTester` target for mobile had the correct Hermes usage.

**RNTester-macOS:** https://github.com/microsoft/react-native-macos/blob/main/packages/rn-tester/RNTester-macOS/AppDelegate.mm
**RNTester:** https://github.com/microsoft/react-native-macos/blob/main/packages/rn-tester/RNTester/AppDelegate.mm

**This change will not enable Hermes by default on RNTester.** Pass `USE_HERMES=1`to `pod install` to enable.

---

The documentation for enabling Hermes on RN Desktop macOS can be simplified now.
https://microsoft.github.io/react-native-windows/docs/hermes#hermes-on-macos

> Install the npm package yarn add 'hermes-engine-darwin@^0.4.3'
* `hermes-engine-darwin` is no longer published/required #952 

> Add (or uncomment) the following pod dependencies to your macOS target in your Podfile:
pod 'React-Core/Hermes', :path => '../node_modules/react-native-macos/'
pod 'hermes', :path => '../node_modules/hermes-engine-darwin'
pod 'libevent', :podspec => '../node_modules/react-native-macos/third-party-podspecs/libevent.podspec'
* Setting `:hermes_enabled => true` in Podfile should do all of the above.
---

## Changelog

[macOS] [pod] Copy Hermes support to `RNTester-macOS` AppDelegate
[macOS] [pod] Remove `pods(:hermes_enabled => true)` in favor of using envvar `USE_HERMES=1` during `pod install`.
 
## Test Plan

**RNTester with Hermes enabled:**

```
cd packages/rn-tester

# Ensure fresh pod install. I noticed `RCT_USE_HERMES` would sometimes not work w/o full clean/rebuild
rm -rf Pods 

# Install pods w/ Hermes flag
USE_HERMES=1 bundle exec pod install --verbose

# Note the installing (or downloading) of hermes-engine

-> Installing hermes-engine (0.11.0)
  > Copying hermes-engine from `/Users/shawndempsey/Library/Caches/CocoaPods/Pods/Release/hermes-engine/0.11.0-84e3a` to `Pods/hermes-engine`

# Open in xcode
open RNTesterPods.xcworkspace
```

https://user-images.githubusercontent.com/96719/181855745-d21f0379-307d-4803-863d-120fb66e5998.mp4

 