### PR TITLE
Hardcode ndk

### DIFF
--- a/.ado/templates/android-nuget-pack.yml
+++ b/.ado/templates/android-nuget-pack.yml
@@ -12,4 +12,4 @@ steps:
   - task: CmdLine@2
     displayName: 'NuGet pack'
     inputs:
-      script: NDK=ndk`cat ${ANDROID_SDK_ROOT}/ndk-bundle/source.properties 2>&1 | grep Pkg.Revision | awk '{ print $3}' | awk -F. '{ print $1 }'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)
+      script: NDK=ndk`./gradlew -q ReactAndroid:properties | grep ndkVersion | awk -F: '{print $2}' | awk -F. '{print $1}' | xargs`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)

--- a/.ado/templates/android-nuget-pack.yml
+++ b/.ado/templates/android-nuget-pack.yml
@@ -12,4 +12,4 @@ steps:
   - task: CmdLine@2
     displayName: 'NuGet pack'
     inputs:
-      script: NDK=ndk`./gradlew -q ReactAndroid:properties | grep ndkVersion | awk '{print $2}' | awk -F. '{print $1}'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)
+      script: NDK=ndk`$(System.DefaultWorkingDirectory)/gradlew -q ReactAndroid:properties | grep ndkVersion | awk '{print $2}' | awk -F. '{print $1}'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)

--- a/.ado/templates/android-nuget-pack.yml
+++ b/.ado/templates/android-nuget-pack.yml
@@ -12,4 +12,4 @@ steps:
   - task: CmdLine@2
     displayName: 'NuGet pack'
     inputs:
-      script: NDK=ndk`./gradlew -q ReactAndroid:properties | grep ndkVersion | awk -F: '{print $2}' | awk -F. '{print $1}' | xargs`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)
+      script: NDK=ndk`./gradlew -q ReactAndroid:properties | grep ndkVersion | awk '{print $2}' | awk -F. '{print $1}'`; mono $(System.DefaultWorkingDirectory)/nuget-bin/nuget.exe pack $(System.DefaultWorkingDirectory)/ReactAndroid/ReactAndroid.nuspec -OutputDirectory $(Build.StagingDirectory)/final -Properties buildNumber=$(buildNumber)-$NDK\;commitId=$(Build.SourceVersion)

--- a/.ado/templates/prep-android-nuget.yml
+++ b/.ado/templates/prep-android-nuget.yml
@@ -1,9 +1,0 @@
-steps:
-  - task: PowerShell@2
-    displayName: Extract version from package.json, and put it in `buildNumber` variable
-    inputs:
-      targetType: inline # filePath | inline
-      script: |
-        $lines = Get-Content package.json | Where {$_ -match '^\s*"version":.*'} 
-        $npmVersion = $lines.Trim().Split()[1].Trim('",');
-        echo "##vso[task.setvariable variable=buildNumber]$npmVersion"

--- a/android-patches/patches/Build/ReactAndroid/build.gradle
+++ b/android-patches/patches/Build/ReactAndroid/build.gradle
@@ -1,6 +1,19 @@
---- ./ReactAndroid/build.gradle	2022-01-11 17:41:28.000000000 -0800
-+++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/Build/ReactAndroid/build.gradle	2022-01-12 15:51:37.000000000 -0800
-@@ -41,6 +41,8 @@
+diff --git a/ReactAndroid/build.gradle b/ReactAndroid/build.gradle
+index 3c23c6a84b4..183bffe7164 100644
+--- a/ReactAndroid/build.gradle
++++ b/ReactAndroid/build.gradle
+@@ -12,6 +12,10 @@ plugins {
+     id("de.undercouch.download")
+ }
+ 
++rootProject.ext {
++    ndkVersion="21.1.6352462"
++}
++
+ import com.facebook.react.tasks.internal.*
+ 
+ import java.nio.file.Paths
+@@ -41,6 +45,8 @@ def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
  // and the build will use that.
  def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
  
@@ -9,7 +22,7 @@
  // Setup build type for NDK, supported values: {debug, release}
  def nativeBuildType = System.getenv("NATIVE_BUILD_TYPE") ?: "release"
  
-@@ -86,11 +88,22 @@
+@@ -86,11 +92,22 @@ task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
      dest(new File(downloadsDir, "folly-${FOLLY_VERSION}.tar.gz"))
  }
  
@@ -32,7 +45,7 @@
      includeEmptyDirs = false
      into("$thirdPartyNdkDir/folly")
  }
-@@ -144,6 +157,14 @@
+@@ -144,6 +161,14 @@ task prepareHermes(dependsOn: createNativeDepsDirectories, type: Copy) {
      into "$thirdPartyNdkDir/hermes"
  }
  
@@ -47,7 +60,7 @@
  task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
      src("https://github.com/google/glog/archive/v${GLOG_VERSION}.tar.gz")
      onlyIfNewer(true)
-@@ -315,6 +336,7 @@
+@@ -315,6 +340,7 @@ android {
                          "REACT_COMMON_DIR=$projectDir/../ReactCommon",
                          "REACT_GENERATED_SRC_DIR=$buildDir/generated/source",
                          "REACT_SRC_DIR=$projectDir/src/main/java/com/facebook/react",
@@ -55,7 +68,7 @@
                          "-j${ndkBuildJobs()}"
  
                  if (Os.isFamily(Os.FAMILY_MAC)) {
-@@ -339,7 +361,7 @@
+@@ -339,7 +365,7 @@ android {
          }
      }
  

--- a/android-patches/patches/Build/ReactAndroid/build.gradle
+++ b/android-patches/patches/Build/ReactAndroid/build.gradle
@@ -7,7 +7,7 @@ index 3c23c6a84b4..183bffe7164 100644
  }
  
 +rootProject.ext {
-+    ndkVersion="21.1.6352462"
++    ndkVersion="21.4.7075529"
 +}
 +
  import com.facebook.react.tasks.internal.*

--- a/android-patches/patches/Build/build.gradle.kts
+++ b/android-patches/patches/Build/build.gradle.kts
@@ -1,0 +1,14 @@
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 4725963eae0..7c71d628832 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -5,9 +5,6 @@
+  * LICENSE file in the root directory of this source tree.
+  */
+ 
+-val ndkPath by extra(System.getenv("ANDROID_NDK"))
+-val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION"))
+-
+ buildscript {
+     repositories {
+         google()


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
After switching from building native libraries by manually invoking ndk-build, to using the Android gradle plugin, the method of querying which ndk is being no longer works. To address this, we will hardcode, via a patch, which ndk is being used. This will also ensure that we are using the same ndk that Office is being built with.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Hardcode ndk version

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Ensure that the ndk is properly queried.