### PR TITLE
Fix for shadow opacity getting set to 1 when appearance changes

### DIFF
--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -139,6 +139,12 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, copy) RCTDirectEventBlock onKeyUp;
 @property (nonatomic, copy) NSArray<NSString*> *validKeysDown;
 @property (nonatomic, copy) NSArray<NSString*> *validKeysUp;
+
+// Shadow Properties
+@property (nonatomic, strong) NSColor *shadowColor;
+@property (nonatomic, assign) CGFloat shadowOpacity;
+@property (nonatomic, assign) CGFloat shadowRadius;
+@property (nonatomic, assign) CGSize shadowOffset;
 #endif // ]TODO(macOS GH#774)
 
 /**

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -716,22 +716,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 #endif // TODO(macOS GH#774)
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
-// Workaround AppKit issue with directly manipulating the view layer's shadow.
-//- (NSShadow*)shadow
-//{
-//  CALayer *layer = self.layer;
-//  NSShadow *shadow = nil;
-//
-//  if (layer.shadowColor != nil && layer.shadowOpacity > 0) {
-//    shadow = [NSShadow new];
-//
-//    shadow.shadowColor = [[NSColor colorWithCGColor:layer.shadowColor] colorWithAlphaComponent:layer.shadowOpacity];
-//    shadow.shadowOffset = layer.shadowOffset;
-//    shadow.shadowBlurRadius = layer.shadowRadius;
-//  }
-//  return shadow;
-//}
-
 - (void)viewDidMoveToWindow
 {
   // Subscribe to view bounds changed notification so that the view can be notified when a

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -165,6 +165,7 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // TODO(macOS I
     _hitTestEdgeInsets = UIEdgeInsetsZero;
 #if TARGET_OS_OSX // TODO(macOS GH#774)
     _transform3D = CATransform3DIdentity;
+    _shadowColor = nil;
 #endif // TODO(macOS GH#774)
 
     _backgroundColor = super.backgroundColor;
@@ -716,6 +717,51 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 #endif // TODO(macOS GH#774)
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
+- (void)setShadowColor:(NSColor *)shadowColor
+{
+    if (_shadowColor != shadowColor)
+    {
+        _shadowColor = shadowColor;
+        [self didUpdateShadow];
+    }
+}
+
+- (void)setShadowOffset:(CGSize)shadowOffset
+{
+    if (!CGSizeEqualToSize(_shadowOffset, shadowOffset))
+    {
+        _shadowOffset = shadowOffset;
+        [self didUpdateShadow];
+    }
+}
+
+- (void)setShadowOpacity:(CGFloat)shadowOpacity
+{
+    if (_shadowOpacity != shadowOpacity)
+    {
+        _shadowOpacity = shadowOpacity;
+        [self didUpdateShadow];
+    }
+}
+
+- (void)setShadowRadius:(CGFloat)shadowRadius
+{
+    if (_shadowRadius != shadowRadius)
+    {
+        _shadowRadius = shadowRadius;
+        [self didUpdateShadow];
+    }
+}
+
+-(void)didUpdateShadow
+{
+    NSShadow *shadow = [NSShadow new];
+    shadow.shadowColor = [[self shadowColor] colorWithAlphaComponent:[self shadowOpacity]];
+    shadow.shadowOffset = [self shadowOffset];
+    shadow.shadowBlurRadius = [self shadowRadius];
+    [self setShadow:shadow];
+}
+
 - (void)viewDidMoveToWindow
 {
   // Subscribe to view bounds changed notification so that the view can be notified when a

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -717,20 +717,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
 // Workaround AppKit issue with directly manipulating the view layer's shadow.
-- (NSShadow*)shadow
-{
-  CALayer *layer = self.layer;
-  NSShadow *shadow = nil;
-
-  if (layer.shadowColor != nil && layer.shadowOpacity > 0) {
-    shadow = [NSShadow new];
-
-    shadow.shadowColor = [[NSColor colorWithCGColor:layer.shadowColor] colorWithAlphaComponent:layer.shadowOpacity];
-    shadow.shadowOffset = layer.shadowOffset;
-    shadow.shadowBlurRadius = layer.shadowRadius;
-  }
-  return shadow;
-}
+//- (NSShadow*)shadow
+//{
+//  CALayer *layer = self.layer;
+//  NSShadow *shadow = nil;
+//
+//  if (layer.shadowColor != nil && layer.shadowOpacity > 0) {
+//    shadow = [NSShadow new];
+//
+//    shadow.shadowColor = [[NSColor colorWithCGColor:layer.shadowColor] colorWithAlphaComponent:layer.shadowOpacity];
+//    shadow.shadowOffset = layer.shadowOffset;
+//    shadow.shadowBlurRadius = layer.shadowRadius;
+//  }
+//  return shadow;
+//}
 
 - (void)viewDidMoveToWindow
 {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -191,10 +191,90 @@ RCT_REMAP_VIEW_PROPERTY(opacity, alpha, CGFloat)
 #else // [TODO(macOS GH#774)
 RCT_REMAP_VIEW_PROPERTY(opacity, alphaValue, CGFloat)
 #endif // ]TODO(macOS GH#774)
-RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
-RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
-RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
-RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
+//RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
+//RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
+//RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
+//RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
+
+RCT_CUSTOM_VIEW_PROPERTY(shadowColor, CGColor, RCTView)
+{
+    NSShadow *shadow = [NSShadow new];
+    shadow.shadowColor = [NSColor colorWithCGColor:[RCTConvert CGColor:json]];
+    if (view.shadow != nil)
+    {
+        shadow.shadowOffset = view.shadow.shadowOffset;
+        shadow.shadowBlurRadius = view.shadow.shadowBlurRadius;
+        shadow.shadowColor = [shadow.shadowColor colorWithAlphaComponent:view.shadow.shadowColor.alphaComponent];
+    }
+    view.shadow = shadow;
+    
+//    NSColor *shadowColor = [NSColor colorWithCGColor:[RCTConvert CGColor:json]];
+//    if (view.shadow == nil)
+//    {
+//        view.shadow = [NSShadow new];
+//        // don't need the next line?
+//        view.shadow.shadowColor = shadowColor;
+//    }
+//    else {
+//        view.shadow.shadowColor = [shadowColor colorWithAlphaComponent:view.shadow.shadowColor.alphaComponent];
+//    }
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(shadowOffset, CGSize, RCTView)
+{
+    NSShadow *shadow = [NSShadow new];
+    shadow.shadowOffset = [RCTConvert CGSize:json];
+    if (view.shadow != nil)
+    {
+        shadow.shadowBlurRadius = view.shadow.shadowBlurRadius;
+        shadow.shadowColor = view.shadow.shadowColor;
+    }
+    view.shadow = shadow;
+    
+//    if (view.shadow == nil)
+//    {
+//        view.shadow = [NSShadow new];
+//    }
+//    view.shadow.shadowOffset = [RCTConvert CGSize:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(shadowOpacity, float, RCTView)
+{
+    NSShadow *shadow = [NSShadow new];
+    if (view.shadow != nil)
+    {
+        shadow.shadowOffset = view.shadow.shadowOffset;
+        shadow.shadowBlurRadius = view.shadow.shadowBlurRadius;
+        shadow.shadowColor = view.shadow.shadowColor;
+    }
+    shadow.shadowColor = [shadow.shadowColor colorWithAlphaComponent:[RCTConvert float:json]];
+    view.shadow = shadow;
+    
+//    float shadowOpacity = [RCTConvert float:json];
+//    if (view.shadow == nil)
+//    {
+//        view.shadow = [NSShadow new];
+//    }
+//    view.shadow.shadowColor = [view.shadow.shadowColor colorWithAlphaComponent:shadowOpacity];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(shadowRadius, CGFloat, RCTView)
+{
+    NSShadow *shadow = [NSShadow new];
+    if (view.shadow != nil)
+    {
+        shadow.shadowOffset = view.shadow.shadowOffset;
+        shadow.shadowColor = view.shadow.shadowColor;
+    }
+    shadow.shadowBlurRadius = [RCTConvert CGFloat:json];
+    view.shadow = shadow;
+    
+//    if (view.shadow == nil)
+//    {
+//        view.shadow = [NSShadow new];
+//    }
+//    view.shadow.shadowBlurRadius = [RCTConvert CGFloat:json];
+}
 RCT_REMAP_VIEW_PROPERTY(needsOffscreenAlphaCompositing, layer.allowsGroupOpacity, BOOL)
 RCT_CUSTOM_VIEW_PROPERTY(overflow, YGOverflow, RCTView)
 {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -191,54 +191,18 @@ RCT_REMAP_VIEW_PROPERTY(opacity, alpha, CGFloat)
 #else // [TODO(macOS GH#774)
 RCT_REMAP_VIEW_PROPERTY(opacity, alphaValue, CGFloat)
 #endif // ]TODO(macOS GH#774)
-//RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
-//RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
-//RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
-//RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
 
-RCT_CUSTOM_VIEW_PROPERTY(shadowColor, CGColor, RCTView)
-{
-    if (view.shadow == nil)
-    {
-        view.shadow = [NSShadow new];
-    }
-    
-    NSColor *shadowColor = [NSColor colorWithCGColor:[RCTConvert CGColor:json]];
-    view.shadow.shadowColor = [shadowColor colorWithAlphaComponent:view.shadow.shadowColor.alphaComponent];
-}
-
-RCT_CUSTOM_VIEW_PROPERTY(shadowOffset, CGSize, RCTView)
-{
-    if (view.shadow == nil)
-    {
-        view.shadow = [NSShadow new];
-    }
-    CGSize shadowOffset = [RCTConvert CGSize:json];
-    view.shadow.shadowOffset = shadowOffset;
-}
-
-RCT_CUSTOM_VIEW_PROPERTY(shadowOpacity, float, RCTView)
-{
-    NSShadow *shadow = [NSShadow new];
-    if (view.shadow != nil)
-    {
-        shadow.shadowOffset = view.shadow.shadowOffset;
-        shadow.shadowBlurRadius = view.shadow.shadowBlurRadius;
-        shadow.shadowColor = view.shadow.shadowColor;
-    }
-    shadow.shadowColor = [shadow.shadowColor colorWithAlphaComponent:[RCTConvert float:json]];
-    view.shadow = shadow;
-}
-
-RCT_CUSTOM_VIEW_PROPERTY(shadowRadius, CGFloat, RCTView)
-{
-    if (view.shadow == nil)
-    {
-        view.shadow = [NSShadow new];
-    }
-    CGFloat shadowRadius = [RCTConvert CGFloat:json];
-    view.shadow.shadowBlurRadius = shadowRadius;
-}
+#if TARGET_OS_OSX // TODO(macOS GH#774)
+RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
+RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
+RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
+RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
+#else // [TODO(macOS GH#774)
+RCT_EXPORT_VIEW_PROPERTY(shadowColor, NSColor)
+RCT_EXPORT_VIEW_PROPERTY(shadowOffset, CGSize)
+RCT_EXPORT_VIEW_PROPERTY(shadowOpacity, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(shadowRadius, CGFloat)
+#endif // ]TODO(macOS GH#774)
 
 RCT_REMAP_VIEW_PROPERTY(needsOffscreenAlphaCompositing, layer.allowsGroupOpacity, BOOL)
 RCT_CUSTOM_VIEW_PROPERTY(overflow, YGOverflow, RCTView)

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -198,44 +198,23 @@ RCT_REMAP_VIEW_PROPERTY(opacity, alphaValue, CGFloat)
 
 RCT_CUSTOM_VIEW_PROPERTY(shadowColor, CGColor, RCTView)
 {
-    NSShadow *shadow = [NSShadow new];
-    shadow.shadowColor = [NSColor colorWithCGColor:[RCTConvert CGColor:json]];
-    if (view.shadow != nil)
+    if (view.shadow == nil)
     {
-        shadow.shadowOffset = view.shadow.shadowOffset;
-        shadow.shadowBlurRadius = view.shadow.shadowBlurRadius;
-        shadow.shadowColor = [shadow.shadowColor colorWithAlphaComponent:view.shadow.shadowColor.alphaComponent];
+        view.shadow = [NSShadow new];
     }
-    view.shadow = shadow;
     
-//    NSColor *shadowColor = [NSColor colorWithCGColor:[RCTConvert CGColor:json]];
-//    if (view.shadow == nil)
-//    {
-//        view.shadow = [NSShadow new];
-//        // don't need the next line?
-//        view.shadow.shadowColor = shadowColor;
-//    }
-//    else {
-//        view.shadow.shadowColor = [shadowColor colorWithAlphaComponent:view.shadow.shadowColor.alphaComponent];
-//    }
+    NSColor *shadowColor = [NSColor colorWithCGColor:[RCTConvert CGColor:json]];
+    view.shadow.shadowColor = [shadowColor colorWithAlphaComponent:view.shadow.shadowColor.alphaComponent];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(shadowOffset, CGSize, RCTView)
 {
-    NSShadow *shadow = [NSShadow new];
-    shadow.shadowOffset = [RCTConvert CGSize:json];
-    if (view.shadow != nil)
+    if (view.shadow == nil)
     {
-        shadow.shadowBlurRadius = view.shadow.shadowBlurRadius;
-        shadow.shadowColor = view.shadow.shadowColor;
+        view.shadow = [NSShadow new];
     }
-    view.shadow = shadow;
-    
-//    if (view.shadow == nil)
-//    {
-//        view.shadow = [NSShadow new];
-//    }
-//    view.shadow.shadowOffset = [RCTConvert CGSize:json];
+    CGSize shadowOffset = [RCTConvert CGSize:json];
+    view.shadow.shadowOffset = shadowOffset;
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(shadowOpacity, float, RCTView)
@@ -249,32 +228,18 @@ RCT_CUSTOM_VIEW_PROPERTY(shadowOpacity, float, RCTView)
     }
     shadow.shadowColor = [shadow.shadowColor colorWithAlphaComponent:[RCTConvert float:json]];
     view.shadow = shadow;
-    
-//    float shadowOpacity = [RCTConvert float:json];
-//    if (view.shadow == nil)
-//    {
-//        view.shadow = [NSShadow new];
-//    }
-//    view.shadow.shadowColor = [view.shadow.shadowColor colorWithAlphaComponent:shadowOpacity];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(shadowRadius, CGFloat, RCTView)
 {
-    NSShadow *shadow = [NSShadow new];
-    if (view.shadow != nil)
+    if (view.shadow == nil)
     {
-        shadow.shadowOffset = view.shadow.shadowOffset;
-        shadow.shadowColor = view.shadow.shadowColor;
+        view.shadow = [NSShadow new];
     }
-    shadow.shadowBlurRadius = [RCTConvert CGFloat:json];
-    view.shadow = shadow;
-    
-//    if (view.shadow == nil)
-//    {
-//        view.shadow = [NSShadow new];
-//    }
-//    view.shadow.shadowBlurRadius = [RCTConvert CGFloat:json];
+    CGFloat shadowRadius = [RCTConvert CGFloat:json];
+    view.shadow.shadowBlurRadius = shadowRadius;
 }
+
 RCT_REMAP_VIEW_PROPERTY(needsOffscreenAlphaCompositing, layer.allowsGroupOpacity, BOOL)
 RCT_CUSTOM_VIEW_PROPERTY(overflow, YGOverflow, RCTView)
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Partial fix for issue #1363, where it looks like there are two issues: 1) when switching between dark and light mode the opacity seems to sometimes get set back to 1, and 2) when switching between dark and light mode, and a different shadow is specified for dark vs. light mode, the shadow doesn't get updated properly (ex. see the light mode shadow in dark mode or the dark mode shadow in light mode). This PR is just fixing the first problem, the second problem is a bug with dynamicColoriOS that should be fixed in RNCore.

On the FURN Tester side (where the original fix for the inconsistent shadows bug was tested) this was actually repro'ing as well but was not obvious because the test page would get refreshed every time we switched between dark/light mode. However after taking a closer look, you can actually see that the opacity gets very dark for a split second before the page is refreshed.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fix for shadow opacity getting set to 1 when appearance changes

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested in the FluentTester in FURN:

Can see that the opacity is very dark for a second after switching appearance/before the page refreshes. Most noticeable when going from dark to light mode, pause at around 8 seconds

https://user-images.githubusercontent.com/78454019/186002314-d20e41a3-51b3-4178-8910-992ee2793bdb.mov

Similar situation happens around 4 seconds, can see that the opacity for that split second is not as dark as before.

https://user-images.githubusercontent.com/78454019/186002329-0423ef7b-1a9c-43ac-a20b-077936de1bc7.mov

Ideally we want to get rid of the split second where the shadow doesn't match the appearance, that would be an issue for RNCore