### PR TITLE
Cherry-pick: Expose UIManager from Scheduler (#33545)

### DIFF
--- a/React/Fabric/RCTScheduler.h
+++ b/React/Fabric/RCTScheduler.h
@@ -16,6 +16,7 @@
 #import <react/renderer/mounting/MountingCoordinator.h>
 #import <react/renderer/scheduler/SchedulerToolbox.h>
 #import <react/renderer/scheduler/SurfaceHandler.h>
+#import <react/renderer/uimanager/UIManager.h>
 #import <react/utils/ContextContainer.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -48,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTScheduler : NSObject
 
 @property (atomic, weak, nullable) id<RCTSchedulerDelegate> delegate;
+@property (readonly) std::shared_ptr<facebook::react::UIManager> const uiManager;
 
 - (instancetype)initWithToolbox:(facebook::react::SchedulerToolbox)toolbox;
 

--- a/React/Fabric/RCTScheduler.mm
+++ b/React/Fabric/RCTScheduler.mm
@@ -203,4 +203,9 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   return _scheduler->removeEventListener(listener);
 }
 
+- (std::shared_ptr<facebook::react::UIManager> const)uiManager
+{
+  return _scheduler->getUIManager();
+}
+
 @end

--- a/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -351,6 +351,10 @@ ContextContainer::Shared Scheduler::getContextContainer() const {
   return contextContainer_;
 }
 
+std::shared_ptr<UIManager> Scheduler::getUIManager() const {
+  return uiManager_;
+}
+
 void Scheduler::addEventListener(
     const std::shared_ptr<EventListener const> &listener) {
   if (eventDispatcher_->has_value()) {

--- a/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -108,6 +108,9 @@ class Scheduler final : public UIManagerDelegate {
 #pragma mark - ContextContainer
   ContextContainer::Shared getContextContainer() const;
 
+#pragma mark - UIManager
+  std::shared_ptr<UIManager> getUIManager() const;
+
 #pragma mark - Event listeners
   void addEventListener(const std::shared_ptr<EventListener const> &listener);
   void removeEventListener(


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/54db5f20129

Exposes `UIManager` instance for access from third-party modules.

## Changelog

Changelog: [Changed] Exposes `UIManager` instance for third-party access.

## Test Plan

Run rn-tester-ios with Fabric enabled:
<img width="945" alt="Screen Shot 2022-11-11 at 11 38 58 PM" src="https://user-images.githubusercontent.com/484044/201440921-ffddac76-955d-4b83-b524-54b490e30d52.png">

