### PR TITLE
AB#6796163: Reverting the old logic in engine selection to old behaviour

### DIFF
--- a/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/android-patches/patches/V8/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -1,5 +1,5 @@
---- "C:\\github\\react-native\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactInstanceManagerBuilder.java"	2022-08-05 12:59:58.286964700 +0530
-+++ "C:\\github\\react-native-macos\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactInstanceManagerBuilder.java"	2022-08-05 15:08:37.009898300 +0530
+--- "\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactInstanceManagerBuilder.java"	2022-09-29 15:47:40.515043600 -0700
++++ "\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactInstanceManagerBuilder.java"	2022-09-29 15:57:50.948475300 -0700
 @@ -34,6 +34,8 @@
  import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
  import com.facebook.react.packagerconnection.RequestHandler;
@@ -9,13 +9,32 @@
  import java.util.ArrayList;
  import java.util.List;
  import java.util.Map;
-@@ -397,6 +399,9 @@
+@@ -382,22 +384,15 @@
+     // if nothing is specified, use old loading method
+     // else load the required engine
+     if (jsInterpreter == JSInterpreter.OLD_LOGIC) {
+-      try {
+-        // If JSC is included, use it as normal
+-        initializeSoLoaderIfNecessary(applicationContext);
+-        JSCExecutor.loadLibrary();
+-        return new JSCExecutorFactory(appName, deviceName);
+-      } catch (UnsatisfiedLinkError jscE) {
+-        if (jscE.getMessage().contains("__cxa_bad_typeid")) {
+-          throw jscE;
+-        }
+-        HermesExecutor.loadLibrary();
+-        return new HermesExecutorFactory();
+-      }
++      V8Executor.loadLibrary();
++      return new V8ExecutorFactory(appName, deviceName);
      } else if (jsInterpreter == JSInterpreter.HERMES) {
        HermesExecutor.loadLibrary();
        return new HermesExecutorFactory();
+-    } else {
 +    } else if(jsInterpreter == JSInterpreter.V8) {
 +      V8Executor.loadLibrary();
 +      return new V8ExecutorFactory(appName, deviceName);
-     } else {
++     } else {
        JSCExecutor.loadLibrary();
        return new JSCExecutorFactory(appName, deviceName);
+     }


### PR DESCRIPTION
Reverting the old_logic codepath in engine selection to old behaviour

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

There were some changes in the JS engine selection logic in RN68, which conflicted with our V8 patched. When rebasing patches we ended up with some subtle behaviour difference which broke commenting test app. 
This patch ensures that any apps without a custom JS executor will use V8.

## Changelog

There were some changes in the JS engine selection logic in RN68, which conflicted with our V8 patched. When rebasing patches we ended up with some subtle behaviour difference which broke commenting test app. 
This patch ensures that any apps without a custom JS executor will use V8.
[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
