### PR TITLE
Update to new version of maven-dependency-utils

### DIFF
--- a/.ado/templates/download-android-dependencies.yml
+++ b/.ado/templates/download-android-dependencies.yml
@@ -11,4 +11,4 @@ steps:
   - task: CmdLine@2
     displayName: 'Verify Dependencies can be enumerated'
     inputs:
-      script: pip3 install maven-dependency-utils==1.22.0 requests && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android
+      script: pip3 install maven-dependency-utils==1.24.0 && python3 .ado/downloadAndroidDependencies.py $(Build.SourcesDirectory) && tree $(Build.SourcesDirectory)/android


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The latest version of maven-dependency-utils automatically pulls in transitive python dependencies, so we do not need to explicitly pip install requests, which is never used directly.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Bump maven-dependency-utils and remove explicit dependency on requests

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Ensure PR build succeeds.