### PR TITLE
[0.66] Allow clients to override keyboard focus props on FlatList

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1352,12 +1352,12 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       return (
         // $FlowFixMe[prop-missing] Invalid prop usage
         <ScrollView
-          {...props}
           // [TODO(macOS GH#774)
           {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
           onPreferredScrollerStyleDidChange={
             preferredScrollerStyleDidChangeHandler
           } // TODO(macOS GH#774)]
+          {...props}
           refreshControl={
             props.refreshControl == null ? (
               <RefreshControl
@@ -1375,12 +1375,12 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       return (
         // $FlowFixMe Invalid prop usage
         <ScrollView
-          {...props}
           // [TODO(macOS GH#774)
           {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
           onPreferredScrollerStyleDidChange={
             preferredScrollerStyleDidChangeHandler
           } // TODO(macOS GH#774)]
+          {...props}
         />
       );
     }

--- a/packages/rn-tester/js/examples/FlatList/FlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExample.js
@@ -61,7 +61,11 @@ type State = {|
   fadingEdgeLength: number,
   onPressDisabled: boolean,
   textSelectable: boolean,
-  enableSelectionOnKeyPress: boolean, // TODO(macOS GH#774)
+  // [TODO(macOS GH#774)
+  enableSelectionOnKeyPress: boolean,
+  focusable: boolean,
+  enableFocusRing: boolean,
+  // ]TODO(macOS GH#774)
 |};
 
 class FlatListExample extends React.PureComponent<Props, State> {
@@ -79,7 +83,11 @@ class FlatListExample extends React.PureComponent<Props, State> {
     fadingEdgeLength: 0,
     onPressDisabled: false,
     textSelectable: true,
-    enableSelectionOnKeyPress: false, //  TODO(macOS GH#774)
+    //  [TODO(macOS GH#774)
+    enableSelectionOnKeyPress: false,
+    focusable: true,
+    enableFocusRing: true,
+    //  ]TODO(macOS GH#774)
   };
 
   _onChangeFilterText = filterText => {
@@ -179,6 +187,18 @@ class FlatListExample extends React.PureComponent<Props, State> {
                   this.state.enableSelectionOnKeyPress,
                   this._setBooleanValue('enableSelectionOnKeyPress'),
                 )}
+              {Platform.OS === 'macos' &&
+                renderSmallSwitchOption(
+                  'Focuasble',
+                  this.state.focusable,
+                  this._setBooleanValue('focusable'),
+                )}
+              {Platform.OS === 'macos' &&
+                renderSmallSwitchOption(
+                  'Focus Ring',
+                  this.state.enableFocusRing,
+                  this._setBooleanValue('enableFocusRing'),
+                )}
               {/* TODO(macOS GH#774)] */}
               {Platform.OS === 'android' && (
                 <View>
@@ -202,6 +222,8 @@ class FlatListExample extends React.PureComponent<Props, State> {
             // [TODO(macOS GH#774)
             enableSelectionOnKeyPress={this.state.enableSelectionOnKeyPress}
             initialSelectedIndex={0}
+            focusable={this.state.focusable}
+            enableFocusRing={this.state.enableFocusRing}
             // ]TODO(macOS GH#774)
             fadingEdgeLength={this.state.fadingEdgeLength}
             ItemSeparatorComponent={ItemSeparatorComponent}


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry pick of #1403

## Changelog

[macOS] [Fixed] - Allow clients to override keyboard focus props on FlatList

