### PR TITLE
Update yaml to add homebrew to PATH

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -197,6 +197,11 @@ jobs:
 
       - template: templates/android-build-office-setup.yml
 
+      - bash: |
+            echo "##vso[task.prependpath]/home/linuxbrew/.linuxbrew/bin"
+            echo ##vso[task.prependpath]/home/linuxbrew/.linuxbrew/sbin
+        displayName: Add Homebrew to PATH
+
       - task: CmdLine@2
         displayName: Bump package version
         inputs:


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary

Homebrew has been removed from GHA, see https://github.com/actions/runner-images/issues/6283

Let's add a step for adding homebrew to PATH.

## Changelog

[macOS] [Fixed] - Update yaml to add Homebrew to PATH

## Test Plan
CI
