### PR TITLE
Add  MultilineTextInput paste support

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -135,7 +135,27 @@ export type SettingChangeEvent = SyntheticEvent<
   $ReadOnly<{|
     enabled: boolean,
   |}>,
->; // ]TODO(macOS GH#774)
+>;
+
+export type PasteEvent = SyntheticEvent<
+  $ReadOnly<{|
+    dataTransfer: {|
+      files: $ReadOnlyArray<{|
+        height: number,
+        size: number,
+        type: string,
+        uri: string,
+        width: number,
+      |}>,
+      items: $ReadOnlyArray<{|
+        kind: string,
+        type: string,
+      |}>,
+      types: $ReadOnlyArray<string>,
+    |},
+  |}>,
+>;
+// ]TODO(macOS GH#774)
 
 type DataDetectorTypesType =
   // iOS+macOS
@@ -739,6 +759,13 @@ export type Props = $ReadOnly<{|
    * Called when a touch is released.
    */
   onPressOut?: ?(event: PressEvent) => mixed,
+
+  /**
+   * Fired when a supported element is pasted
+   *
+   * @platform macos
+   */
+  onPaste?: (event: PasteEvent) => void, // TODO(macOS GH#774)
 
   /**
    * Callback that is called when the text input selection is changed.

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -342,12 +342,25 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
   }
   return YES;
 }
+- (NSArray *)readablePasteboardTypes
+{
+  NSArray *types = [super readablePasteboardTypes];
+  // TODO: Optionally support files/images with a prop
+  return [types arrayByAddingObjectsFromArray:@[NSFilenamesPboardType, NSPasteboardTypePNG, NSPasteboardTypeTIFF]];
+}
+
 #endif // ]TODO(macOS GH#774)
 
 - (void)paste:(id)sender
 {
-  [super paste:sender];
-  _textWasPasted = YES;
+#if TARGET_OS_OSX // TODO(macOS GH#774)
+  if ([self.textInputDelegate textInputShouldHandlePaste:self]) {
+#endif
+    [super paste:sender];
+    _textWasPasted = YES;
+#if TARGET_OS_OSX // TODO(macOS GH#774)
+  }
+#endif
 }
 
 // Turn off scroll animation to fix flaky scrolling.

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)textInputDraggingExited:(id<NSDraggingInfo>)draggingInfo;
 - (BOOL)textInputShouldHandleDragOperation:(id<NSDraggingInfo>)draggingInfo;
 - (void)textInputDidCancel;  // Handle `Escape` key press.
+- (BOOL)textInputShouldHandlePaste:(id<RCTBackedTextInputViewProtocol>)sender; // Return `YES` to have the paste event handled normally. Return `NO` to disallow it and handle it yourself.
 #endif // ]TODO(macOS GH#774)
 
 @optional

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -213,7 +213,12 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
     }
     //paste
   } else if (commandSelector == @selector(paste:)) {
-    _backedTextInputView.textWasPasted = YES;
+    id<RCTBackedTextInputDelegate> textInputDelegate = [_backedTextInputView textInputDelegate];
+    if (textInputDelegate != nil && ![textInputDelegate textInputShouldHandlePaste:_backedTextInputView]) {
+      commandHandled = YES;
+    } else {
+      _backedTextInputView.textWasPasted = YES;
+    }
     //escape
   } else if (commandSelector == @selector(cancelOperation:)) {
     [textInputDelegate textInputDidCancel];

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onContentSizeChange;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onSelectionChange;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onChange;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onPaste; // TODO(OSS Candidate GH#774)
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onChangeSync;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onTextInput;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onScroll;

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -635,6 +635,20 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)decoder)
 - (BOOL)textInputShouldHandleKeyEvent:(NSEvent *)event {
   return ![self handleKeyboardEvent:event];
 }
+
+- (BOOL)textInputShouldHandlePaste:(__unused id)sender
+{
+  NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+  NSPasteboardType fileType = [pasteboard availableTypeFromArray:@[NSFilenamesPboardType, NSPasteboardTypePNG, NSPasteboardTypeTIFF]];
+
+  // If there's a fileType that is of interest, notify JS. Also blocks notifying JS if it's a text paste
+  if (_onPaste && fileType != nil) {
+    _onPaste([self dataTransferInfoFromPasteboard:pasteboard]);
+  }
+
+  // Only allow pasting text.
+  return fileType == nil;
+}
 #endif // ]TODO(macOS GH#774)
 
 - (void)updateLocalData

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -77,6 +77,7 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onKeyPressSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChangeSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPaste, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onTextInput, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
 

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1234,6 +1234,8 @@ RCT_JSON_ARRAY_CONVERTER(NSNumber)
   
   if ([type isEqualToString:@"fileUrl"]) {
     return @[NSFilenamesPboardType];
+  } else if ([type isEqualToString:@"image"]) {
+    return @[NSPasteboardTypePNG, NSPasteboardTypeTIFF];
   }
   
   return @[];

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -31,6 +31,7 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 - (BOOL)resignFirstResponder;
 
 #if TARGET_OS_OSX
+- (NSDictionary*)dataTransferInfoFromPasteboard:(NSPasteboard*)pasteboard;
 - (BOOL)handleKeyboardEvent:(NSEvent *)event;
 #endif
 // ]TODO(OSS Candidate ISS#2710739)

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -18,6 +18,7 @@ const {
   Text,
   TextInput,
   View,
+  Image, // TODO(macOS GH#774)
   Platform, // TODO(macOS GH#774)
   StyleSheet,
   Slider,
@@ -27,6 +28,7 @@ const {
 import type {
   KeyboardType,
   SettingChangeEvent,
+  PasteEvent,
 } from 'react-native/Libraries/Components/TextInput/TextInput'; // [TODO(macOS GH#774)
 
 const TextInputSharedExamples = require('./TextInputSharedExamples.js');
@@ -397,6 +399,41 @@ function OnDragEnterOnDragLeaveOnDrop(): React.Node {
         multiline={true}
         style={styles.multiline}
         placeholder="MULTI LINE w/o onDragEnter|Leave() and onDrop()"
+      />
+    </>
+  );
+}
+
+function OnPaste(): React.Node {
+  const [log, setLog] = React.useState([]);
+  const appendLog = (line: string) => {
+    const limit = 3;
+    let newLog = log.slice(0, limit - 1);
+    newLog.unshift(line);
+    setLog(newLog);
+  };
+  const [imageUri, setImageUri] = React.useState('');
+  return (
+    <>
+      <TextInput
+        multiline={true}
+        style={styles.multiline}
+        onPaste={(e: PasteEvent) => {
+          appendLog(JSON.stringify(e.nativeEvent.dataTransfer.types));
+          setImageUri(e.nativeEvent.dataTransfer.files[0].uri);
+        }}
+        placeholder="MULTI LINE with onPaste() for PNG and TIFF images"
+      />
+      <Text style={{height: 30}}>{log.join('\n')}</Text>
+      <Image
+        source={{uri: imageUri}}
+        style={{
+          width: 128,
+          height: 128,
+          margin: 4,
+          borderWidth: 1,
+          borderColor: 'white',
+        }}
       />
     </>
   );
@@ -913,6 +950,12 @@ if (Platform.OS === 'macos') {
         'onDragEnter, onDragLeave and onDrop - Single- & MultiLineTextInput',
       render: function (): React.Node {
         return <OnDragEnterOnDragLeaveOnDrop />;
+      },
+    },
+    {
+      title: 'onPaste - MultiLineTextInput',
+      render: function (): React.Node {
+        return <OnPaste />;
       },
     },
   );


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This adds an `onPaste` event for `MultilineTextInput` that is fired when a pasting into the input, and includes the same `dataTransfer` info as the `onDrop` callback which is discussed here https://github.com/microsoft/react-native-macos/issues/842
This also fixes a typo in the API name
This also adds logic to extract image size info from pasted images

### Noteworthy:
- ```onPaste``` exists atm only for macOS, but we have the corresponding change to also add it rnw if that is desired
- Should we also add a property ```pasteTypes``` similar to drag&drag ```drag(ged)Types```?

## Changelog

[macOS] [Added] - Add MultilineTextInput paste support

## Test Plan

Using this example with a paste handler. CMD+C, CMD+V
```
        <TextInput
          autoFocus={true}
          multiline={true}
          onPaste={e => console.log(e.nativeEvent.dataTransfer)}
          style={styles.default}
          accessibilityLabel="I am the accessibility label for text input"
        />
```

https://user-images.githubusercontent.com/484044/184038165-c9ae809e-ea05-4874-a57d-68cbb194e8dc.mov



Using that example w/o a paste handler. CMD+C, CMD+V and CMD+V again and again. And contextMenu paste
```
        <TextInput
          autoFocus={true}
          multiline={true}
          style={styles.default}
          accessibilityLabel="I am the accessibility label for text input"
        />
```

https://user-images.githubusercontent.com/484044/184038217-a694f8dd-d67b-444f-a9c8-a4378d372ead.mov


