### PR TITLE
Cherry-pick: Enable ManagedObjectWrapper on react-native-macOS (#35146)

### DIFF
--- a/ReactCommon/react/utils/ManagedObjectWrapper.h
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.h
@@ -10,7 +10,7 @@
 #include <react/debug/react_native_assert.h>
 
 #if defined(__OBJC__) && defined(__cplusplus)
-#if TARGET_OS_MAC && TARGET_OS_IPHONE
+#if TARGET_OS_MAC
 
 #include <memory>
 

--- a/ReactCommon/react/utils/ManagedObjectWrapper.mm
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.mm
@@ -7,8 +7,7 @@
 
 #include "ManagedObjectWrapper.h"
 
-#if defined(__OBJC__) && defined(__cplusplus)
-#if TARGET_OS_MAC && TARGET_OS_IPHONE
+#if TARGET_OS_MAC
 
 namespace facebook {
 namespace react {
@@ -34,5 +33,4 @@ void wrappedManagedObjectDeleter(void *cfPointer) noexcept
 @implementation RCTInternalGenericWeakWrapper
 @end
 
-#endif
 #endif


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This class is used by Fabric - but does not compile on macOS yet.
Now it does.

Pull Request resolved: https://github.com/facebook/react-native/pull/35146

## Changelog
[macOS][Fixed] Make ManagedObjectWrapper compile on macOS

## Test Plan

Xcode Preference's > General > Continue after build errors
<img width="853" alt="image" src="https://user-images.githubusercontent.com/484044/199706486-d0674893-c6b1-41cc-a920-acb32ba69f1d.png">

No compile errors for ManagedObjectWrapper usage when building for macOS:

<img width="845" alt="image" src="https://user-images.githubusercontent.com/484044/199706897-e61b4af4-556d-4534-a412-f1b0f2f90f54.png">

