### PR TITLE
Fix TextInput interfering with Japanese conversion

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -76,6 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif // ]TODO(macOS GH#774)
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
+- (BOOL)hasMarkedText;
 // UITextInput method for OSX
 - (CGSize)sizeThatFits:(CGSize)size;
 #endif // ]TODO(macOS GH#774)

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -153,6 +153,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
                                 range:NSMakeRange(0, attributedTextCopy.length)];
 
   textNeedsUpdate = ([self textOf:attributedTextCopy equals:backedTextInputViewTextCopy] == NO);
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+  // If we are in a language that uses conversion (e.g. Japanese), ignore updates if we have unconverted text.
+  if ([self.backedTextInputView hasMarkedText]) {
+    textNeedsUpdate = NO;
+  }
+#endif // ]TODO(macOS GH#774)
 
   if (eventLag == 0 && textNeedsUpdate) {
 #if !TARGET_OS_OSX // TODO(macOS GH#774)

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -127,6 +127,13 @@
 #endif // ]TODO(macOS GH#774)
 }
 
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+- (BOOL)hasMarkedText
+{
+  return ((NSTextView *)self.currentEditor).hasMarkedText;
+}
+#endif // ]TODO(macOS GH#774)
+  
 #pragma mark - Accessibility
 
 #if !TARGET_OS_OSX // [TODO(macOS GH#774)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The bug happened anywhere we set a onChangeText event handler on TextInput, and rewrite the inflight text such as shown in
https://github.com/microsoft/react-native-macos/blob/main/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js#L137

To fix we have to ignore changes to text if we have incomplete conversions.

## Changelog

[macOS] [Fixed] - Fix TextInput interfering with Japanese conversion

## Test Plan

Go to macOS Preferences > Keyboard > Input Sources > add "Japanese Romaji". Use traditional conversion per https://support.apple.com/guide/japanese-input-method/enter-japanese-text-jpim10265/mac.

In the textInput type "watashi", select first auto complete option (e.g. press SPACE), then type "tachi", and confirm you get "私たち":
### Before
私阿知


https://user-images.githubusercontent.com/484044/184256082-21773286-a367-4b5f-a706-eea5131a4fbe.mov



### After
私たち

https://user-images.githubusercontent.com/484044/184256076-198354ed-153d-4ad4-9f65-5122be3d7086.mov


