### PR TITLE
Cherry-pick: Fix contentInsetAdjustmentBehavior set to automatic on ScrollView in the new architecture (#34217)

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -388,6 +388,9 @@ static void RCTSendPaperScrollEvent_DEPRECATED(UIScrollView *scrollView, NSInteg
   _shouldUpdateContentInsetAdjustmentBehavior = YES;
   _state.reset();
   _isUserTriggeredScrolling = NO;
+  CGRect oldFrame = self.frame;
+  self.frame = CGRectZero;
+  self.frame = oldFrame;
   [super prepareForRecycle];
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a **react-native@0.71** commit into the current main branch: 
https://github.com/facebook/react-native/commit/27fe6f10796

Fixes https://github.com/facebook/react-native/issues/34165 and [Large title fails](https://github.com/reactwg/react-native-new-architecture/discussions/43) on the new React Native architecture.

There are problems with setting `contentInsetAdjustmentBehavior` to `automatic` on the `ScrollView` component in the new React Native architecture. The `automatic` setting matters to navigation libraries (like [my Navigation router](https://github.com/grahammendick/navigation)) because it stops the `ScrollView` from overlapping the `UINavigationBar`. The setting also powers important native features like large titles and search bars on iOS.

The `automatic` setting works fine on the old architecture. It doesn’t work on the new architecture because React Native is recycling views. In https://github.com/facebook/react-native/issues/34165 and [Large title fails](https://github.com/reactwg/react-native-new-architecture/discussions/43) there are videos comparing the setting in the old and the new architecture.

## Changelog

[iOS] [Fixed] - Fix `contentInsetAdjustmentBehavior` set to `automatic` on `ScrollView` in the new architecture

## Test Plan

I checked the fix in both the repros in https://github.com/facebook/react-native/issues/34165 and [Large title fails](https://github.com/reactwg/react-native-new-architecture/discussions/43). Here is a video of the fix running with large titles in the new architecture.

https://user-images.githubusercontent.com/1761227/179612188-162b896b-82c5-45de-bb5a-ba80f452fbee.mov

