### PR TITLE
Cherry-pick: Early exit in scrollToOffset if contentOffset wouldn't change

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -636,6 +636,10 @@ static void RCTSendPaperScrollEvent_DEPRECATED(UIScrollView *scrollView, NSInteg
 
 - (void)scrollToOffset:(CGPoint)offset animated:(BOOL)animated
 {
+  if (CGPointEqualToPoint(_scrollView.contentOffset, offset)) {
+    return;
+  }
+
   [self _forceDispatchNextScrollEvent];
 
   if (_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a **react-native@0.71** commit into the current main branch:
https://github.com/facebook/react-native/commit/dfbf7d4e142

Calling `scrollToOffset` with already set content offset doesn't make sense.

## Changelog

changelog: [internal]

## Test Plan

CircleCi