### PR TITLE
Fix issue with setting initialSelectedindex to 0 in Flatlist

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -800,7 +800,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           (this.props.initialScrollIndex || 0) +
             initialNumToRenderOrDefault(this.props.initialNumToRender),
         ) - 1,
-      selectedRowIndex: this.props.initialSelectedIndex || -1, // TODO(macOS GH#774)
+      selectedRowIndex: this.props.initialSelectedIndex ?? -1, // TODO(macOS GH#774)
     };
 
     if (this._isNestedWithSameOrientation()) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

There was a bug if you set `initialSelectedIndex` to 0 on Flatlist. Turns out this was the issue:

```javascript
0 || -1; // returns -1
0 ?? -1; // returns 0
```

Derp

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Fixed issue with setting initialSelectedIndex to 0 on Flatlist

## Test Plan

Tested the cases `undefined, 0, 1, 2`

https://user-images.githubusercontent.com/6722175/187560479-977f4d92-98a9-4ad5-9150-80bd188db388.mov



