### PR TITLE
[RFC] Add url prop to Text

### DIFF
--- a/Libraries/Text/BaseText/RCTBaseTextViewManager.m
+++ b/Libraries/Text/BaseText/RCTBaseTextViewManager.m
@@ -55,4 +55,8 @@ RCT_REMAP_SHADOW_PROPERTY(textShadowColor, textAttributes.textShadowColor, UICol
 RCT_REMAP_SHADOW_PROPERTY(isHighlighted, textAttributes.isHighlighted, BOOL)
 RCT_REMAP_SHADOW_PROPERTY(textTransform, textAttributes.textTransform, RCTTextTransform)
 
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+RCT_REMAP_SHADOW_PROPERTY(href, textAttributes.href, NSString)
+#endif // ]TODO(macOS GH#774)
+
 @end

--- a/Libraries/Text/RCTTextAttributes.h
+++ b/Libraries/Text/RCTTextAttributes.h
@@ -59,6 +59,10 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 @property (nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
 @property (nonatomic, assign) RCTTextTransform textTransform;
 
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+@property (nonatomic, copy, nullable) NSString *href;
+#endif // ]TODO(macOS GH#774)
+
 #pragma mark - Inheritance
 
 - (void)applyTextAttributes:(RCTTextAttributes *)textAttributes;

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -93,6 +93,10 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   _tag = textAttributes->_tag ?: _tag;
   _layoutDirection = textAttributes->_layoutDirection != UIUserInterfaceLayoutDirectionLeftToRight ? textAttributes->_layoutDirection : _layoutDirection;
   _textTransform = textAttributes->_textTransform != RCTTextTransformUndefined ? textAttributes->_textTransform : _textTransform;
+
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+  _href = textAttributes->_href ?: _href;
+#endif // ]TODO(macOS GH#774)
 }
 
 - (NSParagraphStyle *)effectiveParagraphStyle
@@ -209,6 +213,11 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
     attributes[RCTTextAttributesTagAttributeName] = _tag;
   }
 
+#if TARGET_OS_OSX // TODO(macOS GH#774)
+  if (_href) {
+    attributes[NSLinkAttributeName] = [RCTConvert NSURL:_href];
+  }
+#endif // TODO(macOS GH#774)
   return [attributes copy];
 }
 

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import Linking from '../Linking/Linking'; // [TODO(macOS GH#774)]
 import * as PressabilityDebug from '../Pressability/PressabilityDebug';
 import usePressability from '../Pressability/usePressability';
 import StyleSheet from '../StyleSheet/StyleSheet';
@@ -31,6 +32,7 @@ const Text: React.AbstractComponent<
     accessible,
     allowFontScaling,
     ellipsizeMode,
+    href, // [TODO(macOS GH#774)]
     onLongPress,
     onPress,
     onPressIn,
@@ -49,7 +51,8 @@ const Text: React.AbstractComponent<
   const [isHighlighted, setHighlighted] = useState(false);
 
   const isPressable =
