### PR TITLE
restore exclude so

### DIFF
--- a/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
@@ -1,9 +1,9 @@
 diff --git a/ReactAndroid/ReactAndroid.nuspec b/ReactAndroid/ReactAndroid.nuspec
 new file mode 100644
-index 00000000000..5ea2105f8ac
+index 00000000000..fe19da3f9d4
 --- /dev/null
 +++ b/ReactAndroid/ReactAndroid.nuspec
-@@ -0,0 +1,221 @@
+@@ -0,0 +1,302 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
@@ -113,6 +113,47 @@ index 00000000000..5ea2105f8ac
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\liblogger.so" target="lib\droidx86"/>
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\liblogger.so" target="lib\droidarm64"/>
 +
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_runtimescheduler.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_runtimescheduler.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_runtimescheduler.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_runtimescheduler.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libruntimeexecutor.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libruntimeexecutor.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libruntimeexecutor.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libruntimeexecutor.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_core.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_core.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_core.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_core.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_debug.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_debug.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_debug.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_debug.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_debug.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_debug.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_debug.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_debug.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_utils.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_utils.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_utils.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_utils.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_graphics.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_graphics.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_graphics.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_graphics.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_mapbuffer.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_mapbuffer.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_mapbuffer.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_mapbuffer.so" target="lib\droidarm64"/>
++
++
 +    <!-- Unstripped binaries -->
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libfb.so" target="lib\droidx64\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libfb.so" target="lib\droidarm\unstripped"/>
@@ -208,6 +249,46 @@ index 00000000000..5ea2105f8ac
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\liblogger.so" target="lib\droidarm\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\liblogger.so" target="lib\droidx86\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\liblogger.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_runtimescheduler.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_runtimescheduler.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_runtimescheduler.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_runtimescheduler.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libruntimeexecutor.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libruntimeexecutor.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libruntimeexecutor.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libruntimeexecutor.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_core.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_core.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_core.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_core.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_debug.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_debug.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_debug.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_debug.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_debug.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_debug.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_debug.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_debug.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_utils.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_utils.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_utils.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_utils.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_graphics.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_graphics.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_graphics.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_graphics.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_mapbuffer.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_mapbuffer.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_mapbuffer.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_mapbuffer.so" target="lib\droidarm64\unstripped"/>
 +
 +    <!-- AAR and POM -->
 +    <file src="..\android\com\**\*" target="maven\com"/>

--- a/android-patches/patches/Build/ReactAndroid/build.gradle
+++ b/android-patches/patches/Build/ReactAndroid/build.gradle
@@ -1,5 +1,5 @@
 diff --git a/ReactAndroid/build.gradle b/ReactAndroid/build.gradle
-index 3c23c6a84b4..183bffe7164 100644
+index 3c23c6a84b4..df345f87eab 100644
 --- a/ReactAndroid/build.gradle
 +++ b/ReactAndroid/build.gradle
 @@ -12,6 +12,10 @@ plugins {
@@ -77,3 +77,18 @@ index 3c23c6a84b4..183bffe7164 100644
      preBuild.dependsOn("generateCodegenArtifactsFromSchema")
  
      sourceSets.main {
+@@ -363,8 +389,12 @@ android {
+         // we produce. The reason behind this is that we want to allow users to pick the
+         // JS engine by specifying a dependency on either `hermes-engine` or `android-jsc`
+         // that will include the necessary .so files to load.
+-        exclude("**/libhermes.so")
+-        exclude("**/libjsc.so")
++        if (project.hasProperty('param') ? project.property('param').equals("excludeLibs") : false) {
++            exclude '**/*.so'
++        } else {
++            exclude("**/libhermes.so")
++            exclude("**/libjsc.so")
++        }
+     }
+ 
+     configurations {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

During migration to 0.68, we lost a patch responsible for not packaging any SOs in the react native aar, as we extract them ourselves and package the ones we need. As a result we are observing size regressions. The fix is to add the patch back in.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Restore patch to not package SO files in aar

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

PR pipelines build successfully and will try building locally.
