### PR TITLE
[0.68] Fix build errors with codegen discovery flag enabled

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -41,10 +41,12 @@ def pods(options = {})
 
   prefix_path = "../.."
 
-  if ENV['USE_CODEGEN_DISCOVERY'] == '1'
-    # Custom fabric component is only supported when using codegen discovery.
-    pod 'MyNativeView', :path => "NativeComponentExample"
-  end
+  # [TODO(macOS GH#774) - don't enable Fabric on RNTester by default until it works on macOS
+  # if ENV['USE_CODEGEN_DISCOVERY'] == '1'
+  #   # Custom fabric component is only supported when using codegen discovery.
+  #   pod 'MyNativeView', :path => "NativeComponentExample"
+  # end
+  # ]TODO(macOS GH#774)
 
   use_react_native!(
     path: prefix_path,


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry pick #1320

## Changelog

[macOS] [Fix] Don't try and build Fabric example when USE_CODEGEN_DISCOVERY=1
