### PR TITLE
Fix rn-tester TextInput warning for missing image.source.uri

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -412,7 +412,9 @@ function OnPaste(): React.Node {
     newLog.unshift(line);
     setLog(newLog);
   };
-  const [imageUri, setImageUri] = React.useState('');
+  const [imageUri, setImageUri] = React.useState(
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg==',
+  );
   return (
     <>
       <TextInput


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This fixes an rn-tester only warning introduced in https://github.com/microsoft/react-native-macos/pull/1350 as the image.source.uri should not be empty

## Changelog

[macOS] [Fixed] - Fix rn-tester TextInput warning for missing image.source.uri

## Test Plan

Before
![MicrosoftTeams-image](https://user-images.githubusercontent.com/484044/189795730-cf448742-9d63-4e11-8446-dbeb58c46088.png)


After





https://user-images.githubusercontent.com/484044/189795744-f755c92d-f182-4d44-912c-938cd2e567f1.mov

