### PR TITLE
Refactor handling of keyDown/keyUp

### DIFF
--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -25,6 +25,10 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 
 - (BOOL)becomeFirstResponder;
 - (BOOL)resignFirstResponder;
+
+#if TARGET_OS_OSX
+- (BOOL)handleKeyboardEvent:(NSEvent *)event;
+#endif
 // ]TODO(OSS Candidate ISS#2710739)
 
 /**

--- a/React/Views/RCTViewKeyboardEvent.h
+++ b/React/Views/RCTViewKeyboardEvent.h
@@ -7,33 +7,11 @@
 #import <React/RCTComponentEvent.h>
 
 @interface RCTViewKeyboardEvent : RCTComponentEvent
-+ (instancetype)keyDownEventWithReactTag:(NSNumber *)reactTag
-                             capsLockKey:(BOOL)capsLockKey
-                             shiftKey:(BOOL)shiftKey
-                              ctrlKey:(BOOL)controlKey
-                               altKey:(BOOL)optionKey
-                              metaKey:(BOOL)commandKey
-                        numericPadKey:(BOOL)numericPadKey
-                              helpKey:(BOOL)helpKey
-                          functionKey:(BOOL)functionKey
-                         leftArrowKey:(BOOL)leftArrowKey
-                        rightArrowKey:(BOOL)rightArrowKey
-                           upArrowKey:(BOOL)upArrowKey
-                         downArrowKey:(BOOL)downArrowKey
-                                  key:(NSString *)key;
 
-+ (instancetype)keyUpEventWithReactTag:(NSNumber *)reactTag
-                           capsLockKey:(BOOL)capsLockKey
-                              shiftKey:(BOOL)shiftKey
-                               ctrlKey:(BOOL)controlKey
-                                altKey:(BOOL)optionKey
-                               metaKey:(BOOL)commandKey
-                         numericPadKey:(BOOL)numericPadKey
-                               helpKey:(BOOL)helpKey
-                           functionKey:(BOOL)functionKey
-                          leftArrowKey:(BOOL)leftArrowKey
-                         rightArrowKey:(BOOL)rightArrowKey
-                            upArrowKey:(BOOL)upArrowKey
-                          downArrowKey:(BOOL)downArrowKey
-                                   key:(NSString *)key;
+#if TARGET_OS_OSX // TODO(macOS GH#774)
++ (NSDictionary *)bodyFromEvent:(NSEvent *)event;
++ (NSString *)keyFromEvent:(NSEvent *)event;
++ (instancetype)keyEventFromEvent:(NSEvent *)event reactTag:(NSNumber *)reactTag;
+#endif // TODO(macOS GH#774)
+
 @end

--- a/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
+++ b/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
@@ -53,7 +53,7 @@ class KeyEventExample extends React.Component<{}, State> {
           {Platform.OS === 'macos' ? (
             <View
               focusable={true}
-              validKeysDown={['g', 'Tab', 'Esc', 'Enter', 'ArrowLeft']}
+              validKeysDown={['g', 'Tab', 'Escape', 'Enter', 'ArrowLeft']}
               onKeyDown={this.onKeyDownEvent}
               validKeysUp={['c', 'd']}
               onKeyUp={this.onKeyUpEvent}>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This refactors / simplifies certain keyUp|Down event handling.
It will make a later change (adding textInput handling for textInput fields) easier (to review)

## Changelog

[macOS] [Changed] - Refactor handling of keyDown/keyUp

## Test Plan
Note: The button example is not working ...
Before

https://user-images.githubusercontent.com/484044/183511767-faeda05f-a4fe-44b0-8e62-3cf867b31767.mov

After

https://user-images.githubusercontent.com/484044/183511929-5ccf002b-262d-4153-9ce8-85305a4237c9.mov



