### PR TITLE
[0.68-stable] Grab RCTPerfMonitor's devSettings from the bridge

### DIFF
--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -176,7 +176,7 @@ RCT_EXPORT_MODULE()
 {
   if (!_devMenuItem) {
     __weak __typeof__(self) weakSelf = self;
-    __weak RCTDevSettings *devSettings = [self->_moduleRegistry moduleForName:"DevSettings"];
+    __weak RCTDevSettings *devSettings = [[self bridge] devSettings]; // TODO(macOS GH#774)
     if (devSettings.isPerfMonitorShown) {
       [weakSelf show];
     }


### PR DESCRIPTION
Cherry-pick of #1426.