### PR TITLE
Add fragmentLinePadding for multiline shadow view to track TextView correctly

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -225,7 +225,19 @@
 
   if (!_textStorage) {
     _textContainer = [NSTextContainer new];
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
     _textContainer.lineFragmentPadding = 0.0; // Note, the default value is 5.
+#else
+    // macOS has a bug in multiline where setting the real text view's lineFragmentPadding to 0 will
+    // cause the scroll view to scroll to top when inserting a newline at the bottom of
+    // a NSTextView when it has more rows than can be displayed on screen. The shadow needs to match
+    // the NSTextView that it is tracking.
+    if (_maximumNumberOfLines != 1) {
+      _textContainer.lineFragmentPadding = 1;
+    } else {
+      _textContainer.lineFragmentPadding = 0.0; // Note, the default value is 5.
+    }
+#endif // ]TODO(macOS GH#774)
     _layoutManager = [NSLayoutManager new];
     [_layoutManager addTextContainer:_textContainer];
     _textStorage = [NSTextStorage new];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Shadow views are used to calculate the container's size using NSTextContainer + NSLayoutManager + NSTextStorage according to https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextLayout/Tasks/StringHeight.html.

However, when typing certain text, the TextView itself overflows, but its container doesn't.
This means our shadow view isn't tracking the TextView correctly.
Root cause was that we added a 1px lineFragmentPadding in https://github.com/microsoft/react-native-macos/pull/640, but we didn't add the save padding in our shadow view.

## Changelog

[macOS] [Fixed] - Add fragmentLinePadding for multiline shadow view to track TextView correctly

## Test Plan

- Shrink app to minimum width
- Type some text which overflows

### Before

https://user-images.githubusercontent.com/484044/183131964-82a32954-3420-4dbe-ae74-4de1aae5bc0e.mov


### After

https://user-images.githubusercontent.com/484044/183131945-b8134e20-56b3-434f-a347-f4b303c7b60c.mov


