### PR TITLE
Merge pull request #1391 from rasaha91/restore-exclude-so

### DIFF
--- a/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches/Build/ReactAndroid/ReactAndroid.nuspec
@@ -1,9 +1,9 @@
 diff --git a/ReactAndroid/ReactAndroid.nuspec b/ReactAndroid/ReactAndroid.nuspec
 new file mode 100644
-index 00000000000..5ea2105f8ac
+index 00000000000..d468fe65341
 --- /dev/null
 +++ b/ReactAndroid/ReactAndroid.nuspec
-@@ -0,0 +1,231 @@
+@@ -0,0 +1,312 @@
 +<?xml version="1.0" encoding="utf-8"?>
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
@@ -118,6 +118,47 @@ index 00000000000..5ea2105f8ac
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\liblogger.so" target="lib\droidx86"/>
 +    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\liblogger.so" target="lib\droidarm64"/>
 +
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_runtimescheduler.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_runtimescheduler.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_runtimescheduler.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_runtimescheduler.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libruntimeexecutor.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libruntimeexecutor.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libruntimeexecutor.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libruntimeexecutor.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_core.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_core.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_core.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_core.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_debug.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_debug.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_debug.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_debug.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_debug.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_debug.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_debug.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_debug.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_utils.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_utils.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_utils.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_utils.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_graphics.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_graphics.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_graphics.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_graphics.so" target="lib\droidarm64"/>
++
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86_64\libreact_render_mapbuffer.so" target="lib\droidx64"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\armeabi-v7a\libreact_render_mapbuffer.so" target="lib\droidarm"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\x86\libreact_render_mapbuffer.so" target="lib\droidx86"/>
++    <file src="build\intermediates\stripped_native_libs\release\out\lib\arm64-v8a\libreact_render_mapbuffer.so" target="lib\droidarm64"/>
++
++
 +    <!-- Unstripped binaries -->
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libfb.so" target="lib\droidx64\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libfb.so" target="lib\droidarm\unstripped"/>
@@ -218,6 +259,46 @@ index 00000000000..5ea2105f8ac
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\liblogger.so" target="lib\droidarm\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\liblogger.so" target="lib\droidx86\unstripped"/>
 +    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\liblogger.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_runtimescheduler.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_runtimescheduler.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_runtimescheduler.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_runtimescheduler.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libruntimeexecutor.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libruntimeexecutor.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libruntimeexecutor.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libruntimeexecutor.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_core.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_core.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_core.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_core.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_debug.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_debug.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_debug.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_debug.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_debug.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_debug.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_debug.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_debug.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_utils.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_utils.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_utils.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_utils.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_graphics.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_graphics.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_graphics.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_graphics.so" target="lib\droidarm64\unstripped"/>
++
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86_64\libreact_render_mapbuffer.so" target="lib\droidx64\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\armeabi-v7a\libreact_render_mapbuffer.so" target="lib\droidarm\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\x86\libreact_render_mapbuffer.so" target="lib\droidx86\unstripped"/>
++    <file src="build\intermediates\merged_native_libs\release\out\lib\arm64-v8a\libreact_render_mapbuffer.so" target="lib\droidarm64\unstripped"/>
 +
 +    <!-- AAR and POM -->
 +    <file src="..\android\com\**\*" target="maven\com"/>

--- a/android-patches/patches/Build/ReactAndroid/build.gradle
+++ b/android-patches/patches/Build/ReactAndroid/build.gradle
@@ -1,5 +1,5 @@
 diff --git a/ReactAndroid/build.gradle b/ReactAndroid/build.gradle
-index 3c23c6a84b4..183bffe7164 100644
+index 3c23c6a84b4..df345f87eab 100644
 --- a/ReactAndroid/build.gradle
 +++ b/ReactAndroid/build.gradle
 @@ -12,6 +12,10 @@ plugins {
@@ -77,3 +77,18 @@ index 3c23c6a84b4..183bffe7164 100644
      preBuild.dependsOn("generateCodegenArtifactsFromSchema")
  
      sourceSets.main {
+@@ -363,8 +389,12 @@ android {
+         // we produce. The reason behind this is that we want to allow users to pick the
+         // JS engine by specifying a dependency on either `hermes-engine` or `android-jsc`
+         // that will include the necessary .so files to load.
+-        exclude("**/libhermes.so")
+-        exclude("**/libjsc.so")
++        if (project.hasProperty('param') ? project.property('param').equals("excludeLibs") : false) {
++            exclude '**/*.so'
++        } else {
++            exclude("**/libhermes.so")
++            exclude("**/libjsc.so")
++        }
+     }
+ 
+     configurations {

--- a/android-patches/patches/Build/ReactAndroid/build.gradle
+++ b/android-patches/patches/Build/ReactAndroid/build.gradle
@@ -1,5 +1,5 @@
 diff --git a/ReactAndroid/build.gradle b/ReactAndroid/build.gradle
-index 3c23c6a84b4..df345f87eab 100644
+index cae7d90ada9..f14559c03a8 100644
 --- a/ReactAndroid/build.gradle
 +++ b/ReactAndroid/build.gradle
 @@ -12,6 +12,10 @@ plugins {
@@ -60,7 +60,7 @@ index 3c23c6a84b4..df345f87eab 100644
  task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
      src("https://github.com/google/glog/archive/v${GLOG_VERSION}.tar.gz")
      onlyIfNewer(true)
-@@ -315,6 +340,7 @@ android {
+@@ -312,6 +337,7 @@ android {
                          "REACT_COMMON_DIR=$projectDir/../ReactCommon",
                          "REACT_GENERATED_SRC_DIR=$buildDir/generated/source",
                          "REACT_SRC_DIR=$projectDir/src/main/java/com/facebook/react",
@@ -68,7 +68,7 @@ index 3c23c6a84b4..df345f87eab 100644
                          "-j${ndkBuildJobs()}"
  
                  if (Os.isFamily(Os.FAMILY_MAC)) {
-@@ -339,7 +365,7 @@ android {
+@@ -331,7 +357,7 @@ android {
          }
      }
  
@@ -77,17 +77,13 @@ index 3c23c6a84b4..df345f87eab 100644
      preBuild.dependsOn("generateCodegenArtifactsFromSchema")
  
      sourceSets.main {
-@@ -363,8 +389,12 @@ android {
-         // we produce. The reason behind this is that we want to allow users to pick the
-         // JS engine by specifying a dependency on either `hermes-engine` or `android-jsc`
-         // that will include the necessary .so files to load.
--        exclude("**/libhermes.so")
--        exclude("**/libjsc.so")
+@@ -351,6 +377,10 @@ android {
+     packagingOptions {
+         exclude("META-INF/NOTICE")
+         exclude("META-INF/LICENSE")
++
 +        if (project.hasProperty('param') ? project.property('param').equals("excludeLibs") : false) {
 +            exclude '**/*.so'
-+        } else {
-+            exclude("**/libhermes.so")
-+            exclude("**/libjsc.so")
 +        }
      }
  


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Cherry-pick of changes to re-add patches that were accidentally removed during the 0.68 merge.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Cherry-pick of readding patch to exclude packaging SOs in the react-native aar.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Ensure PR build succeeds.