-    (onPress != null ||
+    (props.href != null || // [TODO(macOS GH#774)]
+      onPress != null ||
       onLongPress != null ||
       onStartShouldSetResponder != null) &&
     restProps.disabled !== true;
@@ -62,7 +65,18 @@ const Text: React.AbstractComponent<
             disabled: !isPressable,
             pressRectOffset: pressRetentionOffset,
             onLongPress,
-            onPress,
+            // [TODO(macOS GH#774)]
+            onPress(event) {
+              onPress?.(event);
+              if (
+                href != null &&
+                !event.isDefaultPrevented() &&
+                event.nativeEvent.button === 0
+              ) {
+                Linking.openURL(href);
+              }
+            },
+            // ]TODO(macOS GH#774)]
             onPressIn(event) {
               setHighlighted(!suppressHighlighting);
               onPressIn?.(event);
@@ -77,6 +91,7 @@ const Text: React.AbstractComponent<
           }
         : null,
     [
+      href, // [TODO(macOS GH#774)]
       initialized,
       isPressable,
       pressRetentionOffset,
@@ -140,6 +155,11 @@ const Text: React.AbstractComponent<
       : processColor(restProps.selectionColor);
 
   let style = restProps.style;
+  if (href != null) {
+    style = StyleSheet.compose(restProps.style, {
+      cursor: 'pointer',
+    });
+  }
   if (__DEV__) {
     if (PressabilityDebug.isEnabled() && onPress != null) {
       style = StyleSheet.compose(restProps.style, {
@@ -162,6 +182,7 @@ const Text: React.AbstractComponent<
     <NativeVirtualText
       {...restProps}
       {...eventHandlersForText}
+      href={href} // [TODO(macOS GH#774)]
       isHighlighted={isHighlighted}
       isPressable={isPressable}
       numberOfLines={numberOfLines}

--- a/Libraries/Text/TextNativeComponent.js
+++ b/Libraries/Text/TextNativeComponent.js
@@ -46,6 +46,7 @@ export const NativeText: HostComponent<NativeTextProps> =
       dataDetectorType: true,
       android_hyphenationFrequency: true,
       tooltip: true, // [TODO(macOS GH#774)]
+      href: true, // [TODO(macOS GH#774)]
     },
     directEventTypes: {
       topTextLayout: {
@@ -67,6 +68,7 @@ export const NativeVirtualText: HostComponent<NativeTextProps> =
           isHighlighted: true,
           isPressable: true,
           maxFontSizeMultiplier: true,
+          href: true, // [TODO(macOS GH#774)]
         },
         uiViewClassName: 'RCTVirtualText',
       })): any);

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -200,12 +200,18 @@ export type TextProps = $ReadOnly<{|
    */
   suppressHighlighting?: ?boolean,
 
-  /**
-   * macOS Only
-   */
-
+  // [TODO(macOS GH#774)
   /**
    * Specifies the Tooltip for the button view
+   * @platform macos
    */
   tooltip?: ?string,
+
+  /**
+   * Specifies a URL so the text behaves like a hyperlink (clicking
+   * it will open the URL.
+   * @platform macos
+   */
+  href?: ?string,
+  // ]TODO(macOS GH#774)
 |}>;

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1246,3 +1246,37 @@ exports.examples = [
     },
   },
 ];
+// [TODO(macOS GH#774)
+if (Platform.OS === 'macos') {
+  exports.examples.push(
+    {
+      title: 'Hyperlink',
+      render: function (): React.Node {
+        return (
+          <Text
+            style={{textDecorationLine: 'underline', color: 'red'}}
+            href="https://reactnative.dev"
+            selectable={true}>
+            This text is a hyperlink.
+          </Text>
+        );
+      },
+    },
+    {
+      title: 'Hyperlink in nested TextView',
+      render: function (): React.Node {
+        return (
+          <Text selectable={true}>
+            This is regular text.{' '}
+            <Text
+              style={{textDecorationLine: 'underline', color: 'blue'}}
+              href="https://github.com/microsoft/react-native-macos">
+              This text is hyperlink.
+            </Text>
+          </Text>
+        );
+      },
+    },
+  );
+}
+// ]TODO(macOS GH#774)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This adds a basic url handling support for ```<Text />``` components on macOS.
We could make this feature a bit nicer if we would have
- cursor support in textViews, an evolution of https://github.com/microsoft/react-native-macos/pull/760
- back RCTTextView by NSTextView (required for cursor support) to add macOS specific contentMenuItems as 'Open Link'

### Discussion
- This property does not exist on mobile
- Android has it's custom feature https://reactnative.dev/docs/0.67/text#datadetectortype-android
- We can align a ```url``` property handling between macOS and Windows if that API surface is desired

## Changelog

[macOS] [Added] - Add url prop to Text

## Test Plan

Added example to rn-tester


https://user-images.githubusercontent.com/484044/183544200-d8376be7-0787-4bfe-972e-cc7039434fbf.mov


