### PR TITLE
Cherry-pick: Fix: Make RCTSurfacePresenter weakly retain its observers

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -80,8 +80,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   RuntimeExecutor _runtimeExecutor; // Protected by `_schedulerLifeCycleMutex`.
 
   butter::shared_mutex _observerListMutex;
-  NSMutableArray<id<RCTSurfacePresenterObserver>> *_observers;
-  RCTImageLoader *_imageLoader;
+  std::vector<__weak id<RCTSurfacePresenterObserver>> _observers; // Protected by `_observerListMutex`.
 }
 
 - (instancetype)initWithContextContainer:(ContextContainer::Shared)contextContainer
@@ -96,8 +95,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     _mountingManager = [RCTMountingManager new];
     _mountingManager.contextContainer = contextContainer;
     _mountingManager.delegate = self;
-
-    _observers = [NSMutableArray array];
 
     _scheduler = [self _createScheduler];
   }
@@ -367,13 +364,17 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 - (void)addObserver:(id<RCTSurfacePresenterObserver>)observer
 {
   std::unique_lock<butter::shared_mutex> lock(_observerListMutex);
-  [self->_observers addObject:observer];
+  _observers.push_back(observer);
 }
 
 - (void)removeObserver:(id<RCTSurfacePresenterObserver>)observer
 {
   std::unique_lock<butter::shared_mutex> lock(_observerListMutex);
-  [self->_observers removeObject:observer];
+  std::vector<__weak id<RCTSurfacePresenterObserver>>::const_iterator it =
+      std::find(_observers.begin(), _observers.end(), observer);
+  if (it != _observers.end()) {
+    _observers.erase(it);
+  }
 }
 
 #pragma mark - RCTMountingManagerDelegate
@@ -382,8 +383,13 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 {
   RCTAssertMainQueue();
 
-  std::shared_lock<butter::shared_mutex> lock(_observerListMutex);
-  for (id<RCTSurfacePresenterObserver> observer in _observers) {
+  NSArray<id<RCTSurfacePresenterObserver>> *observersCopy;
+  {
+    std::shared_lock<butter::shared_mutex> lock(_observerListMutex);
+    observersCopy = [self _getObservers];
+  }
+
+  for (id<RCTSurfacePresenterObserver> observer in observersCopy) {
     if ([observer respondsToSelector:@selector(willMountComponentsWithRootTag:)]) {
       [observer willMountComponentsWithRootTag:rootTag];
     }
@@ -394,12 +400,29 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 {
   RCTAssertMainQueue();
 
-  std::shared_lock<butter::shared_mutex> lock(_observerListMutex);
-  for (id<RCTSurfacePresenterObserver> observer in _observers) {
+  NSArray<id<RCTSurfacePresenterObserver>> *observersCopy;
+  {
+    std::shared_lock<butter::shared_mutex> lock(_observerListMutex);
+    observersCopy = [self _getObservers];
+  }
+
+  for (id<RCTSurfacePresenterObserver> observer in observersCopy) {
     if ([observer respondsToSelector:@selector(didMountComponentsWithRootTag:)]) {
       [observer didMountComponentsWithRootTag:rootTag];
     }
   }
+}
+
+- (NSArray<id<RCTSurfacePresenterObserver>> *)_getObservers
+{
+  NSMutableArray<id<RCTSurfacePresenterObserver>> *observersCopy = [NSMutableArray new];
+  for (id<RCTSurfacePresenterObserver> observer : _observers) {
+    if (observer) {
+      [observersCopy addObject:observer];
+    }
+  }
+
+  return observersCopy;
 }
 
 @end


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/88814d52ddd

There is retain cycle because RCTSurfacePresenter is keeping an array of  RCTSurfacePresenterObserver, which is strongly retaining the class that owns this RCTSurfacePresenter.

This diff makes RCTSurfacePresenter weakly retain observers instead.
 
## Changelog

Changelog: [Fabric][iOS] Fix: Make RCTSurfacePresenter weakly retain its observers

## Test Plan

Build iOS with Fabric enabled and test a few examples:


https://user-images.githubusercontent.com/484044/201446166-d0f290a1-20fb-4386-866e-1623bdd86708.mov


