### PR TITLE
Cherry-pick: Add ObjC feature flag for dispatching w3c pointer events

### DIFF
--- a/React/Base/RCTConstants.h
+++ b/React/Base/RCTConstants.h
@@ -15,3 +15,9 @@ RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollec
  */
 RCT_EXTERN BOOL RCTExperimentGetPreemptiveViewAllocationDisabled(void);
 RCT_EXTERN void RCTExperimentSetPreemptiveViewAllocationDisabled(BOOL value);
+
+/*
+ * W3C Pointer Events
+ */
+RCT_EXTERN BOOL RCTGetDispatchW3CPointerEvents(void);
+RCT_EXTERN void RCTSetDispatchW3CPointerEvents(BOOL value);

--- a/React/Base/RCTConstants.m
+++ b/React/Base/RCTConstants.m
@@ -24,3 +24,18 @@ void RCTExperimentSetPreemptiveViewAllocationDisabled(BOOL value)
 {
   RCTExperimentPreemptiveViewAllocationDisabled = value;
 }
+
+/*
+ * W3C Pointer Events
+ */
+static BOOL RCTDispatchW3CPointerEvents = NO;
+
+BOOL RCTGetDispatchW3CPointerEvents()
+{
+  return RCTDispatchW3CPointerEvents;
+}
+
+void RCTSetDispatchW3CPointerEvents(BOOL value)
+{
+  RCTDispatchW3CPointerEvents = value;
+}

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -256,6 +256,10 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     RCTExperimentSetPreemptiveViewAllocationDisabled(YES);
   }
 
+  if (reactNativeConfig && reactNativeConfig->getBool("rn_convergence:dispatch_pointer_events")) {
+    RCTSetDispatchW3CPointerEvents(YES);
+  }
+
   auto componentRegistryFactory =
       [factory = wrapManagedObject(_mountingManager.componentViewRegistry.componentViewFactory)](
           EventDispatcher::Weak const &eventDispatcher, ContextContainer::Shared const &contextContainer) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/e85f2e25478

Set up iOS feature flag for w3c pointer event dispatch
## Changelog

Changelog: [Internal] Set up iOS feature flag for w3c pointer event dispatch


## Test Plan

Build rn-tester with Fabric enabled
`
bundle install && USE_FABRIC=1 bundle exec pod install
`
and run it:
<img width="1571" alt="Screen Shot 2022-11-11 at 9 47 42 AM" src="https://user-images.githubusercontent.com/484044/201305042-ab954e5b-f3d4-4498-b416-aa2c4e836c9e.png">

### Flow
```
react-native-macos % yarn flow
yarn run v1.17.0-20190429.1820
$ flow
No errors!
✨  Done in 0.34s.
```
