### PR TITLE
Grab RCTPerfMonitor's devSettings from the bridge

### DIFF
--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -176,7 +176,7 @@ RCT_EXPORT_MODULE()
 {
   if (!_devMenuItem) {
     __weak __typeof__(self) weakSelf = self;
-    __weak RCTDevSettings *devSettings = [self->_moduleRegistry moduleForName:"DevSettings"];
+    __weak RCTDevSettings *devSettings = [[self bridge] devSettings]; // TODO(macOS GH#774)
     if (devSettings.isPerfMonitorShown) {
       [weakSelf show];
     }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

We've seen an issue on iOS when doing remote web debugging while using [integrated RN](https://reactnative.dev/docs/integration-with-existing-apps) with a custom `RCTDevSettingsDataSource` that doesn't persist globally (unlike [the default](https://github.com/microsoft/react-native-macos/blob/b0aff93e9f804ef399737a8af5b48dd1761bf7de/React/CoreModules/RCTDevSettings.h#L15-L39) which uses `NSUserSettings`), a scenario useful when simultaneously running multiple RN instances with different dev settings.

When we reload the bridge upon establishing a remote debugging connection, we reinitialize all our modules. On iOS this includes `PerfMonitor`, which depends on `DevSettings`, which attempts to load the current values using the default `NSUserSettings`-based dev settings when it gets reinitialized. However, since the original custom data source is designed to keep dev settings compartmentalized to particular RN instances, our "global defaults" that we load upon initialization have a different value. This causes the bridge to reload once again, resulting in an infinite loop.

The fix here is to use the bridge's already established `devSettings` so we ensure we're using our local dev settings instead of trying to default to global ones.

## Changelog

[iOS] [Fixed] - Fix issue with custom non-persistent `RCTDevSettingsDataSource`

## Test Plan

Validated that this fixes the original issue while keeping remote debugging in RNTester okay. Initial tests show that for `RCTPerfMonitor`, `[self->_moduleRegistry moduleForName:"DevSettings"]` and `[[self bridge] devSettings]` return the same value, so this shouldn't affect the remote debugging process in other cases.
