### PR TITLE
Fix compile errors when building with Fabric on rn-iOS

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -82,7 +82,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   butter::shared_mutex _observerListMutex;
   NSMutableArray<id<RCTSurfacePresenterObserver>> *_observers;
   RCTImageLoader *_imageLoader;
-  RuntimeExecutor _runtimeExecutor;
 }
 
 - (instancetype)initWithContextContainer:(ContextContainer::Shared)contextContainer


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When enabling the Fabric podspec files
https://github.com/microsoft/react-native-macos/pull/1460 we can't even compile rn-iOS.

Here is the 1st of 2 necessary fixes
## Changelog

[iOS] [Fixed] - Fix compile errors when building with Fabric on rn-iOS

## Test Plan


https://user-images.githubusercontent.com/484044/198394877-f9a70a11-41e9-41c7-a3ac-d749a2ef933a.mov

