### PR TITLE
Cherry-pick: Add event listeners to Scheduler

### DIFF
--- a/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -36,6 +36,10 @@ EventDispatcher::EventDispatcher(
 
 void EventDispatcher::dispatchEvent(RawEvent &&rawEvent, EventPriority priority)
     const {
+  // Allows the event listener to interrupt default event dispatch
+  if (eventListeners_.willDispatchEvent(rawEvent)) {
+    return;
+  }
   getEventQueue(priority).enqueueEvent(std::move(rawEvent));
 }
 
@@ -46,6 +50,10 @@ void EventDispatcher::dispatchStateUpdate(
 }
 
 void EventDispatcher::dispatchUniqueEvent(RawEvent &&rawEvent) const {
+  // Allows the event listener to interrupt default event dispatch
+  if (eventListeners_.willDispatchEvent(rawEvent)) {
+    return;
+  }
   asynchronousBatchedQueue_->enqueueUniqueEvent(std::move(rawEvent));
 }
 
@@ -60,6 +68,19 @@ const EventQueue &EventDispatcher::getEventQueue(EventPriority priority) const {
     case EventPriority::AsynchronousBatched:
       return *asynchronousBatchedQueue_;
   }
+}
+
+void EventDispatcher::addListener(
+    const std::shared_ptr<EventListener const> &listener) const {
+  eventListeners_.addListener(listener);
+}
+
+/*
+ * Removes provided event listener to the event dispatcher.
+ */
+void EventDispatcher::removeListener(
+    const std::shared_ptr<EventListener const> &listener) const {
+  eventListeners_.removeListener(listener);
 }
 
 } // namespace react

--- a/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -9,6 +9,7 @@
 
 #include <react/renderer/core/BatchedEventQueue.h>
 #include <react/renderer/core/EventBeat.h>
+#include <react/renderer/core/EventListener.h>
 #include <react/renderer/core/EventPriority.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/StateUpdate.h>
@@ -52,6 +53,18 @@ class EventDispatcher {
   void dispatchStateUpdate(StateUpdate &&stateUpdate, EventPriority priority)
       const;
 
+#pragma mark - Event listeners
+  /*
+   * Adds provided event listener to the event dispatcher.
+   */
+  void addListener(const std::shared_ptr<EventListener const> &listener) const;
+
+  /*
+   * Removes provided event listener to the event dispatcher.
+   */
+  void removeListener(
+      const std::shared_ptr<EventListener const> &listener) const;
+
  private:
   EventQueue const &getEventQueue(EventPriority priority) const;
 
@@ -59,6 +72,8 @@ class EventDispatcher {
   std::unique_ptr<BatchedEventQueue> synchronousBatchedQueue_;
   std::unique_ptr<UnbatchedEventQueue> asynchronousUnbatchedQueue_;
   std::unique_ptr<BatchedEventQueue> asynchronousBatchedQueue_;
+
+  mutable EventListenerContainer eventListeners_;
 };
 
 } // namespace react

--- a/ReactCommon/react/renderer/core/EventListener.cpp
+++ b/ReactCommon/react/renderer/core/EventListener.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "EventListener.h"
+
+namespace facebook::react {
+
+bool EventListenerContainer::willDispatchEvent(const RawEvent &event) {
+  std::shared_lock<butter::shared_mutex> lock(mutex_);
+
+  bool handled = false;
+  for (auto const &listener : eventListeners_) {
+    handled = handled || listener->operator()(event);
+  }
+  return handled;
+}
+
+void EventListenerContainer::addListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  std::unique_lock<butter::shared_mutex> lock(mutex_);
+
+  eventListeners_.push_back(listener);
+}
+
+void EventListenerContainer::removeListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  std::unique_lock<butter::shared_mutex> lock(mutex_);
+
+  auto it = std::find(eventListeners_.begin(), eventListeners_.end(), listener);
+  if (it != eventListeners_.end()) {
+    eventListeners_.erase(it);
+  }
+}
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/core/EventListener.h
+++ b/ReactCommon/react/renderer/core/EventListener.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <react/renderer/core/RawEvent.h>
+
+#include <butter/mutex.h>
+
+namespace facebook {
+namespace react {
+
+/**
+ * Listener for events dispatched to JS runtime.
+ * Return `true` to interrupt default dispatch to JS event emitter, `false` to
+ * pass through to default handlers.
+ */
+using EventListener = std::function<bool(const RawEvent &event)>;
+
+class EventListenerContainer {
+ public:
+  /*
+   * Invoke listeners in this container with the event.
+   * Returns true if event was handled by the listener, false to continue
+   * default dispatch.
+   */
+  bool willDispatchEvent(const RawEvent &event);
+
+  void addListener(const std::shared_ptr<EventListener const> &listener);
+  void removeListener(const std::shared_ptr<EventListener const> &listener);
+
+ private:
+  butter::shared_mutex mutex_;
+  std::vector<std::shared_ptr<EventListener const>> eventListeners_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -351,5 +351,19 @@ ContextContainer::Shared Scheduler::getContextContainer() const {
   return contextContainer_;
 }
 
+void Scheduler::addEventListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  if (eventDispatcher_->has_value()) {
+    eventDispatcher_->value().addListener(listener);
+  }
+}
+
+void Scheduler::removeEventListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  if (eventDispatcher_->has_value()) {
+    eventDispatcher_->value().removeListener(listener);
+  }
+}
+
 } // namespace react
 } // namespace facebook

--- a/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -16,6 +16,7 @@
 #include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventEmitter.h>
+#include <react/renderer/core/EventListener.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/scheduler/InspectorData.h>
@@ -106,6 +107,11 @@ class Scheduler final : public UIManagerDelegate {
 
 #pragma mark - ContextContainer
   ContextContainer::Shared getContextContainer() const;
+
+#pragma mark - Event listeners
+  void addEventListener(const std::shared_ptr<EventListener const> &listener);
+  void removeEventListener(
+      const std::shared_ptr<EventListener const> &listener);
 
  private:
   friend class SurfaceHandler;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/e51e19ecc1d1b8ac5c860eac55338ef13471844f

Minimal set of changes to intercept events in external modules. Current intended use-case is for Reanimated to handle events for the Animated properties.

## Changelog

Changelog: [Added] Add listeners to allow intercepting events in C++ core.

## Test Plan

Build rn-tester with Fabric enabled
`
bundle install && USE_FABRIC=1 bundle exec pod install
`
and run it. 
<img width="552" alt="image" src="https://user-images.githubusercontent.com/484044/201325845-da30a891-1323-4a0e-b8cb-78c7384fd0fa.png">


### Flow
```
flow
Version mismatch! Server binary is Flow v0.170.0 but we are using v0.170.0
Restarting command using the same binary as the server
No errors!
```
