### PR TITLE
Cherry-pick: Fix reatain cycle RCTPullToRefreshViewComponentView <-> RCTScrollViewComponentView

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -25,7 +25,7 @@ using namespace facebook::react;
 
 @implementation RCTPullToRefreshViewComponentView {
   UIRefreshControl *_refreshControl;
-  RCTScrollViewComponentView *_scrollViewComponentView;
+  RCTScrollViewComponentView *__weak _scrollViewComponentView;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a **react-native@0.70** commit into the current main branch:
https://github.com/facebook/react-native/commit/4e4b9e2111f

`_scrollViewComponentView` is set to `RCTPullToRefreshViewComponentView's` superview:
```
_scrollViewComponentView = [RCTScrollViewComponentView findScrollViewComponentViewForView:self];
```
It should be safe to make it weak.

## Changelog

Changelog: [iOS][Fixed] - Fix reatain cycle RCTPullToRefreshViewComponentView <-> RCTScrollViewComponentView
## Test Plan

CircleCI