### PR TITLE
Merge remote-tracking branch 'fb/0.68-stable' into 0.68-stable

### DIFF
--- a/.ado/templates/apple-droid-node-patching.yml
+++ b/.ado/templates/apple-droid-node-patching.yml
@@ -5,4 +5,4 @@ steps:
   - task: CmdLine@2
     displayName: Apply Android specific patches for Office consumption
     inputs:
-      script: npm_config_yes=true npx @rnx-kit/patcher-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC JniUtils RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}
+      script: npm_config_yes=true npx @rnx-kit/patcher-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
@@ -40,7 +40,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_uimanager \
   libreact_utils \
   libreact_config \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_image \
   librrc_root \
   librrc_unimplementedview \

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
@@ -19,7 +19,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 
 LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
 
-LOCAL_SHARED_LIBRARIES = libfb libfbjni libreactnativeutilsjni libruntimeexecutor
+LOCAL_SHARED_LIBRARIES = libfb libfbjni libreactnativejni libruntimeexecutor
 
 LOCAL_STATIC_LIBRARIES = libcallinvoker libreactperfloggerjni
 

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -3,66 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
-##########################
-### React Native Utils ###
-##########################
-
 LOCAL_PATH := $(call my-dir)
-
-include $(CLEAR_VARS)
-
-# Include . in the header search path for all source files in this module.
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-
-# Include ./../../ in the header search path for modules that depend on
-# reactnativejni. This will allow external modules to require this module's
-# headers using #include <react/jni/<header>.h>, assuming:
-#   .     == jni
-#   ./../ == react
-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../..
-
-LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
-
-LOCAL_LDLIBS += -landroid
-
-# The dynamic libraries (.so files) that this module depends on.
-LOCAL_SHARED_LIBRARIES := \
-  libfb \
-  libfbjni \
-  libfolly_json \
-  libglog_init \
-  libreact_render_runtimescheduler \
-  libruntimeexecutor \
-  libyoga
-
-# The static libraries (.a files) that this module depends on.
-LOCAL_STATIC_LIBRARIES := libreactnative libcallinvokerholder
-
-# Name of this module.
-#
-# Other modules can depend on this one by adding libreactnativejni to their
-# LOCAL_SHARED_LIBRARIES variable.
-LOCAL_MODULE := reactnativeutilsjni
-
-# Compile all local c++ files.
-LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
-LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(LOCAL_SRC_FILES))
-
-ifeq ($(APP_OPTIM),debug)
-  # Keep symbols by overriding the strip command invoked by ndk-build.
-  # Note that this will apply to all shared libraries,
-  # i.e. shared libraries will NOT be stripped
-  # even though we override it in this Android.mk
-  cmd-strip :=
-endif
-
-# Build the files in this directory as a shared library
-include $(BUILD_SHARED_LIBRARY)
-
-
-
-
 
 ######################
 ### reactnativejni ###
@@ -91,7 +32,6 @@ LOCAL_SHARED_LIBRARIES := \
   libfolly_json \
   libglog_init \
   libreact_render_runtimescheduler \
-  libreactnativeutilsjni \
   libruntimeexecutor \
   libyoga \
   logger

--- a/ReactCommon/react/renderer/components/progressbar/Android.mk
+++ b/ReactCommon/react/renderer/components/progressbar/Android.mk
@@ -35,7 +35,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_debug \
   libreact_render_graphics \
   libreact_render_uimanager \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_view \
   libyoga
 

--- a/ReactCommon/react/renderer/components/slider/Android.mk
+++ b/ReactCommon/react/renderer/components/slider/Android.mk
@@ -37,7 +37,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_imagemanager \
   libreact_render_mapbuffer \
   libreact_render_uimanager \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_image \
   librrc_view \
   libyoga

--- a/ReactCommon/react/renderer/components/switch/Android.mk
+++ b/ReactCommon/react/renderer/components/switch/Android.mk
@@ -35,7 +35,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_debug \
   libreact_render_graphics \
   libreact_render_uimanager \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_view \
   libyoga
 

