### PR TITLE
Flatlist: Let ArrowUp/ArrowDown bubble at the top/bottom of list

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1335,14 +1335,14 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     const invertedDidChange = this.props.onInvertedDidChange;
 
     const isFirstRowSelected = this.state.selectedRowIndex === this.state.first;
-    const isLasttRowSelected = this.state.selectedRowIndex === this.state.last;
+    const isLastRowSelected = this.state.selectedRowIndex === this.state.last;
 
     // Don't pass in ArrowUp/ArrowDown at the top/bottom of the list so that keyboard event can bubble
     let _validKeysDown = ['Home', 'End'];
     if (!isFirstRowSelected) {
       _validKeysDown.push('ArrowUp');
     }
-    if (!isLasttRowSelected) {
+    if (!isLastRowSelected) {
       _validKeysDown.push('ArrowDown');
     }
 

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1334,9 +1334,21 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       this.props.onPreferredScrollerStyleDidChange;
     const invertedDidChange = this.props.onInvertedDidChange;
 
+    const isFirstRowSelected = this.state.selectedRowIndex === this.state.first;
+    const isLasttRowSelected = this.state.selectedRowIndex === this.state.last;
+
+    // Don't pass in ArrowUp/ArrowDown at the top/bottom of the list so that keyboard event can bubble
+    let _validKeysDown = ['Home', 'End'];
+    if (!isFirstRowSelected) {
+      _validKeysDown.push('ArrowUp');
+    }
+    if (!isLasttRowSelected) {
+      _validKeysDown.push('ArrowDown');
+    }
+
     const keyboardNavigationProps = {
       focusable: true,
-      validKeysDown: ['ArrowUp', 'ArrowDown', 'Home', 'End'],
+      validKeysDown: _validKeysDown,
       onKeyDown: this._handleKeyDown,
     };
     // ]TODO(macOS GH#774)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

We have a client who would like the ArrowUp/Down event to bubble at the top and bottom of Flatlist (so that a super view like FocusZone can handle it). This is a simple change to make that happen. 

## Changelog

[macOS] [Fixed] - Flatlist: Let ArrowUp/ArrowDown bubble at the top/bottom of list

## Test Plan

(I didn't include the test code in this PR)

Added a simple `validKeysDown/onKeyDown` test to the View that wraps `<Flatlist>` in the Flatlist test page to verify that the event did bubble. 

https://user-images.githubusercontent.com/6722175/198132559-082ca8e0-af82-4d1e-90d1-05a75f72d3df.mov

