### PR TITLE
Add patch to issue warning instead of error for acceptsKeyboardFocus

### DIFF
--- a/.ado/templates/apple-droid-node-patching.yml
+++ b/.ado/templates/apple-droid-node-patching.yml
@@ -5,4 +5,4 @@ steps:
   - task: CmdLine@2
     displayName: Apply Android specific patches for Office consumption
     inputs:
-      script: npm_config_yes=true npx @rnx-kit/patcher-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC RootViewAttach --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}
+      script: npm_config_yes=true npx @rnx-kit/patcher-rnmacos patch $(System.DefaultWorkingDirectory) Build OfficeRNHost V8 Focus MAC RootViewAttach ErrorToWarning --patch-store $(System.DefaultWorkingDirectory)/android-patches/patches --log-folder $(System.DefaultWorkingDirectory)/android-patches/logs --confirm ${{ parameters.apply_office_patches }}

--- a/android-patches/patches/ErrorToWarning/Libraries/Components/View/View.js
+++ b/android-patches/patches/ErrorToWarning/Libraries/Components/View/View.js
@@ -1,0 +1,22 @@
+diff --git a/Libraries/Components/View/View.js b/Libraries/Components/View/View.js
+index 42da7a9215e..f8355eef6fd 100644
+--- a/Libraries/Components/View/View.js
++++ b/Libraries/Components/View/View.js
+@@ -29,11 +29,12 @@ const View: React.AbstractComponent<
+   React.ElementRef<typeof ViewNativeComponent>,
+ > = React.forwardRef((props: ViewProps, forwardedRef) => {
+   // [TODO(macOS GH#774)
+-  invariant(
+-    // $FlowFixMe Wanting to catch untyped usages
+-    props.acceptsKeyboardFocus === undefined,
+-    'Support for the "acceptsKeyboardFocus" property has been removed in favor of "focusable"',
+-  );
++  if (props.acceptsKeyboardFocus !== undefined) {
++    warnOnce(
++      'deprecated-acceptsKeyboardFocus',
++      '"acceptsKeyboardFocus" has been deprecated in favor of "focusable" and will be removed soon',
++    );
++  }
+   // TODO(macOS GH#774)]
+   return (
+     <TextAncestor.Provider value={false}>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
In order to unblock the RN68 bump for Office, we will temporarily need to patch RN to issue a warning instead of error for use of acceptsKeyboardFocus. Once we are able to consume fixed bundles that do not make use of the deprecated property, we will revert the patch.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Temporarily patch RN Android to issue warnings instead of errors for use of acceptsKeyboardFocus

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Test built nuget package on local office build and ensure currently broken bundles render.
