### PR TITLE
Ensure we pass `--frozen-lockfile` for reproducible CI

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -147,7 +147,7 @@ jobs:
         inputs:
           script: |
             cd packages/react-native-macos-init
-            yarn install
+            yarn install --frozen-lockfile
 
       - task: CmdLine@2
         displayName: yarn build

--- a/.ado/templates/apple-job-javascript.yml
+++ b/.ado/templates/apple-job-javascript.yml
@@ -12,8 +12,10 @@ steps:
       slice_name: ${{ parameters.slice_name }}
       xcode_version: ${{ parameters.xcode_version }}
 
-  - script: 'yarn install'
-    displayName: 'yarn install'
+  - task: CmdLine@2
+    displayName: yarn install
+    inputs:
+      script: yarn install --frozen-lockfile
 
   - task: CmdLine@2
     displayName: yarn test-ci [test]

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -27,7 +27,7 @@ steps:
   - task: CmdLine@2
     displayName: yarn install
     inputs:
-      script: yarn install
+      script: yarn install --frozen-lockfile
 
   - task: CmdLine@2
     displayName: pod install


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

See https://classic.yarnpkg.com/lang/en/docs/cli/install/

We should pass `--frozen-lockfile` to any `yarn install` invocation to make sure we respect the locally checked in lock file.

## Changelog

[Internal] [Fixed] - Ensure we pass `--frozen-lockfile` for reproducible CI

## Test Plan

CI should pass
