### PR TITLE
Cherry-pick: Remove flag react_native_new_architecture:runtimescheduler_enable_yielding_ios

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -276,6 +276,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   auto weakRuntimeScheduler = _contextContainer->find<std::weak_ptr<RuntimeScheduler>>("RuntimeScheduler");
   auto runtimeScheduler = weakRuntimeScheduler.hasValue() ? weakRuntimeScheduler.value().lock() : nullptr;
   if (runtimeScheduler) {
+    runtimeScheduler->setEnableYielding(true);
     runtimeExecutor = [runtimeScheduler](std::function<void(jsi::Runtime & runtime)> &&callback) {
       runtimeScheduler->scheduleWork(std::move(callback));
     };


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/cefc0562417

This is shipped on iOS, let's remove gating.

## Changelog

changelog: [internal]

## Test Plan

CircleCI