### PR TITLE
RNTester: Only show the Flatlist keyboard navigation switch on macOS

### DIFF
--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -359,12 +359,18 @@ const styles = StyleSheet.create({
   },
   // [TODO(macOS GH#774)
   selectedItem: {
-    backgroundColor: PlatformColor('selectedContentBackgroundColor'),
+    backgroundColor: Platform.select({
+      macos: PlatformColor('selectedContentBackgroundColor'),
+      default: 'blue',
+    }),
   },
   selectedItemText: {
     // This was the closest UI Element color that looked right...
     // https://developer.apple.com/documentation/appkit/nscolor/ui_element_colors
-    color: PlatformColor('selectedMenuItemTextColor'),
+    color: Platform.select({
+      macos: PlatformColor('selectedMenuItemTextColor'),
+      default: 'white',
+    }),
   },
   // [TODO(macOS GH#774)]
 });

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -185,11 +185,12 @@ class FlatListExample extends React.PureComponent<Props, State> {
                 this._setBooleanValue('useFlatListItemComponent'),
               )}
               {/* [TODO(macOS GH#774)  */}
-              {renderSmallSwitchOption(
-                'Keyboard Navigation',
-                this.state.enableSelectionOnKeyPress,
-                this._setBooleanValue('enableSelectionOnKeyPress'),
-              )}
+              {Platform.OS === 'macos' &&
+                renderSmallSwitchOption(
+                  'Keyboard Navigation',
+                  this.state.enableSelectionOnKeyPress,
+                  this._setBooleanValue('enableSelectionOnKeyPress'),
+                )}
               {/* TODO(macOS GH#774)] */}
               {Platform.OS === 'android' && (
                 <View>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

We show the Switch to enable Keyboard Navigation on all platforms. Let's make it only macOS, the only platform we validated. Also, let's change some styles used only by the test app to have a fallback non-platform color if we're not on macOS, should someone manage to enable the switch anyway. 

## Changelog

[macOS] [Fixed] - Only show the Flatlist keyboard navigation switch on macOS

## Test Plan

Switch no longer shows up on iOS

![Screen Shot 2022-08-25 at 11 28 46 AM](https://user-images.githubusercontent.com/6722175/186742882-4c2259b3-2c78-4bd0-945a-d192b3b7c985.png)


If I force it to be true on iOS, the test app isn't too broken:


https://user-images.githubusercontent.com/6722175/186742896-b60f80ab-3bcc-4725-b2eb-b9b929473410.mov


