### PR TITLE
Fix Appearance module to observe application appearance

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -431,15 +431,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
                     RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey : self.traitCollection,
                   }];
 }
-#else // [TODO(macOS GH#774)
-- (void)viewDidChangeEffectiveAppearance {
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTUserInterfaceStyleDidChangeNotification
-                                                      object:self
-                                                    userInfo:@{
-                                                      RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey: self.effectiveAppearance,
-                                                    }];
-
-}
 #endif // ]TODO(macOS GH#774)
 
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes the `Appearance.getColorScheme()` API to return the application-level appearance instead of the last appearance of any root view, which breaks down in multi-window applications.

In Messenger Desktop we always respect the OS appearance for main and setting windows, but force a darkTheme in the calling UI.
W/o this change returning from the calling UI would result in a wrong appearance setting on light theme OS setting.

## Changelog

[macOS] [Fixed] - Fix Appearance module to observe application appearance

## Test Plan

I have added this snippet to RNTester-macOS/ViewController.m
```
- (void)viewWillAppear {
    [super viewWillAppear];
    NSAppearance* appearance = [NSAppearance appearanceNamed:NSAppearanceNameVibrantLight];
    self.view.window.appearance = appearance;
}
```

The macOS appearance was set to darkTheme.
(The test plan is not ideal as I don't have a valid multi-window setup, but it should suffice for a basic test)

Before


https://user-images.githubusercontent.com/484044/183536256-5966fc59-759f-4b1d-8897-d6af76546b56.mov

After

https://user-images.githubusercontent.com/484044/183536269-9d9aab71-bcb1-401a-9d7e-433b4b2b98d1.mov


