### PR TITLE
Cherry-pick: Disable default clipping in Fabric's SafeAreaView implementation

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -24,7 +24,6 @@ using namespace facebook::react;
   if (self = [super initWithFrame:frame]) {
     static auto const defaultProps = std::make_shared<SafeAreaViewProps const>();
     _props = defaultProps;
-    self.clipsToBounds = YES;
   }
 
   return self;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [X] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Summary:
Cherry-pick a **react-native@0.71 commit** into the current main branch:
https://github.com/facebook/react-native/commit/d9f93d30e09

This behavior diverges from the original SafeAreaView implementation and causes issues when you try to use SafeAreaView in non-root placements (not recommended)

## Changelog

Changelog: [iOS][Internal]

## Test Plan

CirclecI