### PR TITLE
Force update to 0.68.56

### DIFF
--- a/Libraries/Core/ReactNativeVersion.js
+++ b/Libraries/Core/ReactNativeVersion.js
@@ -16,6 +16,6 @@
 exports.version = {
   major: 0,
   minor: 68,
-  patch: 55,
+  patch: 56,
   prerelease: null,
 };

--- a/React/Base/RCTVersion.m
+++ b/React/Base/RCTVersion.m
@@ -27,7 +27,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(68),
-                  RCTVersionPatch: @(55),
+                  RCTVersionPatch: @(56),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.68.55
+VERSION_NAME=0.68.56
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -21,6 +21,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 68,
-      "patch", 55,
+      "patch", 56,
       "prerelease", null);
 }

--- a/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -21,7 +21,7 @@ namespace facebook::react {
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 68;
-  int32_t Patch = 55;
+  int32_t Patch = 56;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-macos",
   "private": true,
-  "version": "0.68.55",
+  "version": "0.68.56",
   "bin": "./cli.js",
   "description": "React Native for macOS",
   "license": "MIT",

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.55)
-  - FBReactNativeSpec (0.68.55):
+  - FBLazyVector (0.68.56)
+  - FBReactNativeSpec (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.55)
-    - RCTTypeSafety (= 0.68.55)
-    - React-Core (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
+    - RCTRequired (= 0.68.56)
+    - RCTTypeSafety (= 0.68.56)
+    - React-Core (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -86,312 +86,312 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.55)
-  - RCTTypeSafety (0.68.55):
-    - FBLazyVector (= 0.68.55)
+  - RCTRequired (0.68.56)
+  - RCTTypeSafety (0.68.56):
+    - FBLazyVector (= 0.68.56)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.55)
-    - React-Core (= 0.68.55)
-  - React (0.68.55):
-    - React-Core (= 0.68.55)
-    - React-Core/DevSupport (= 0.68.55)
-    - React-Core/RCTWebSocket (= 0.68.55)
-    - React-RCTActionSheet (= 0.68.55)
-    - React-RCTAnimation (= 0.68.55)
-    - React-RCTBlob (= 0.68.55)
-    - React-RCTImage (= 0.68.55)
-    - React-RCTLinking (= 0.68.55)
-    - React-RCTNetwork (= 0.68.55)
-    - React-RCTSettings (= 0.68.55)
-    - React-RCTText (= 0.68.55)
-    - React-RCTVibration (= 0.68.55)
-  - React-callinvoker (0.68.55)
-  - React-Codegen (0.68.55):
-    - FBReactNativeSpec (= 0.68.55)
+    - RCTRequired (= 0.68.56)
+    - React-Core (= 0.68.56)
+  - React (0.68.56):
+    - React-Core (= 0.68.56)
+    - React-Core/DevSupport (= 0.68.56)
+    - React-Core/RCTWebSocket (= 0.68.56)
+    - React-RCTActionSheet (= 0.68.56)
+    - React-RCTAnimation (= 0.68.56)
+    - React-RCTBlob (= 0.68.56)
+    - React-RCTImage (= 0.68.56)
+    - React-RCTLinking (= 0.68.56)
+    - React-RCTNetwork (= 0.68.56)
+    - React-RCTSettings (= 0.68.56)
+    - React-RCTText (= 0.68.56)
+    - React-RCTVibration (= 0.68.56)
+  - React-callinvoker (0.68.56)
+  - React-Codegen (0.68.56):
+    - FBReactNativeSpec (= 0.68.56)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.55)
-    - RCTTypeSafety (= 0.68.55)
-    - React-Core (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-Core (0.68.55):
+    - RCTRequired (= 0.68.56)
+    - RCTTypeSafety (= 0.68.56)
+    - React-Core (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-Core (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.55)
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-Core/Default (= 0.68.56)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.55):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
-    - Yoga
-  - React-Core/Default (0.68.55):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
-    - Yoga
-  - React-Core/DevSupport (0.68.55):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.55)
-    - React-Core/RCTWebSocket (= 0.68.55)
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-jsinspector (= 0.68.55)
-    - React-perflogger (= 0.68.55)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.55):
+  - React-Core/CoreModulesHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.55):
+  - React-Core/Default (0.68.56):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
+    - Yoga
+  - React-Core/DevSupport (0.68.56):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.56)
+    - React-Core/RCTWebSocket (= 0.68.56)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-jsinspector (= 0.68.56)
+    - React-perflogger (= 0.68.56)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.55):
+  - React-Core/RCTAnimationHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.55):
+  - React-Core/RCTBlobHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.55):
+  - React-Core/RCTImageHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.55):
+  - React-Core/RCTLinkingHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.68.55):
+  - React-Core/RCTNetworkHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.55):
+  - React-Core/RCTPushNotificationHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.55):
+  - React-Core/RCTSettingsHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.55):
+  - React-Core/RCTTextHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.55):
+  - React-Core/RCTVibrationHeaders (0.68.56):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.55)
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsiexecutor (= 0.68.55)
-    - React-perflogger (= 0.68.55)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
     - Yoga
