### PR TITLE
Cherry-pick: Remove unused #import <UIKit/UIGestureRecognizerSubclass.h> import which breaks macOS (#35131)

### DIFF
--- a/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -9,7 +9,6 @@
 
 #import <React/RCTUtils.h>
 #import <React/RCTViewComponentView.h>
-#import <UIKit/UIGestureRecognizerSubclass.h>
 
 #import "RCTConversions.h"
 #import "RCTTouchableComponentViewProtocol.h"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Pull Request resolved: https://github.com/facebook/react-native/pull/35131

## Changelog

[macOS][Fixed] - Remove unused #import <UIKit/UIGestureRecognizerSubclass.h> import which breaks macOS

## Test Plan

Not used for macOS
Would not work on macOS

rn-iOS + Fabric still works:
