### PR TITLE
Remove TextInput setting insertionPointColor

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -46,7 +46,6 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
     _placeholderView.numberOfLines = 0;
     [self addSubview:_placeholderView];
 #else // [TODO(macOS GH#774)
-    self.insertionPointColor = [NSColor selectedControlColor];
     // Fix blurry text on non-retina displays.
     self.canDrawSubviewsIntoLayer = YES;
     self.allowsUndo = YES;
@@ -131,7 +130,7 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
   NSMutableDictionary *selectTextAttributes = self.selectedTextAttributes.mutableCopy;
   selectTextAttributes[NSBackgroundColorAttributeName] = selectionColor ?: [NSColor selectedControlColor];
   self.selectedTextAttributes = selectTextAttributes.copy;
-  self.insertionPointColor = self.selectionColor ?: [NSColor selectedControlColor];
+  self.insertionPointColor = self.selectionColor ?: [NSColor textColor];
 }
 
 - (RCTUIColor*)selectionColor

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -77,7 +77,6 @@
   NSMutableDictionary *selectTextAttributes = fieldEditor.selectedTextAttributes.mutableCopy;
   selectTextAttributes[NSBackgroundColorAttributeName] = self.selectionColor ?: [NSColor selectedControlColor];
 	fieldEditor.selectedTextAttributes = selectTextAttributes;
-  fieldEditor.insertionPointColor = self.selectionColor ?: [RCTUIColor selectedControlColor];
   return fieldEditor;
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

We should not be setting the insertionPointColor by default.
Let the OS do its thing.
Later we can consider exposing a prop for this but the default should be to not set it.

## Changelog

[macOS] [Changed] - Remove TextInput setting insertionPointColor

## Test Plan

Setting a purple ```selectionColor``` on the texInput fields

```
selectionColor='purple'
```

### Before

<img width="956" alt="before" src="https://user-images.githubusercontent.com/484044/182494647-85946983-936a-4792-a350-518f8b7e7009.png">

<img width="972" alt="before2" src="https://user-images.githubusercontent.com/484044/182494652-a4433404-cd9f-4db8-a5e9-bac09be04198.png">


### After

<img width="961" alt="after" src="https://user-images.githubusercontent.com/484044/182494674-6714694f-91b4-4b79-ac02-249b091f7492.png">

<img width="950" alt="after2" src="https://user-images.githubusercontent.com/484044/182494675-cac93541-f8fd-46c8-8bf8-6e5a353de6e5.png">