-  - React-CoreModules (0.68.55):
+  - React-Core/RCTWebSocket (0.68.56):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.55)
-    - React-Codegen (= 0.68.55)
-    - React-Core/CoreModulesHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-RCTImage (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-cxxreact (0.68.55):
+    - React-Core/Default (= 0.68.56)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsiexecutor (= 0.68.56)
+    - React-perflogger (= 0.68.56)
+    - Yoga
+  - React-CoreModules (0.68.56):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.56)
+    - React-Codegen (= 0.68.56)
+    - React-Core/CoreModulesHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-RCTImage (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-cxxreact (0.68.56):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-jsinspector (= 0.68.55)
-    - React-logger (= 0.68.55)
-    - React-perflogger (= 0.68.55)
-    - React-runtimeexecutor (= 0.68.55)
-  - React-jsi (0.68.55):
+    - React-callinvoker (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-jsinspector (= 0.68.56)
+    - React-logger (= 0.68.56)
+    - React-perflogger (= 0.68.56)
+    - React-runtimeexecutor (= 0.68.56)
+  - React-jsi (0.68.56):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.55)
-  - React-jsi/Default (0.68.55):
+    - React-jsi/Default (= 0.68.56)
+  - React-jsi/Default (0.68.56):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.55):
+  - React-jsiexecutor (0.68.56):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-perflogger (= 0.68.55)
-  - React-jsinspector (0.68.55)
-  - React-logger (0.68.55):
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-perflogger (= 0.68.56)
+  - React-jsinspector (0.68.56)
+  - React-logger (0.68.56):
     - glog
