### PR TITLE
Cherry-pick: 1/3 Add validation reporting APIs for unexpected uses of Paper when Fabric is enabled, in Bridge mode

### DIFF
--- a/React/Base/RCTAssert.h
+++ b/React/Base/RCTAssert.h
@@ -170,21 +170,35 @@ RCT_EXTERN NSString *RCTFormatStackTrace(NSArray<NSDictionary<NSString *, id> *>
 
 #endif
 
+// MARK: - New Architecture Validation
+
+typedef enum {
+  RCTNotAllowedInFabric = 1,
+  RCTNotAllowedInBridgeless = 2,
+} RCTNotAllowedValidation;
+
 /**
- * Controls for ensuring the new architecture runtime assumption holds.
+ * Ensure runtime assumptions holds for the new architecture by reporting when assumptions are violated.
  * Note: this is work in progress.
+ *
+ * When type is RCTNotAllowedInFabric, validate Fabric assumptions in Bridge or Bridgeless mode.
+ * i.e. Report legacy pre-Fabric call sites that should not be used while Fabric is enabled,
+ *
+ * When type is RCTNotAllowedInBridgeless, validate Bridgeless assumptions, in Bridgeless mode only.
+ * i.e. Report Bridge call sites that should not be used while Bridgeless mode is enabled.
+ *
+ * Note: enabling this at runtime is not early enough to report issues within ObjC class +load execution.
  */
+__attribute__((used)) RCT_EXTERN void RCTEnableNewArchitectureValidationReporting(RCTNotAllowedValidation type);
 
-// Enable reporting of any violation related to the new React Native architecture.
-// If RCT_NEW_ARCHITECTURE is defined, it is already enabled by default, otherwise, no violation will be
-// reported until enabled.
-// Note: enabling this at runtime is not early enough to report issues within ObjC class +load execution.
-__attribute__((used)) RCT_EXTERN void RCTEnableNewArchitectureViolationReporting(BOOL enabled);
-
-// When reporting is enabled, trigger an assertion.
-__attribute__((used)) RCT_EXTERN void RCTEnforceNotAllowedForNewArchitecture(id context, NSString *extra);
-// When reporting is enabled, trigger an error but do not crash. Use this to prepare a specific callsite
-// for stricter enforcement. When ready, switch it to use the variant above.
-__attribute__((used)) RCT_EXTERN void RCTErrorNotAllowedForNewArchitecture(id context, NSString *extra);
-// When reporting is enabled, log an message. When ready, switch it to use the variant above.
-__attribute__((used)) RCT_EXTERN void RCTLogNotAllowedForNewArchitecture(id context, NSString *extra);
+// When new architecture validation reporting is enabled, trigger an assertion and crash.
+__attribute__((used)) RCT_EXTERN void
+RCTEnforceNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra);
+// When new architecture validation reporting is enabled, trigger an error but do not crash.
+// When ready, switch to stricter variant above.
+__attribute__((used)) RCT_EXTERN void
+RCTErrorNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra);
+// When new architecture validation reporting is enabled, log an message.
+// When ready, switch to stricter variant above.
+__attribute__((used)) RCT_EXTERN void
+RCTLogNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra);

--- a/React/Base/RCTAssert.m
+++ b/React/Base/RCTAssert.m
@@ -231,63 +231,94 @@ RCTFatalExceptionHandler RCTGetFatalExceptionHandler(void)
   return RCTCurrentFatalExceptionHandler;
 }
 
-// -------------------------
-// New architecture section
-// -------------------------
+// MARK: - New Architecture Validation - Enable Reporting
 
 #if RCT_NEW_ARCHITECTURE
-static BOOL newArchitectureViolationReporting = YES;
+static RCTNotAllowedValidation validationReportingEnabled = RCTNotAllowedInBridgeless;
 #else
-static BOOL newArchitectureViolationReporting = NO;
+static RCTNotAllowedValidation validationReportingEnabled = 0;
 #endif
 
-void RCTEnableNewArchitectureViolationReporting(BOOL enabled)
+__attribute__((used)) RCT_EXTERN void RCTEnableNewArchitectureValidationReporting(RCTNotAllowedValidation type)
 {
 #if RCT_NEW_ARCHITECTURE
   // Cannot disable the reporting in this mode.
 #else
-  newArchitectureViolationReporting = enabled;
+  validationReportingEnabled = type;
 #endif
 }
 
-static NSString *getNewArchitectureViolationMessage(id context, NSString *extra)
+// MARK: - New Architecture Validation - Private
+
+static BOOL shouldEnforceValidation(RCTNotAllowedValidation type)
 {
-  NSString *tag = @"uncategorized";
+  switch (type) {
+    case RCTNotAllowedInFabric:
+      return validationReportingEnabled == RCTNotAllowedInBridgeless ||
+          validationReportingEnabled == RCTNotAllowedInFabric;
+    case RCTNotAllowedInBridgeless:
+      return validationReportingEnabled == RCTNotAllowedInBridgeless;
+  }
+  return NO;
+}
+
+static NSString *stringDescribingContext(id context)
+{
   if ([context isKindOfClass:NSString.class]) {
-    tag = context;
+    return context;
   } else if (context) {
     Class klass = [context class];
     if (klass) {
-      tag = NSStringFromClass(klass);
+      return NSStringFromClass(klass);
     }
   }
-  NSString *errorMessage = extra ?: @"Unexpectedly reached this code path.";
-  return [NSString stringWithFormat:@"[ReactNative Architecture][%@] %@", tag, errorMessage];
+  return @"uncategorized";
 }
 
