### PR TITLE
[0.66] Fix issue with setting initialSelectedindex to 0 in Flatlist

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -798,7 +798,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           (this.props.initialScrollIndex || 0) +
             initialNumToRenderOrDefault(this.props.initialNumToRender),
         ) - 1,
-      selectedRowIndex: this.props.initialSelectedIndex || -1, // TODO(macOS GH#774)
+      selectedRowIndex: this.props.initialSelectedIndex ?? -1, // TODO(macOS GH#774)
     };
 
     if (this._isNestedWithSameOrientation()) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Backport of #1399 

## Changelog

[macOS] [Fix] - Fixed issue with setting initialSelectedindex to 0 in Flatlist
