### PR TITLE
Cherry-pick: Convert CGFLOAT_MAX to infinity

### DIFF
--- a/React/Fabric/RCTConversions.h
+++ b/React/Fabric/RCTConversions.h
@@ -173,9 +173,17 @@ inline facebook::react::Point RCTPointFromCGPoint(const CGPoint &point)
   return {point.x, point.y};
 }
 
+inline facebook::react::Float RCTFloatFromCGFloat(CGFloat value)
+{
+  if (value == CGFLOAT_MAX) {
+    return std::numeric_limits<facebook::react::Float>::infinity();
+  }
+  return value;
+}
+
 inline facebook::react::Size RCTSizeFromCGSize(const CGSize &size)
 {
-  return {size.width, size.height};
+  return {RCTFloatFromCGFloat(size.width), RCTFloatFromCGFloat(size.height)};
 }
 
 inline facebook::react::Rect RCTRectFromCGRect(const CGRect &rect)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/538636440b8

For embedded React Native screens, we need to calculate the intrinsic size. To do that, we need to pass Yoga value `YGUndefined`. However, if available size was `CGFLOAT_MAX` (which is not inifinity), we would pass it to Yoga and it would calculate layout with available height/width `CGFLOAT_MAX`.

To fix this, we convert `CGFLOAT_MAX` to infinity. Which in YogaLayoutableShadowNode gets converted to YGUndefined.

## Changelog

changelog: [internal]

## Test Plan

Code is only used for Fabric - which is not enabled yet for react-native-macOS