### PR TITLE
Prevent Tab moving focus from multiline TextInput

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -412,6 +412,14 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
       [_backedTextInputView.window makeFirstResponder:nil];
       commandHandled = YES;
     }
+    // tab
+  } else if (commandSelector == @selector(insertTab:) ) {
+    [_backedTextInputView.window selectNextKeyView:nil];
+    commandHandled = YES;
+    // shift-tab
+  } else if (commandSelector == @selector(insertBacktab:)) {
+    [_backedTextInputView.window selectPreviousKeyView:nil];
+    commandHandled = YES;
     //backspace
   } else if (commandSelector == @selector(deleteBackward:)) {
     commandHandled = textInputDelegate != nil && ![textInputDelegate textInputShouldHandleDeleteBackward:_backedTextInputView];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This matches the behavior we already have on Windows.
We almost never want the Tab key to insert a Tab character, so it makes sense allow the Tab to navigate focus as expected.
Even if we did want to use `TextInput` for something like a text editor, the `Tab` key would need to be overridden from JS to insert spaces instead or indent bullets, etc.

## Changelog

[macOS] [Fixed] - Prevent Tab moving focus from multiline TextInput

## Test Plan

I have been using this example

```
            <>
              <View
                focusable={true}
                style={styles.row}
                validKeysDown={['g', 'Escape', 'Enter', 'ArrowLeft']}
                onKeyDown={this.onKeyDownEvent}
                validKeysUp={['c', 'd']}
                onKeyUp={this.onKeyUpEvent}></View>
              <TextInput
                blurOnSubmit={false}
                placeholder={'Singleline textInput'}
                multiline={false}
                focusable={true}
                style={styles.row}
                validKeysDown={['ArrowRight', 'ArrowDown']}
                onKeyDown={this.onKeyDownEvent}
                validKeysUp={['Escape', 'Enter']}
                onKeyUp={this.onKeyUpEvent}
              />
              <TextInput
                placeholder={'Multiline textInput'}
                multiline={true}
                focusable={true}
                style={styles.row}
                validKeysDown={['ArrowLeft', 'ArrowUp']}
                onKeyDown={this.onKeyDownEvent}
                validKeysUp={['Escape', 'Enter']}
                onKeyUp={this.onKeyUpEvent}
              />
            </>
```

See bottomLeft corner highlighting keys pressing using keyCastr.app

Before

https://user-images.githubusercontent.com/484044/183531106-d91a2f78-9e48-40ac-9a40-f9d68f96e8a8.mov

After

https://user-images.githubusercontent.com/484044/183531117-6d8251e7-21a4-415c-86fa-a85532b020c8.mov