-void RCTEnforceNotAllowedForNewArchitecture(id context, NSString *extra)
+static NSString *validationMessage(RCTNotAllowedValidation type, id context, NSString *extra)
 {
-  if (!newArchitectureViolationReporting) {
+  NSString *notAllowedType;
+  switch (type) {
+    case RCTNotAllowedInFabric:
+      notAllowedType = @"Fabric";
+      break;
+    case RCTNotAllowedInBridgeless:
+      notAllowedType = @"Bridgeless";
+      break;
+  }
+
+  return
+      [NSString stringWithFormat:@"[ReactNative Architecture][NotAllowedIn%@] Unexpectedly reached code path in %@. %@",
+                                 notAllowedType,
+                                 stringDescribingContext(context),
+                                 extra ?: @""];
+}
+
+// MARK: - New Architecture Validation - Public
+
+void RCTEnforceNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra)
+{
+  if (!shouldEnforceValidation(type)) {
     return;
   }
 
-  RCTAssert(0, @"%@", getNewArchitectureViolationMessage(context, extra));
+  RCTAssert(0, @"%@", validationMessage(type, context, extra));
 }
 
-void RCTErrorNotAllowedForNewArchitecture(id context, NSString *extra)
+void RCTErrorNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra)
 {
-  if (!newArchitectureViolationReporting) {
+  if (!shouldEnforceValidation(type)) {
     return;
   }
 
-  RCTLogError(@"%@", getNewArchitectureViolationMessage(context, extra));
+  RCTLogError(@"%@", validationMessage(type, context, extra));
 }
 
-void RCTLogNotAllowedForNewArchitecture(id context, NSString *extra)
+void RCTLogNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra)
 {
-  if (!newArchitectureViolationReporting) {
+  if (!shouldEnforceValidation(type)) {
     return;
   }
 
-  RCTLogInfo(@"%@", getNewArchitectureViolationMessage(context, extra));
+  RCTLogInfo(@"%@", validationMessage(type, context, extra));
 }

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -60,8 +60,10 @@ NSArray<Class> *RCTGetModuleClasses(void)
 void RCTRegisterModule(Class);
 void RCTRegisterModule(Class moduleClass)
 {
-  RCTLogNotAllowedForNewArchitecture(
-      @"RCTRegisterModule()", [NSString stringWithFormat:@"'%@' was registered unexpectedly", moduleClass]);
+  RCTLogNewArchitectureValidation(
+      RCTNotAllowedInBridgeless,
+      @"RCTRegisterModule()",
+      [NSString stringWithFormat:@"'%@' was registered unexpectedly", moduleClass]);
 
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
@@ -223,7 +225,7 @@ static RCTBridge *RCTCurrentBridgeInstance = nil;
                    launchOptions:(NSDictionary *)launchOptions
 {
   if (self = [super init]) {
-    RCTEnforceNotAllowedForNewArchitecture(self, nil);
+    RCTEnforceNewArchitectureValidation(RCTNotAllowedInBridgeless, self, nil);
     _delegate = delegate;
     _bundleURL = bundleURL;
     _moduleProvider = block;

--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -109,7 +109,8 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
 + (BOOL)isSupported:(NSString *)componentName
 {
-  RCTLogNotAllowedForNewArchitecture(
+  RCTLogNewArchitectureValidation(
+      RCTNotAllowedInBridgeless,
       self,
       [NSString
           stringWithFormat:

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -156,7 +156,8 @@ RCT_EXPORT_MODULE()
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  RCTEnforceNotAllowedForNewArchitecture(self, @"RCTUIManager must not be initialized for the new architecture");
+  RCTEnforceNewArchitectureValidation(
+      RCTNotAllowedInBridgeless, self, @"RCTUIManager must not be initialized for the new architecture");
 
   RCTAssert(_bridge == nil, @"Should not re-use same UIManager instance");
   _bridge = bridge;

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -95,7 +95,8 @@ RCT_EXPORT_MODULE()
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  RCTErrorNotAllowedForNewArchitecture(self, @"RCTViewManager must not be initialized for the new architecture");
+  RCTErrorNewArchitectureValidation(
+      RCTNotAllowedInBridgeless, self, @"RCTViewManager must not be initialized for the new architecture");
   _bridge = bridge;
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/743d0706e20

## RCTNotAllowedInBridgeless
Previously, we only had violation reporting APIs for when **Bridge APIs** are used in **Bridgeless mode**, which was only enabled in Bridgeless mode.

## RCTNotAllowedInFabric
This diff adds violation reporting APIs to use when **pre-Fabric Bridge APIs** are used in **Bridge or Bridgeless mode**. This allows us to add RCTAssert/RCTError/RCTLog to more APIs in Bridge mode. The main purpose is to distinguish between Bridge APIs that still work in Fabric, versus Bridge APIs that are no longer used in Fabric, so that the latter can be removed.


## Changelog

Changelog: [Internal][iOS] Add validation reporting APIs for unexpected uses of Paper when Fabric is enabled

## Test Plan

Run rn-iOS with Fabric enabled. Created Xcode project via:
```
bundle install && USE_FABRIC=1 bundle exec pod install
```

https://user-images.githubusercontent.com/484044/201445597-e9ab0502-0c0a-4520-90cd-39340cbc6fdb.mov


