### PR TITLE
Cherry-pick: Fall back to non-localized string if no translation is available

### DIFF
--- a/React/Fabric/RCTLocalizationProvider.mm
+++ b/React/Fabric/RCTLocalizationProvider.mm
@@ -26,15 +26,21 @@ void setLocalizationLanguagePack(NSDictionary<NSString *, NSString *> *pack)
 
 + (NSString *)RCTLocalizedString:(NSString *)oldString withDescription:(NSString *)description
 {
+  NSString *candidate = nil;
+
   if (_delegate != nil) {
-    return [_delegate localizedString:oldString withDescription:description];
+    candidate = [_delegate localizedString:oldString withDescription:description];
   }
 
-  if (_languagePack != nil) {
-    return _languagePack[oldString];
+  if (candidate == nil && _languagePack != nil) {
+    candidate = _languagePack[oldString];
   }
 
-  return oldString;
+  if (candidate == nil) {
+    candidate = oldString;
+  }
+
+  return candidate;
 }
 
 @end


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/18196512db6

We've seen a couple of `EXC_BAD_ACCESS` crashes in [`RCTParagraphComponentAccessibilityProvider.mm:L125`](https://github.com/facebook/react-native/blob/52d8a797e7a6be3fa472f323ceca4814a28ef596/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.mm#L125), most likely explained by [RCTLocalizationProvider RCTLocalizedString] returning nil, which will happen in the case that a language pack has no entry for the input string.

This is a small defensive change to fall back to the input if there's no better alternative.

## Changelog

Changelog:
[iOS][Fixed] - `RCTLocalizationProvider` Fall back to input when no localization is available

## Test Plan

Build rn-tester with Fabric enabled
`
bundle install && USE_FABRIC=1 bundle exec pod install
`
and run it:


https://user-images.githubusercontent.com/484044/201316474-ae51b377-44bc-494b-9f13-64376bada059.mov


### Flow
```
flow
Version mismatch! Server binary is Flow v0.170.0 but we are using v0.170.0
Restarting command using the same binary as the server
No errors!
```
