### PR TITLE
Fix macOS 13 build error 

### DIFF
--- a/React/Views/RCTActivityIndicatorView.m
+++ b/React/Views/RCTActivityIndicatorView.m
@@ -8,7 +8,8 @@
 #import "RCTActivityIndicatorView.h"
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
-#import <QuartzCore/QuartzCore.h>
+#import <CoreImage/CIFilter.h>
+#import <CoreImage/CIVector.h>
 
 @interface RCTActivityIndicatorView ()
 @property (nonatomic, readwrite, getter=isAnimating) BOOL animating;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

For whatever reason, I need to update these headers to build on macOS 13 Ventura, Beta 4. 

Error message before update:


> error build: Definition of 'CIFilter' must be imported from module 'CoreImage.CIFilter' before it is required

## Changelog


[macOS] [Fixed] - Fix macOS 13 build error 

## Test Plan

Builds on my local machine. I'm hoping the CI will inform me whether this change is valid on older macOS versions.
