### PR TITLE
Pass callbacks for when grammarCheck, spellCheck and autoCorrect are changed on macOS

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -130,6 +130,13 @@ export type EditingEvent = SyntheticEvent<
   |}>,
 >;
 
+// macOS-only // [TODO(macOS GH#774)
+export type SettingChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    enabled: boolean,
+  |}>,
+>; // ]TODO(macOS GH#774)
+
 type DataDetectorTypesType =
   // iOS+macOS
   | 'phoneNumber'
@@ -306,7 +313,7 @@ type IOSProps = $ReadOnly<{|
   // [TODO(macOS GH#774)
   /**
    * If `false`, disables grammar-check.
-   * @platform macOS
+   * @platform macos
    */
   grammarCheck?: ?boolean,
   // ]TODO(macOS GH#774)
@@ -636,6 +643,38 @@ export type Props = $ReadOnly<{|
    * Changed text is passed as an argument to the callback handler.
    */
   onChangeText?: ?(text: string) => mixed,
+
+  // [TODO(macOS GH#774)
+  /**
+   * Callback that is called when the text input's autoCorrect setting changes.
+   * This will be called with
+   * `{ nativeEvent: { enabled } }`.
+   * Does only work with 'multiline={true}'.
+   *
+   * @platform macos
+   */
+  onAutoCorrectChange?: ?(e: SettingChangeEvent) => mixed,
+
+  /**
+   * Callback that is called when the text input's spellCheck setting changes.
+   * This will be called with
+   * `{ nativeEvent: { enabled } }`.
+   * Does only work with 'multiline={true}'.
+   *
+   * @platform macos
+   */
+  onSpellCheckChange?: ?(e: SettingChangeEvent) => mixed,
+
+  /**
+   * Callback that is called when the text input's grammarCheck setting changes.
+   * This will be called with
+   * `{ nativeEvent: { enabled } }`.
+   * Does only work with 'multiline={true}'.
+   *
+   * @platform macos
+   */
+  onGrammarCheckChange?: ?(e: SettingChangeEvent) => mixed,
+  // ]TODO(macOS GH#774)
 
   /**
    * DANGER: this API is not stable and will change in the future.

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -125,6 +125,24 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
 }
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
+- (void)toggleAutomaticSpellingCorrection:(id)sender
+{
+  self.automaticSpellingCorrectionEnabled = !self.isAutomaticSpellingCorrectionEnabled;
+  [_textInputDelegate automaticSpellingCorrectionDidChange:self.isAutomaticSpellingCorrectionEnabled];
+}
+
+- (void)toggleContinuousSpellChecking:(id)sender
+{
+  self.continuousSpellCheckingEnabled = !self.isContinuousSpellCheckingEnabled;
+  [_textInputDelegate continuousSpellCheckingDidChange:self.isContinuousSpellCheckingEnabled];
+}
+
+- (void)toggleGrammarChecking:(id)sender
+{
+  self.grammarCheckingEnabled = !self.isGrammarCheckingEnabled;
+  [_textInputDelegate grammarCheckingDidChange:self.isGrammarCheckingEnabled];
+}
+
 - (void)setSelectionColor:(RCTUIColor *)selectionColor
 {
   NSMutableDictionary *selectTextAttributes = self.selectedTextAttributes.mutableCopy;

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
@@ -22,6 +22,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)textInputShouldReturn; // May be called right before `textInputShouldEndEditing` if "Return" button was pressed.
 - (void)textInputDidReturn;
 
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+- (void)automaticSpellingCorrectionDidChange:(BOOL)enabled;
+- (void)continuousSpellCheckingDidChange:(BOOL)enabled;
+- (void)grammarCheckingDidChange:(BOOL)enabled;
+#endif // ]TODO(macOS GH#774)
+
 /*
  * Called before any change in the TextInput. The delegate has the opportunity to change the replacement string or reject the change completely.
  * To change the replacement, return the changed version of the `text`.

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -42,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onChangeSync;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onTextInput;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onScroll;
+#if TARGET_OS_OSX // TODO(macOS GH#774)
+@property (nonatomic, copy, nullable) RCTBubblingEventBlock onAutoCorrectChange;
+@property (nonatomic, copy, nullable) RCTBubblingEventBlock onSpellCheckChange;
+@property (nonatomic, copy, nullable) RCTBubblingEventBlock onGrammarCheckChange;
+#endif // TODO(macOS GH#774)
 
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, assign, readonly) NSInteger nativeEventCount;

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -402,6 +402,29 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
                                eventCount:_nativeEventCount];
 }
 
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+- (void)automaticSpellingCorrectionDidChange:(BOOL)enabled
+{
+  if (_onAutoCorrectChange) {
+    _onAutoCorrectChange(@{@"enabled": [NSNumber numberWithBool:enabled]});
+  }
+}
+
+- (void)continuousSpellCheckingDidChange:(BOOL)enabled
+{
+  if (_onSpellCheckChange) {
+    _onSpellCheckChange(@{@"enabled": [NSNumber numberWithBool:enabled]});
+  }
+}
+
+- (void)grammarCheckingDidChange:(BOOL)enabled
+{
+  if (_onGrammarCheckChange) {
+    _onGrammarCheckChange(@{@"enabled": [NSNumber numberWithBool:enabled]});
+  }
+}
+#endif // ]TODO(macOS GH#774)
+
 - (BOOL)textInputShouldReturn
 {
   // We send `submit` event here, in `textInputShouldReturn`

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -67,6 +67,12 @@ RCT_EXPORT_VIEW_PROPERTY(inputAccessoryViewID, NSString)
 RCT_EXPORT_VIEW_PROPERTY(textContentType, NSString)
 RCT_EXPORT_VIEW_PROPERTY(passwordRules, NSString)
 
+#if TARGET_OS_OSX // TODO(macOS GH#774)
+RCT_EXPORT_VIEW_PROPERTY(onAutoCorrectChange, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onSpellCheckChange, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onGrammarCheckChange, RCTBubblingEventBlock);
+#endif // TODO(macOS GH#774)
+
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onKeyPressSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChangeSync, RCTDirectEventBlock)

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -18,12 +18,16 @@ const {
   Text,
   TextInput,
   View,
+  Platform, // TODO(macOS GH#774)
   StyleSheet,
   Slider,
   Switch,
   Alert,
 } = require('react-native');
-import type {KeyboardType} from 'react-native/Libraries/Components/TextInput/TextInput';
+import type {
+  KeyboardType,
+  SettingChangeEvent,
+} from 'react-native/Libraries/Components/TextInput/TextInput'; // [TODO(macOS GH#774)
 
 const TextInputSharedExamples = require('./TextInputSharedExamples.js');
 
@@ -322,6 +326,39 @@ const styles = StyleSheet.create({
     width: 24,
   },
 });
+
+// [TODO(macOS GH#774)
+function AutoCorrectSpellCheckGrammarCheckCallbacks(): React.Node {
+  const [enableAutoCorrect, setEnableAutoCorrect] = React.useState(false);
+  const [enableSpellSpeck, setEnableSpellSpeck] = React.useState(false);
+  const [enableGrammarCheck, setEnableGrammarCheck] = React.useState(false);
+  return (
+    <>
+      <Text>
+        enableAutoCorrect: {enableAutoCorrect ? 'enabled' : 'disabled'}
+      </Text>
+      <Text>enableSpellSpeck: {enableSpellSpeck ? 'enabled' : 'disabled'}</Text>
+      <Text>
+        enableGrammarCheck: {enableGrammarCheck ? 'enabled' : 'disabled'}
+      </Text>
+      <TextInput
+        autoCorrect={enableAutoCorrect}
+        style={{padding: 10, marginTop: 10}}
+        multiline={true}
+        onAutoCorrectChange={(event: SettingChangeEvent) =>
+          setEnableAutoCorrect(event.nativeEvent.enabled)
+        }
+        onSpellCheckChange={(event: SettingChangeEvent) =>
+          setEnableSpellSpeck(event.nativeEvent.enabled)
+        }
+        onGrammarCheckChange={(event: SettingChangeEvent) =>
+          setEnableGrammarCheck(event.nativeEvent.enabled)
+        }
+      />
+    </>
+  );
+}
+// ]TODO(macOS GH#774)
 
 exports.displayName = (undefined: ?string);
 exports.title = 'TextInput';
@@ -818,3 +855,14 @@ exports.examples = ([
     },
   },
 ]: Array<RNTesterModuleExample>);
+// [TODO(macOS GH#774)
+if (Platform.OS === 'macos') {
+  exports.examples.push({
+    title:
+      'AutoCorrect, spellCheck and grammarCheck callbacks - Multiline Textfield',
+    render: function (): React.Node {
+      return <AutoCorrectSpellCheckGrammarCheckCallbacks />;
+    },
+  });
+}
+// ]TODO(macOS GH#774)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When users change spellCheck, grammarCheck or autoCorrect in the context menu, one of 3 callbacks for MULTILINE inputs are called:
- toggleGrammarChecking
- toggleContinuousSpellChecking
- toggleAutomaticSpellingCorrection

If JS is going to be the source of truth for text proofing settings, we should have a way to notify JS when these settings are changed from the native side.

## Changelog

[macOS] [Added] - Pass callbacks for when grammarCheck, spellCheck and autoCorrect are changed on macOS

## Test Plan

Added Example

https://user-images.githubusercontent.com/484044/182961942-8b747b59-1c43-4e73-8349-742f77f7aac7.mov



