### PR TITLE
update v8jsi version

### DIFF
--- a/android-patches/patches/Build/ReactAndroid/build.gradle
+++ b/android-patches/patches/Build/ReactAndroid/build.gradle
@@ -17,7 +17,7 @@ index 3c23c6a84b4..183bffe7164 100644
  // and the build will use that.
  def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
  
-+def V8Path = 'packages/ReactNative.V8Jsi.Android.0.66.0-stable-v2'
++def V8Path = 'packages/ReactNative.V8Jsi.Android.0.68-stable-v1'
 +
  // Setup build type for NDK, supported values: {debug, release}
  def nativeBuildType = System.getenv("NATIVE_BUILD_TYPE") ?: "release"

--- a/android-patches/patches/Build/ReactAndroid/build.gradle
+++ b/android-patches/patches/Build/ReactAndroid/build.gradle
@@ -17,7 +17,7 @@ index 3c23c6a84b4..183bffe7164 100644
  // and the build will use that.
  def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
  
-+def V8Path = 'packages/ReactNative.V8Jsi.Android.0.68-stable-v1'
++def V8Path = 'packages/ReactNative.V8Jsi.Android.0.68.0-stable-v1'
 +
  // Setup build type for NDK, supported values: {debug, release}
  def nativeBuildType = System.getenv("NATIVE_BUILD_TYPE") ?: "release"

--- a/android-patches/patches/Build/ReactAndroid/packages.config
+++ b/android-patches/patches/Build/ReactAndroid/packages.config
@@ -7,5 +7,5 @@ index 0000000000..dcaed5f4d0
 +﻿<?xml version="1.0" encoding="utf-8"?>
 +<packages>
 +  <package id="boost" version="1.68.0.0" targetFramework="native" />
-+  <package id="ReactNative.V8JSI.Android" version="0.68-stable-v1" targetFramework="native" />
++  <package id="ReactNative.V8JSI.Android" version="0.68.0-stable-v1" targetFramework="native" />
 +</packages>

--- a/android-patches/patches/Build/ReactAndroid/packages.config
+++ b/android-patches/patches/Build/ReactAndroid/packages.config
@@ -7,5 +7,5 @@ index 0000000000..dcaed5f4d0
 +﻿<?xml version="1.0" encoding="utf-8"?>
 +<packages>
 +  <package id="boost" version="1.68.0.0" targetFramework="native" />
-+  <package id="ReactNative.V8JSI.Android" version="0.66.0-stable-v2" targetFramework="native" />
++  <package id="ReactNative.V8JSI.Android" version="0.68-stable-v1" targetFramework="native" />
 +</packages>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
As part of the RN bump to 0.68, we need to update to a corresponding version of V8Jsi.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Update V8 JSI version for 0.68-stable

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Ensure Android PR pipeline build successfully. This version of the v8 jsi has functionally the same headers as the previous version, so we do not expect any runtime changes.
