### PR TITLE
Expose scheduler through RCTSurfacePresenter

### DIFF
--- a/React/Fabric/RCTScheduler.h
+++ b/React/Fabric/RCTScheduler.h
@@ -10,6 +10,7 @@
 
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #import <react/renderer/core/ComponentDescriptor.h>
+#import <react/renderer/core/EventListener.h>
 #import <react/renderer/core/LayoutConstraints.h>
 #import <react/renderer/core/LayoutContext.h>
 #import <react/renderer/mounting/MountingCoordinator.h>
@@ -63,6 +64,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onAllAnimationsComplete;
 
 - (void)animationTick;
+
+- (void)addEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;
+
+- (void)removeEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;
 
 @end
 

--- a/React/Fabric/RCTScheduler.mm
+++ b/React/Fabric/RCTScheduler.mm
@@ -193,4 +193,14 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   }
 }
 
+- (void)addEventListener:(std::shared_ptr<EventListener> const &)listener
+{
+  return _scheduler->addEventListener(listener);
+}
+
+- (void)removeEventListener:(std::shared_ptr<EventListener> const &)listener
+{
+  return _scheduler->removeEventListener(listener);
+}
+
 @end

--- a/React/Fabric/RCTSurfacePresenter.h
+++ b/React/Fabric/RCTSurfacePresenter.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RCTFabricSurface;
 @class RCTImageLoader;
 @class RCTMountingManager;
+@class RCTScheduler;
 
 /**
  * Coordinates presenting of React Native Surfaces and represents application
@@ -53,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unregisterSurface:(RCTFabricSurface *)surface;
 
 @property (readonly) RCTMountingManager *mountingManager;
+@property (readonly, nullable) RCTScheduler *scheduler;
 
 - (nullable RCTFabricSurface *)surfaceForRootTag:(ReactTag)rootTag;
 

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -110,7 +110,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   return _mountingManager;
 }
 
-- (RCTScheduler *_Nullable)_scheduler
+- (RCTScheduler *_Nullable)scheduler
 {
   std::lock_guard<std::mutex> lock(_schedulerAccessMutex);
   return _scheduler;
@@ -146,7 +146,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 - (void)registerSurface:(RCTFabricSurface *)surface
 {
   [_surfaceRegistry registerSurface:surface];
-  RCTScheduler *scheduler = [self _scheduler];
+  RCTScheduler *scheduler = [self scheduler];
   if (scheduler) {
     [scheduler registerSurface:surface.surfaceHandler];
   }
@@ -154,7 +154,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (void)unregisterSurface:(RCTFabricSurface *)surface
 {
-  RCTScheduler *scheduler = [self _scheduler];
+  RCTScheduler *scheduler = [self scheduler];
   if (scheduler) {
     [scheduler unregisterSurface:surface.surfaceHandler];
   }
@@ -175,7 +175,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (BOOL)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag props:(NSDictionary *)props
 {
-  RCTScheduler *scheduler = [self _scheduler];
+  RCTScheduler *scheduler = [self scheduler];
   if (!scheduler) {
     return NO;
   }
@@ -199,7 +199,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (void)setupAnimationDriverWithSurfaceHandler:(facebook::react::SurfaceHandler const &)surfaceHandler
 {
-  [[self _scheduler] setupAnimationDriver:surfaceHandler];
+  [[self scheduler] setupAnimationDriver:surfaceHandler];
 }
 
 - (BOOL)suspend


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/614aa869163

Exposes event listener through iOS scheduler wrapper (`RCTScheduler`) and exposes scheduler itself through `RCTSurfacePresenter`.

## Changelog

Changelog: [Changed] Exposed `RCTScheduler` to allow setting event listeners.

## Test Plan

Build rn-tester with Fabric enabled
`
bundle install && USE_FABRIC=1 bundle exec pod install
`
and run it:

<img width="1028" alt="Screen Shot 2022-11-11 at 10 47 22 PM" src="https://user-images.githubusercontent.com/484044/201435482-110e1c8b-372c-445e-8385-3bf1e6a3bf95.png">
