### PR TITLE
Adds declarative props to clear/submit MultilineTextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -353,6 +353,31 @@ type IOSProps = $ReadOnly<{|
   textContentType?: ?TextContentType,
 |}>;
 
+// [TODO(macOS GH#774)
+export type SubmitKeyEvent = $ReadOnly<{|
+  key: string,
+  altKey?: ?boolean,
+  ctrlKey?: ?boolean,
+  metaKey?: ?boolean,
+  shiftKey?: ?boolean,
+  functionKey?: ?boolean,
+|}>;
+
+type MacOSProps = $ReadOnly<{|
+  /**
+   * If `true`, clears the text field synchronously before `onSubmitEditing` is emitted.
+   * @platform macos
+   */
+  clearTextOnSubmit?: ?boolean,
+
+  /**
+   * Configures keys that can be used to submit editing for the TextInput. Defaults to 'Enter' key.
+   * @platform macos
+   */
+  submitKeyEvents?: ?$ReadOnlyArray<SubmitKeyEvent>,
+|}>;
+// ]TODO(macOS GH#774)
+
 type AndroidProps = $ReadOnly<{|
   /**
    * Specifies autocomplete hints for the system, so it can provide autofill. On Android, the system will always attempt to offer autofill by using heuristics to identify the type of content.
@@ -515,6 +540,7 @@ type AndroidProps = $ReadOnly<{|
 export type Props = $ReadOnly<{|
   ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
   ...IOSProps,
+  ...MacOSProps,
   ...AndroidProps,
 
   /**

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -555,9 +555,18 @@ static RCTUIColor *defaultPlaceholderColor() // TODO(OSS Candidate ISS#2710739)
 }
 #else
 - (void)keyDown:(NSEvent *)event {
-  // If hasMarkedText is true then an IME is open, so don't send event to JS.
-  if (self.hasMarkedText || [self.textInputDelegate textInputShouldHandleKeyEvent:event]) {
+  // If has marked text, handle by native and return
+  // Do this check before textInputShouldHandleKeyEvent as that one attempts to send the event to JS
+  if (self.hasMarkedText) {
     [super keyDown:event];
+    return;
+  }
+
+  // textInputShouldHandleKeyEvent represents if native should handle the event instead of JS.
+  // textInputShouldHandleKeyEvent also sends keyDown event to JS internally, so we only call this once  
+  if ([self.textInputDelegate textInputShouldHandleKeyEvent:event]) {
+    [super keyDown:event];
+    [self.textInputDelegate submitOnKeyDownIfNeeded:event];
   }
 }
 

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)automaticSpellingCorrectionDidChange:(BOOL)enabled;
 - (void)continuousSpellCheckingDidChange:(BOOL)enabled;
 - (void)grammarCheckingDidChange:(BOOL)enabled;
+- (void)submitOnKeyDownIfNeeded:(NSEvent *)event;
 #endif // ]TODO(macOS GH#774)
 
 /*

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -47,8 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) RCTBubblingEventBlock onAutoCorrectChange;
 @property (nonatomic, copy, nullable) RCTBubblingEventBlock onSpellCheckChange;
 @property (nonatomic, copy, nullable) RCTBubblingEventBlock onGrammarCheckChange;
+@property (nonatomic, assign) BOOL clearTextOnSubmit;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onSubmitEditing;
+@property (nonatomic, copy) NSArray<NSDictionary *> *submitKeyEvents;
 #endif // TODO(macOS GH#774)
-
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, assign, readonly) NSInteger nativeEventCount;
 @property (nonatomic, assign) BOOL autoFocus;

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -71,6 +71,11 @@ RCT_EXPORT_VIEW_PROPERTY(passwordRules, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onAutoCorrectChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onSpellCheckChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onGrammarCheckChange, RCTBubblingEventBlock);
+
+// Specifically for clearing text on enter key press
+RCT_EXPORT_VIEW_PROPERTY(clearTextOnSubmit, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(onSubmitEditing, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(submitKeyEvents, NSArray<NSDictionary *>);
 #endif // TODO(macOS GH#774)
 
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -304,6 +304,9 @@ const styles = StyleSheet.create({
     fontFamily: 'Cochin',
     height: 60,
   },
+  singleLine: {
+    fontSize: 16,
+  },
   singlelinePlaceholderStyles: {
     letterSpacing: 10,
     textAlign: 'center',
@@ -945,6 +948,42 @@ if (Platform.OS === 'macos') {
         'AutoCorrect, spellCheck and grammarCheck callbacks - Multiline Textfield',
       render: function (): React.Node {
         return <AutoCorrectSpellCheckGrammarCheckCallbacks />;
+      },
+    },
+    {
+      title: 'Clear text on submit - Multiline Textfield',
+      render: function (): React.Node {
+        return (
+          <View>
+            <Text>Default submit key (Enter):</Text>
+            <TextInput
+              multiline={true}
+              clearTextOnSubmit={true}
+              style={styles.multiline}
+            />
+            <Text>Custom submit key (Enter): - same as above</Text>
+            <TextInput
+              multiline={true}
+              clearTextOnSubmit={true}
+              style={styles.multiline}
+              submitKeyEvents={[{key: 'Enter'}]}
+            />
+            <Text>Custom submit key (CMD + Enter):</Text>
+            <TextInput
+              multiline={true}
+              clearTextOnSubmit={true}
+              style={styles.multiline}
+              submitKeyEvents={[{key: 'Enter', metaKey: true}]}
+            />
+            <Text>Custom submit key (Shift + Enter):</Text>
+            <TextInput
+              multiline={true}
+              clearTextOnSubmit={true}
+              style={styles.multiline}
+              submitKeyEvents={[{key: 'Enter', shiftKey: true}]}
+            />
+          </View>
+        );
       },
     },
     {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This brings macOS parity with react-native-windows https://github.com/microsoft/react-native-windows/pull/7333 for MultilineTextInput fields See react-native-windows PR for desired feature set.

We can't do it for SinglelineTextInput fields (at least not w/o hacks) as it does not support overriding the keyDown event :-( https://stackoverflow.com/a/6076492

## Changelog

[macOS] [Added] - Adds declarative props to clear/submit MultilineTextInput

## Test Plan


https://user-images.githubusercontent.com/484044/189212524-3e1cee6e-a123-46c3-94c5-4e30f5917d5c.mov

