### PR TITLE
Bump brew script up

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -205,6 +205,11 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      - bash: |
+            echo "##vso[task.prependpath]/home/linuxbrew/.linuxbrew/bin"
+            echo ##vso[task.prependpath]/home/linuxbrew/.linuxbrew/sbin
+        displayName: Add Homebrew to PATH
+
       - template: templates/android-build-office-setup.yml
 
       - template: templates/apple-node-setup.yml
@@ -218,11 +223,6 @@ jobs:
         displayName: Install bundler
         inputs:
           script: gem install bundler
-
-      - bash: |
-            echo "##vso[task.prependpath]/home/linuxbrew/.linuxbrew/bin"
-            echo ##vso[task.prependpath]/home/linuxbrew/.linuxbrew/sbin
-        displayName: Add Homebrew to PATH
 
       - task: CmdLine@2
         displayName: Bump package version


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

## Summary
https://github.com/microsoft/react-native-macos/pull/1441 added a step for adding Homebrew to PATH. Turns out brew is needed for earlier steps like apple-node-setup, so let's bump it up.
## Changelog

[macOS] [Fixed] - Message

## Test Plan
Just CI, will make necessary changes if anything goes wrong.
