### PR TITLE
Revert "Alleviate excessive layout jittering when resizing window (#439)"

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -33,10 +33,6 @@
 #import "RCTDevMenu.h"
 #endif // ]TODO(OSS Candidate ISS#2710739)
 
-#if TARGET_OS_OSX // [TODO(macOS GH#774)
-#define RCT_LAYOUT_THROTTLE 0.25
-#endif // ]TODO(macOS GH#774)
-
 NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";
 
 @interface RCTUIManager (RCTRootView)
@@ -51,11 +47,6 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
   RCTRootContentView *_contentView;
   BOOL _passThroughTouches;
   CGSize _intrinsicContentSize;
-
-#if TARGET_OS_OSX // [TODO(macOS GH#774)
-  NSDate *_lastLayout;
-  BOOL _throttleLayout;
-#endif // ]TODO(macOS GH#774)
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -84,10 +75,6 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
     _loadingViewFadeDuration = 0.25;
     _sizeFlexibility = RCTRootViewSizeFlexibilityNone;
     _minimumSize = CGSizeZero;
-
-#if TARGET_OS_OSX // [TODO(macOS GH#774)
-    _lastLayout = [NSDate new];
-#endif // ]TODO(macOS GH#774)
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(bridgeDidReload)
@@ -181,35 +168,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 
   return fitSize;
 }
-
-#if TARGET_OS_OSX // [TODO(macOS GH#774)
-// TODO: https://github.com/microsoft/react-native-macos/issues/459
-// This is a workaround for window resizing events overloading the shadow queue:
-//  - https://github.com/microsoft/react-native-macos/issues/322
-//  - https://github.com/microsoft/react-native-macos/issues/422
-// We should revisit this issue when we switch over to Fabric.
-- (void)layout
-{
-  if (self.window != nil && !_throttleLayout) {
-    NSTimeInterval interval = [[NSDate date] timeIntervalSinceDate:_lastLayout];
-    if (interval >= RCT_LAYOUT_THROTTLE) {
-      _lastLayout = [NSDate new];
-      [self layoutSubviews];
-    } else {
-      _throttleLayout = YES;
-      __weak typeof(self) weakSelf = self;
-      int64_t delta = (RCT_LAYOUT_THROTTLE - interval) * NSEC_PER_SEC;
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delta), dispatch_get_main_queue(), ^{
-        typeof(self) strongSelf = weakSelf;
-        if (strongSelf != nil) {
-          strongSelf->_throttleLayout = NO;
-          [strongSelf setNeedsLayout];
-        }
-      });
-    }
-  }
-}
-#endif // ]TODO(macOS GH#774)
 
 - (void)layoutSubviews
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This change reverts https://github.com/microsoft/react-native-macos/pull/439 - but still tries to address the original issues:
- https://github.com/microsoft/react-native-macos/issues/422
- https://github.com/microsoft/react-native-macos/issues/322

and the follow up https://github.com/microsoft/react-native-macos/issues/459

This also addresses an issue when programmatically resizing windows where the ```RCTRootContentView``` may end up at the wrong size because an in-flight layout gets resolved after the resize on the main thread.
We now keep sync dispatch on the shadow queue for live resizing windows (to prevent tearing) but also dispatch async (as done on iOS) so the latest new size is sure to win.
The block has a check to bail if the size doesn't change, so this isn't a perf drain running the block twice.

## Changelog

[macOS] [Changed] - Revert "Alleviate excessive layout jittering when resizing window (#439)"

## Test Plan

### Before
Works - but resizing drags ...

https://youtu.be/obQwaxcL48k

### Revert 439
Doesn't work

https://youtu.be/LV00uFOBddY

### Ater
Works and resizing is smooth

https://youtu.be/rzp1H_tfqGY
