### PR TITLE
Enable .podspec files for Fabric

### DIFF
--- a/React/React-RCTFabric.podspec
+++ b/React/React-RCTFabric.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "11.0" }
+  s.platforms              = { :ios => "11.0", :osx => "10.15" } # TODO(macOS GH#774)
   s.source                 = source
   s.source_files           = "Fabric/**/*.{c,h,m,mm,S,cpp}"
   s.exclude_files          = "**/tests/*",

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "11.0" }
+  s.platforms              = { :ios => "11.0", :osx => "10.15" } # TODO(macOS GH#774)
   s.source                 = source
   s.source_files           = "dummyFile.cpp"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",

--- a/ReactCommon/React-rncore.podspec
+++ b/ReactCommon/React-rncore.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "11.0" }
+  s.platforms              = { :ios => "11.0", :osx => "10.15" } # TODO(macOS GH#774)
   s.source                 = source
   s.source_files           = "dummyFile.cpp"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",

--- a/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "11.0", :tvos => "11.0" }
+  s.platforms              = { :ios => "11.0", :osx => "10.15" } # TODO(macOS GH#774)
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = "**/*.{m,mm,cpp,h}"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Right now running:
bundle install && USE_FABRIC=1 bundle exec pod install

in packages/rn-tester fails as certain targets are not enabled for macOS 10.15

This fixes the .podspec files - Fabric related code does not compile - but at least we can build rn-iOS with Fabric now.

## ATTENTION, ATTENTION
If you ever build with Fabric enabled and then switch to a non Fabric workspace > there is a huge change the Xcode will produce funky compile errors.

Follow https://reactnative.dev/docs/the-new-architecture/use-app-template#troubleshooting

## Changelog

[macOS] [Fixed] - Enable .podspec files for Fabric

## Test Plan

Pod installation complete! There are 69 dependencies from the Podfile and 57 total pods installed.

[!] The Podfile contains framework or static library targets (iosDeviceBuild, iosSimulatorBuild, macOSBuild), for which the Podfile does not contain host targets (targets which embed the framework). If this project is for doing framework development, you can ignore this message. Otherwise, add a target to the Podfile that embeds these frameworks to make this message go away (e.g. a test target).
