### PR TITLE
Add missing scaleFactor argument to Fabric RCTViewComponentView.mm

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -591,6 +591,12 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 
     RCTBorderColors borderColors = RCTCreateRCTBorderColorsFromBorderColors(borderMetrics.borderColors);
 
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+  CGFloat scaleFactor = self.window.backingScaleFactor;
+#else
+  // On iOS setting the scaleFactor to 0.0 will default to the device's native scale factor.
+  CGFloat scaleFactor = 0.0;
+#endif // ]TODO(macOS GH#774)
     UIImage *image = RCTGetBorderImage(
         RCTBorderStyleFromBorderStyle(borderMetrics.borderStyles.left),
         layer.bounds.size,
@@ -598,7 +604,8 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
         RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths),
         borderColors,
         _backgroundColor.CGColor,
-        self.clipsToBounds);
+        self.clipsToBounds,
+        scaleFactor); // TODO(macOS GH#774)
 
     RCTReleaseRCTBorderColors(borderColors);
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
This is the last change we need to make to enable Fabric + iOS

## Changelog
[macOS] [Fixed] - Add missing scaleFactor argument to Fabric RCTViewComponentView.mm

## Test Plan
in packages/rn-tester run:
`
bundle install && USE_FABRIC=1 bundle exec pod install
`

Open Xcode and run on iOS Simulator


https://user-images.githubusercontent.com/484044/199705740-ea057fd9-c986-4975-876d-a0eff9aac4fb.mov


