### PR TITLE
Provide option to not blindly foreground app's lastWindow from deepLinks

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -15,6 +15,7 @@
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
 + (void)getUrlEventHandler:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
++ (void)setAlwaysForegroundLastWindow:(BOOL)alwaysForeground;
 #else // ]TODO(macOS GH#774)
 + (BOOL)application:(nonnull UIApplication *)app
             openURL:(nonnull NSURL *)URL

--- a/Libraries/LinkingIOS/macos/RCTLinkingManager.mm
+++ b/Libraries/LinkingIOS/macos/RCTLinkingManager.mm
@@ -21,6 +21,7 @@ NSString *const RCTOpenURLNotification = @"RCTOpenURLNotification";
 
 static NSString *initialURL = nil;
 static BOOL moduleInitalized = NO;
+static BOOL alwaysForegroundLastWindow = YES;
 
 static void postNotificationWithURL(NSString *url, id sender)
 {
@@ -60,6 +61,11 @@ RCT_EXPORT_MODULE()
     return @[@"url"];
 }
 
++ (void)setAlwaysForegroundLastWindow:(BOOL)alwaysForeground
+{
+    alwaysForegroundLastWindow = alwaysForeground;
+}
+
 + (void)getUrlEventHandler:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
     // extract url value from the event
@@ -76,12 +82,13 @@ RCT_EXPORT_MODULE()
 
 - (void)handleOpenURLNotification:(NSNotification *)notification
 {
-    // foreground top level window, need to grab it like this, because [NSApp mainWindow] returns nil when the app is hidden
-    // and another app is maximized
+    // Activate app, because [NSApp mainWindow] returns nil when the app is hidden and another app is maximized
     [NSApp activateIgnoringOtherApps:YES];
-    NSWindow *lastWindow = [[NSApp windows] lastObject];
-    [lastWindow makeKeyAndOrderFront:nil];
-
+    // foreground top level window
+    if (alwaysForegroundLastWindow) {      
+      NSWindow *lastWindow = [[NSApp windows] lastObject];
+      [lastWindow makeKeyAndOrderFront:nil];
+    }
     [self sendEventWithName:@"url" body:notification.userInfo];
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Messenger Desktop is a multi-window application (chat, calling, settings, …) and we maintain the various windows with a windowNativeModule which allows JS interaction.

When receiving deep-links from other apps we don’t want to necessary re-open the lastWindow open as the deep-link might contain information about a particular scenario (open login page, start a call). Hence, we need to disable this behavior app wide and use our windowNativeModule to foreground the specific window related to the deep link.

- This change has 0 effect on other apps
- We could make this property an ivar, but then we need to manually register RCTLinkingManager.mm in ReactBridgeFactory-macOS.mm ….
- We could append a special url property to deep-links, but I think that would make the ‘API’ harder to use`

To use this 'feature' you would add this line in AppDelegate
```
  [RCTLinkingManager setAlwaysForegroundLastWindow:NO]; // <- Add this
  [[NSAppleEventManager sharedAppleEventManager] setEventHandler:[RCTLinkingManager class]
                                                     andSelector:@selector(getUrlEventHandler:withReplyEvent:)
                                                   forEventClass:kInternetEventClass
```

## Changelog

[macOS] [Added] - Provide option to not blindly foreground app's lastWindow from deepLinks

## Test Plan

Using js/examples/Linking/LinkingExample.js I simply added an eventListener
```
Linking.addEventListener('url', url => console.log(url));
```
as otherwise the LinkingManager.mm does not observe:
https://github.com/microsoft/react-native-macos/blob/main/Libraries/LinkingIOS/macos/RCTLinkingManager.mm#L44

https://github.com/microsoft/react-native-macos/blob/main/React/Modules/RCTEventEmitter.m#L115

### Disable alwaysForegroundLastWindow

https://user-images.githubusercontent.com/484044/184185540-b88c3d6f-ee0c-4db8-b187-137e8755cf7b.mov


## Current behavior, always foreground

https://user-images.githubusercontent.com/484044/184185585-b4db2dbc-e72c-456e-874f-15803dc21419.mov


