### PR TITLE
Allow clients to override keyboard focus props on FlatList

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1351,12 +1351,12 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       return (
         // $FlowFixMe[prop-missing] Invalid prop usage
         <ScrollView
-          {...props}
           // [TODO(macOS GH#774)
           {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
           onPreferredScrollerStyleDidChange={
             preferredScrollerStyleDidChangeHandler
           } // TODO(macOS GH#774)]
+          {...props}
           refreshControl={
             props.refreshControl == null ? (
               <RefreshControl
@@ -1374,12 +1374,12 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       return (
         // $FlowFixMe Invalid prop usage
         <ScrollView
-          {...props}
           // [TODO(macOS GH#774)
           {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
           onPreferredScrollerStyleDidChange={
             preferredScrollerStyleDidChangeHandler
           } // TODO(macOS GH#774)]
+          {...props}
         />
       );
     }

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -63,7 +63,11 @@ type State = {|
   fadingEdgeLength: number,
   onPressDisabled: boolean,
   textSelectable: boolean,
-  enableSelectionOnKeyPress: boolean, // TODO(macOS GH#774)
+  // [TODO(macOS GH#774)
+  enableSelectionOnKeyPress: boolean,
+  focusable: boolean,
+  enableFocusRing: boolean,
+  // ]TODO(macOS GH#774)
 |};
 
 class FlatListExample extends React.PureComponent<Props, State> {

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -198,13 +198,13 @@ class FlatListExample extends React.PureComponent<Props, State> {
               {Platform.OS === 'macos' &&
                 renderSmallSwitchOption(
                   'Focuasble',
-                  this.state.enableSelectionOnKeyPress,
+                  this.state.focusable,
                   this._setBooleanValue('focusable'),
                 )}
               {Platform.OS === 'macos' &&
                 renderSmallSwitchOption(
                   'Focus Ring',
-                  this.state.enableSelectionOnKeyPress,
+                  this.state.enableFocusRing,
                   this._setBooleanValue('enableFocusRing'),
                 )}
               {/* TODO(macOS GH#774)] */}

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -81,7 +81,11 @@ class FlatListExample extends React.PureComponent<Props, State> {
     fadingEdgeLength: 0,
     onPressDisabled: false,
     textSelectable: true,
-    enableSelectionOnKeyPress: false, //  TODO(macOS GH#774)
+    //  [TODO(macOS GH#774)
+    enableSelectionOnKeyPress: false,
+    focusable: true,
+    enableFocusRing: true,
+    //  ]TODO(macOS GH#774)
   };
 
   _onChangeFilterText = filterText => {
@@ -191,6 +195,18 @@ class FlatListExample extends React.PureComponent<Props, State> {
                   this.state.enableSelectionOnKeyPress,
                   this._setBooleanValue('enableSelectionOnKeyPress'),
                 )}
+              {Platform.OS === 'macos' &&
+                renderSmallSwitchOption(
+                  'Focuasble',
+                  this.state.enableSelectionOnKeyPress,
+                  this._setBooleanValue('focusable'),
+                )}
+              {Platform.OS === 'macos' &&
+                renderSmallSwitchOption(
+                  'Focus Ring',
+                  this.state.enableSelectionOnKeyPress,
+                  this._setBooleanValue('enableFocusRing'),
+                )}
               {/* TODO(macOS GH#774)] */}
               {Platform.OS === 'android' && (
                 <View>
@@ -214,6 +230,8 @@ class FlatListExample extends React.PureComponent<Props, State> {
             // [TODO(macOS GH#774)
             enableSelectionOnKeyPress={this.state.enableSelectionOnKeyPress}
             initialSelectedIndex={0}
+            focusable={this.state.focusable}
+            enableFocusRing={this.state.enableFocusRing}
             // ]TODO(macOS GH#774)
             fadingEdgeLength={this.state.fadingEdgeLength}
             ItemSeparatorComponent={ItemSeparatorComponent}


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

With `enableSelectionOnKeyPress` set to true, I made the Flatlist by default focusable and show the focus ring. This matches the behavior of some NSTableViews in macOS, but not all. There are cases where the overall table is focusable and does not show a focus ring (showing the selected cells with a highlight instead) like in sidebars. 

Let's allow the user to override `focusable` and `enableFocusRing` on Flatlist, so that they have more control over the UX. Turns out all this needed was moving `{...props}` _after_ `keyboardNavigationProps`, so that the users passed in props could overwrite the defaults. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Allow clients to override keyboard focus props on FlatList

## Test Plan

Added two switches to the test page to test the combos of props. 

https://user-images.githubusercontent.com/6722175/187573457-2a852d49-f1ee-4d6a-853c-6a89716c1842.mov


