### PR TITLE
Fix drag and drop of files in multiline textfield when a custom draggedType property is used

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -681,7 +681,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)decoder)
 - (BOOL)textInputShouldHandlePaste:(__unused id)sender
 {
   NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
-  NSPasteboardType fileType = [pasteboard availableTypeFromArray:@[NSPasteboardTypeFileURL, NSPasteboardTypePNG, NSPasteboardTypeTIFF]];
+  NSPasteboardType fileType = [pasteboard availableTypeFromArray:@[NSFilenamesPboardType, NSPasteboardTypePNG, NSPasteboardTypeTIFF]];
   NSArray<NSPasteboardType>* pastedTypes = ((RCTUITextView*) self.backedTextInputView).readablePasteboardTypes;
       
   // If there's a fileType that is of interest, notify JS. Also blocks notifying JS if it's a text paste

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1233,7 +1233,7 @@ RCT_JSON_ARRAY_CONVERTER(NSNumber)
   }
   
   if ([type isEqualToString:@"fileUrl"]) {
-    return @[NSPasteboardTypeFileURL];
+    return @[NSFilenamesPboardType];
   } else if ([type isEqualToString:@"image"]) {
     return @[NSPasteboardTypePNG, NSPasteboardTypeTIFF];
   } else if ([type isEqualToString:@"string"]) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

In https://github.com/microsoft/react-native-macos/pull/1429 I had naively assumed that `NSPasteboardTypeFileURL` is 1:1 replacement for the deprecated `NSFilenamesPboardType` property. It is not. It causes drag and drop of files from Finder to stop working when a `pastedTypes` property is set.

## Changelog

[macOS][Fixed] - Fix drag and drop of files in multiline textfield when a custom draggedType property is used

## Test Plan

Before

https://user-images.githubusercontent.com/484044/195694913-2bdfa768-4e84-4e2e-9788-7eb5948f009c.mov



After


https://user-images.githubusercontent.com/484044/195694931-66821d49-81ff-4ceb-aeaf-055322648f6e.mov

