### PR TITLE
Cherry-pick: (Easy) Log errors to Logview when Bridge is used in Bridgeless

### DIFF
--- a/React/Base/RCTAssert.h
+++ b/React/Base/RCTAssert.h
@@ -183,7 +183,6 @@ __attribute__((used)) RCT_EXTERN void RCTEnableNewArchitectureViolationReporting
 
 // When reporting is enabled, trigger an assertion.
 __attribute__((used)) RCT_EXTERN void RCTEnforceNotAllowedForNewArchitecture(id context, NSString *extra);
-
-// When reporting is enabled, warn about the violation. Use this to prepare a specific callsite
+// When reporting is enabled, trigger an error but do not crash. Use this to prepare a specific callsite
 // for stricter enforcement. When ready, switch it to use the variant above.
-__attribute__((used)) RCT_EXTERN void RCTWarnNotAllowedForNewArchitecture(id context, NSString *extra);
+__attribute__((used)) RCT_EXTERN void RCTErrorNotAllowedForNewArchitecture(id context, NSString *extra);

--- a/React/Base/RCTAssert.m
+++ b/React/Base/RCTAssert.m
@@ -274,11 +274,11 @@ void RCTEnforceNotAllowedForNewArchitecture(id context, NSString *extra)
   RCTAssert(0, @"%@", getNewArchitectureViolationMessage(context, extra));
 }
 
-void RCTWarnNotAllowedForNewArchitecture(id context, NSString *extra)
+void RCTErrorNotAllowedForNewArchitecture(id context, NSString *extra)
 {
   if (!newArchitectureViolationReporting) {
     return;
   }
 
-  RCTLogWarn(@"%@", getNewArchitectureViolationMessage(context, extra));
+  RCTLogError(@"%@", getNewArchitectureViolationMessage(context, extra));
 }

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -60,7 +60,7 @@ NSArray<Class> *RCTGetModuleClasses(void)
 void RCTRegisterModule(Class);
 void RCTRegisterModule(Class moduleClass)
 {
-  RCTWarnNotAllowedForNewArchitecture(
+  RCTErrorNotAllowedForNewArchitecture(
       @"RCTRegisterModule()", [NSString stringWithFormat:@"'%@' was registered unexpectedly", moduleClass]);
 
   static dispatch_once_t onceToken;

--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -29,7 +29,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    RCTWarnNotAllowedForNewArchitecture(
+    RCTErrorNotAllowedForNewArchitecture(
         self, @"ViewManager with interop layer is not allowed in the new architecture.");
     static const auto defaultProps = std::make_shared<const LegacyViewManagerInteropViewProps>();
     _props = defaultProps;

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -95,7 +95,7 @@ RCT_EXPORT_MODULE()
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  RCTWarnNotAllowedForNewArchitecture(self, @"RCTViewManager must not be initialized for the new architecture");
+  RCTErrorNotAllowedForNewArchitecture(self, @"RCTViewManager must not be initialized for the new architecture");
   _bridge = bridge;
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/3c4850d76b8

- Set `RCTEnableNewArchitectureViolationReporting` to YES in app-wide Bridgeless mode.
- Rename `RCTWarnNotAllowedForNewArchitecture` to `RCTErrorNotAllowedForNewArchitecture`, and use `RCTLogError` instead of `RCTLogWarn` so the error goes to Logview.

## Changelog

Changelog: [Internal]

## Test Plan

Build and run rn-tester-iOS