-  - React-perflogger (0.68.55)
-  - React-RCTActionSheet (0.68.55):
-    - React-Core/RCTActionSheetHeaders (= 0.68.55)
-  - React-RCTAnimation (0.68.55):
+  - React-perflogger (0.68.56)
+  - React-RCTActionSheet (0.68.56):
+    - React-Core/RCTActionSheetHeaders (= 0.68.56)
+  - React-RCTAnimation (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.55)
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTAnimationHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTBlob (0.68.55):
+    - RCTTypeSafety (= 0.68.56)
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTAnimationHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTBlob (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTBlobHeaders (= 0.68.55)
-    - React-Core/RCTWebSocket (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-RCTNetwork (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTImage (0.68.55):
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTBlobHeaders (= 0.68.56)
+    - React-Core/RCTWebSocket (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-RCTNetwork (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTImage (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.55)
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTImageHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-RCTNetwork (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTLinking (0.68.55):
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTLinkingHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTNetwork (0.68.55):
+    - RCTTypeSafety (= 0.68.56)
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTImageHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-RCTNetwork (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTLinking (0.68.56):
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTLinkingHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTNetwork (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.55)
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTNetworkHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTPushNotification (0.68.55):
-    - RCTTypeSafety (= 0.68.55)
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTPushNotificationHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTSettings (0.68.55):
+    - RCTTypeSafety (= 0.68.56)
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTNetworkHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTPushNotification (0.68.56):
+    - RCTTypeSafety (= 0.68.56)
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTPushNotificationHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTSettings (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.55)
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTSettingsHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTTest (0.68.55):
+    - RCTTypeSafety (= 0.68.56)
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTSettingsHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTTest (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core (= 0.68.55)
-    - React-CoreModules (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-RCTText (0.68.55):
-    - React-Core/RCTTextHeaders (= 0.68.55)
-  - React-RCTVibration (0.68.55):
+    - React-Core (= 0.68.56)
+    - React-CoreModules (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-RCTText (0.68.56):
+    - React-Core/RCTTextHeaders (= 0.68.56)
+  - React-RCTVibration (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.55)
-    - React-Core/RCTVibrationHeaders (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-runtimeexecutor (0.68.55):
-    - React-jsi (= 0.68.55)
-  - React-TurboModuleCxx-RNW (0.68.55):
+    - React-Codegen (= 0.68.56)
+    - React-Core/RCTVibrationHeaders (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-runtimeexecutor (0.68.56):
+    - React-jsi (= 0.68.56)
+  - React-TurboModuleCxx-RNW (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.55)
-    - React-TurboModuleCxx-WinRTPort (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
-  - React-TurboModuleCxx-WinRTPort (0.68.55):
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.55)
-    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.68.55)
-  - React-TurboModuleCxx-WinRTPort/Shared (0.68.55)
-  - React-TurboModuleCxx-WinRTPort/WinRT (0.68.55):
+    - React-callinvoker (= 0.68.56)
+    - React-TurboModuleCxx-WinRTPort (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
+  - React-TurboModuleCxx-WinRTPort (0.68.56):
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.56)
+    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.68.56)
+  - React-TurboModuleCxx-WinRTPort/Shared (0.68.56)
+  - React-TurboModuleCxx-WinRTPort/WinRT (0.68.56):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.55)
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.55)
-  - ReactCommon/turbomodule/core (0.68.55):
+    - React-callinvoker (= 0.68.56)
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.56)
+  - ReactCommon/turbomodule/core (0.68.56):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.55)
-    - React-Core (= 0.68.55)
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-logger (= 0.68.55)
-    - React-perflogger (= 0.68.55)
-  - ReactCommon/turbomodule/samples (0.68.55):
+    - React-callinvoker (= 0.68.56)
+    - React-Core (= 0.68.56)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-logger (= 0.68.56)
+    - React-perflogger (= 0.68.56)
+  - ReactCommon/turbomodule/samples (0.68.56):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.55)
-    - React-Core (= 0.68.55)
-    - React-cxxreact (= 0.68.55)
-    - React-jsi (= 0.68.55)
-    - React-logger (= 0.68.55)
-    - React-perflogger (= 0.68.55)
-    - ReactCommon/turbomodule/core (= 0.68.55)
+    - React-callinvoker (= 0.68.56)
+    - React-Core (= 0.68.56)
+    - React-cxxreact (= 0.68.56)
+    - React-jsi (= 0.68.56)
+    - React-logger (= 0.68.56)
+    - React-perflogger (= 0.68.56)
+    - ReactCommon/turbomodule/core (= 0.68.56)
   - ScreenshotManager (0.0.1):
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core
@@ -560,8 +560,8 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: a2fb9250824f410cdfad959324438258a95c8400
-  FBReactNativeSpec: 6f26a0b3b592d9f260f804581f14012623b4af1a
+  FBLazyVector: 18641da08cf753313d5859fb9a59ce1024bad5eb
+  FBReactNativeSpec: af898c7ecabf46f7c69d6bef35aca5543a8232b5
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 3d3d04a078d4f3a1b6c6916587f159dc11f232c4
@@ -575,38 +575,38 @@ SPEC CHECKSUMS:
   glog: 20113a0d46931b6f096cf8302c68691d75a456ff
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 24c6da766832002a4a2aac5f79ee0ca50fbe8507
-  RCTRequired: c1e37dcdcf46e0753331c1072df326b42e7c31e9
-  RCTTypeSafety: 53123da3c1c43c88cbdb32cb0296ad5eea42387a
-  React: 47acb9b9e46d24373e644428830b33fd64cc5650
-  React-callinvoker: 8a3e4fa28ced3e457c33a0e935e9fea488949d60
-  React-Codegen: 978d7f224289008c30963a9f497ceafd8ed60b38
-  React-Core: 8df9b796bcb6b13d056f774dffb4c5b3b8814e4f
-  React-CoreModules: 5accd212b83fedfd591866b9eed7fffe5d6a9533
-  React-cxxreact: fc62b9f0811a2429f200d3752578e5ff45134561
-  React-jsi: 88baf825d173b3f5207a713c7b2c79ab1fcb2426
-  React-jsiexecutor: 7fa885daf306042412cbb3b004e9e7e9577682b8
-  React-jsinspector: 43d7244065559fb72a556478786f9ec255b26a92
-  React-logger: ae560f5f449e711821dba0b02f27b5411d99dde5
-  React-perflogger: 15a372366ffa1d6969e34b8bdd19f9d7f969d2f0
-  React-RCTActionSheet: 46629702bdc91284524c261654db0663c4145aa7
-  React-RCTAnimation: 4d8d32673a9614eaa2dffb5c7ca98d50ac00e8cc
-  React-RCTBlob: bd2750d84bde201ab5f4206a045123dca6dadecd
-  React-RCTImage: a0fbedb2ae62ebeb7968d6d8a641b89bd93bcc93
-  React-RCTLinking: 2db88108c096c74d9cc4d83f5296859bf6b7653d
-  React-RCTNetwork: 2d6a3ea30ea0bef17a5328accc5983ed93c34c07
-  React-RCTPushNotification: b8a00b4ed24adbbebf913e7d225620ba515c2c1f
-  React-RCTSettings: dbec0048eafebb2e4b264089c45c5a97a584b689
-  React-RCTTest: 20b386b76508d51a5860d678fdc399158f4494d0
-  React-RCTText: b97b6a15a056aeefae201d0940d6257e8b890811
-  React-RCTVibration: 0b0c5816251978c977bbd40a41c6e6177d5b8722
-  React-runtimeexecutor: aff8474c9847afe35131e63ce2eacd15bf1bfe0e
-  React-TurboModuleCxx-RNW: 71f51f80ff529e2eff1a070798abbebcd6c82ac1
-  React-TurboModuleCxx-WinRTPort: 7aea389ca6137143d2bfdc8245183a13b1a72a1c
-  ReactCommon: 4ae270e0cabe153d4156e98bb5271cb64ee71f9b
+  RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
+  RCTRequired: 6079a4b5c147806c225e68c5e031649601a388bf
+  RCTTypeSafety: 9df11222eb80bdf9e6c659669ab3449b8bedb896
+  React: 4f260df2060bc1f8e17e4329e78abeeacbc24c7b
+  React-callinvoker: 29cbb5ee8a61f808cabb59fde3758e18861dcc5c
+  React-Codegen: b7356aff3166fdc0238ff1f9925b522a16067e79
+  React-Core: 803ab4de0a7520eb801d1c92889df7a9c33ebed9
+  React-CoreModules: f6dec468282d6aa238cd6cd03da463fe0fb08dce
+  React-cxxreact: 88450e03d64bec2d91da5593340c32cc26ca5d92
+  React-jsi: f61771cfc31c086d0c338196e7d2ef12a6a10e86
+  React-jsiexecutor: 4b9d38c92064cb6caa013853690c5e33cf20fac3
+  React-jsinspector: 2e6f3d2f5c9e73a74ed4eb73de69a1218397cab8
+  React-logger: fc58563e12be01a794ec8968ebf39727d508e606
+  React-perflogger: b0d3da31dc80e44219fb7e3e679b1bfdacede97d
+  React-RCTActionSheet: d351e42323e541d83492c524176808a03979ff97
+  React-RCTAnimation: 8329a1caaf7cbfeb3933c29b5a1a768dbfffaa77
+  React-RCTBlob: 808b743a2cac2d96073184f2fca828241eca8cc7
+  React-RCTImage: d5bb617c3d7ecf5ffe610ab2425f758ac0a3963d
+  React-RCTLinking: 6b2251a61c7e6c1c6ac3354bf507d87167012e4c
+  React-RCTNetwork: 3d1e5fd94639aed0c4ada530f461bbc3bf105f01
+  React-RCTPushNotification: cd60dafd933ff010f8e27a64c6f76538902ae3dc
+  React-RCTSettings: d844229e4466b3913645390fbdaed4c2b20d2800
+  React-RCTTest: 2a3e858b157ed63d921883a379fa2c1af148d2d9
+  React-RCTText: d6be8f0bf52ef82d40201b3a49e73734b94ff5c4
+  React-RCTVibration: 86fff62056e82c061a78f34b297163ab922fb9ce
+  React-runtimeexecutor: 6f486c0268d901ff7513e2d3cc2d51600dc79315
+  React-TurboModuleCxx-RNW: ed939e1efdd9df04353a59740aec7f14c3952a23
+  React-TurboModuleCxx-WinRTPort: 9ab3a55ce2f22271b470f744ead9e407202a7840
+  ReactCommon: 8bdba91850cdca4f356c18a2a2696c6d134e4483
   ScreenshotManager: a2479ac2273d34c8c2c1e4b8e33fe46fb2f0fb60
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 2995c039a13989c927279e29f9f9d3750da4e3d7
+  Yoga: 4b53be737c7c8f32e8c2756b081f0fc6a0b7bef7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: f75714fcec17ede364b8166fcfded0d9bc9ea275

--- a/template/package.json
+++ b/template/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "17.0.2",
-    "react-native-macos": "0.68.55"
+    "react-native-macos": "0.68.56"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Force an update to 0.68.56.

A couple of days ago, our version bump pipeline failed to run to completion due to a merge conflict, so 0.68.56 published to NPM, but the version changes didn't get checked into the repo.

This fixes that. The next version bump to 0.68.57 should clean things up if all goes well.
