### PR TITLE
Fix cursor not showing when tabbing into multiline TextInput

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -172,7 +172,7 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
 
 - (BOOL)becomeFirstResponder
 {
-  BOOL success =  [[self window] makeFirstResponder:self];
+  BOOL success = [super becomeFirstResponder];
 
   if (success) {
     id<RCTBackedTextInputDelegate> textInputDelegate = [self textInputDelegate];

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -286,7 +286,7 @@
 	if (![[self window] makeFirstResponder:self]) {
 #else
 	if (![self becomeFirstResponder]) {
-#endif //// TODO(macOS GH#774)]
+#endif // TODO(macOS GH#774)]
 		self.reactIsFocusNeeded = YES;
 	}
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This bug happens because `RCTUITextView` (which multiline TextInput uses) was overriding NSTextView's `becomeFirstResponder` method and didn't call `[super becomeFirstResponder]`.
This seems to mess with AppKit's logic of drawing the cursor initially.

This is alluded to in the [docs](https://developer.apple.com/documentation/appkit/nstextview/1807130-becomefirstresponder?language=objc#) for `[NSTextView becomeFirstResponder]`:

> If the previous first responder was not a text view on the same layout manager as the receiving text view, this method draws the selection and updates the insertion point if necessary.

Simply switching to call `[super becomeFirstResponder]` led to a cryptic exception within AppKit. This was likely because in the `reactFocus` (and `reactFocusIfNeeded`) we were calling `becomeFirstResponder` directly.
The [docs](https://developer.apple.com/documentation/appkit/nsresponder/1526750-becomefirstresponder?language=objc#) for `[NSResponder becomeFirstResponder]` say:

> Use the NSWindow makeFirstResponder: method, not this method, to make an object the first responder. Never invoke this method directly.

There necessary fixes are already part of https://github.com/microsoft/react-native-macos/commit/84c08634eabeb5e0690ded1cb35614cb1ec856c3#diff-8a3ec110f2ee884d2ef078efddc4ebba9413c7e8cb90b6f5cebff19b2c0a1951 and hence not included in this diff

```
#if TARGET_OS_OSX // [TODO(macOS GH#774). 
	if (![[self window] makeFirstResponder:self]) {
#else
// ...
}

- (void)reactFocusIfNeeded
{
	if (self.reactIsFocusNeeded) {
#if TARGET_OS_OSX // [TODO(macOS GH#774)
		if ([[self window] makeFirstResponder:self]) {
#else
// ...
}
```


## Changelog

[macOS] [Fixed] - Fix cursor not showing when tabbing into multiline TextInput

## Test Plan

Using this example

```
            <>
              <View
                focusable={true}
                style={styles.row}
                validKeysDown={['g', 'Escape', 'Enter', 'ArrowLeft']}
                onKeyDown={this.onKeyDownEvent}
                validKeysUp={['c', 'd']}
                onKeyUp={this.onKeyUpEvent}></View>
              <TextInput
                blurOnSubmit={false}
                placeholder={'Singleline textInput'}
                multiline={false}
                focusable={true}
                style={styles.row}
                validKeysDown={['ArrowRight', 'ArrowDown']}
                onKeyDown={this.onKeyDownEvent}
                validKeysUp={['Escape', 'Enter']}
                onKeyUp={this.onKeyUpEvent}
              />
              <TextInput
                placeholder={'Multiline textInput'}
                multiline={true}
                focusable={true}
                style={styles.row}
                validKeysDown={['ArrowLeft', 'ArrowUp']}
                onKeyDown={this.onKeyDownEvent}
                validKeysUp={['Escape', 'Enter']}
                onKeyUp={this.onKeyUpEvent}
              />
            </>
```

Before


https://user-images.githubusercontent.com/484044/183539803-0ad4601d-7f17-4d21-a4eb-ea7c871f23c9.mov


After

https://user-images.githubusercontent.com/484044/183539819-8721395e-46dd-479b-9889-3aa65c5c1182.mov