--- a/ReactCommon/react/renderer/textlayoutmanager/Android.mk
+++ b/ReactCommon/react/renderer/textlayoutmanager/Android.mk
@@ -31,7 +31,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_telemetry \
   libreact_render_uimanager \
   libreact_utils \
-  libreactnativeutilsjni \
+  libreactnativejni \
   libyoga
 
 LOCAL_STATIC_LIBRARIES :=

--- a/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000000..5ea2105f8ac
 --- /dev/null
 +++ b/ReactAndroid/ReactAndroid.nuspec
-@@ -0,0 +1,231 @@
+@@ -0,0 +1,221 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
@@ -92,11 +92,6 @@ index 00000000000..5ea2105f8ac
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_nativemodule_core.so" target="lib\droidarm"/>
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_nativemodule_core.so" target="lib\droidx86"/>
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_nativemodule_core.so" target="lib\droidarm64"/>
-+
-+    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreactnativeutilsjni.so" target="lib\droidx64"/>
-+    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreactnativeutilsjni.so" target="lib\droidarm"/>
-+    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreactnativeutilsjni.so" target="lib\droidx86"/>
-+    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreactnativeutilsjni.so" target="lib\droidarm64"/>
 +
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreactperfloggerjni.so" target="lib\droidx64"/>
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreactperfloggerjni.so" target="lib\droidarm"/>
@@ -193,11 +188,6 @@ index 00000000000..5ea2105f8ac
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_nativemodule_core.so" target="lib\droidarm\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_nativemodule_core.so" target="lib\droidx86\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_nativemodule_core.so" target="lib\droidarm64\unstripped"/>
-+
-+    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreactnativeutilsjni.so" target="lib\droidx64\unstripped"/>
-+    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreactnativeutilsjni.so" target="lib\droidarm\unstripped"/>
-+    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreactnativeutilsjni.so" target="lib\droidx86\unstripped"/>
-+    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreactnativeutilsjni.so" target="lib\droidarm64\unstripped"/>
 +
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreactperfloggerjni.so" target="lib\droidx64\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreactperfloggerjni.so" target="lib\droidarm\unstripped"/>

--- a/android-patches/patches/V8/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/android-patches/patches/V8/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -1,6 +1,6 @@
 --- ./ReactAndroid/src/main/jni/react/jni/Android.mk	2022-01-11 17:41:29.000000000 -0800
 +++ /var/folders/vs/8_b205053dddbcv7btj0w0v80000gn/T/update-1h8V3n/merge/V8/ReactAndroid/src/main/jni/react/jni/Android.mk	2022-01-12 15:04:31.000000000 -0800
-@@ -129,6 +129,7 @@
+@@ -87,6 +87,7 @@
  $(call import-module,reactperflogger)
  $(call import-module,hermes)
  $(call import-module,runtimeexecutor)
@@ -8,7 +8,7 @@
  $(call import-module,react/renderer/runtimescheduler)
  $(call import-module,react/nativemodule/core)
  
-@@ -147,5 +148,6 @@
+@@ -105,5 +106,6 @@
  include $(REACT_SRC_DIR)/../hermes/reactexecutor/Android.mk
  include $(REACT_SRC_DIR)/../hermes/instrumentation/Android.mk
  include $(REACT_SRC_DIR)/modules/blob/jni/Android.mk

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -1,5 +1,5 @@
 # Gemfile
 source 'https://rubygems.org'
 
-gem 'cocoapods', '= 1.11.2'
+gem 'cocoapods', '~> 1.11', '>= 1.11.2'
 gem 'rexml'


### PR DESCRIPTION
# :warning: Make sure you are targeting microsoft/react-native-macos for your PR :warning:
(then delete these lines)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Merge remote-tracking branch 'fb/0.68-stable' into 0.68-stable
## Changelog
Merge remote-tracking branch 'fb/0.68-stable' into 0.68-stable

[CATEGORY] [TYPE] - Message

## Test Plan
To be tested
