### PR TITLE
Cherry-pick: Make ScrollView sticky headers work w/o dispatching RCTEventEmitter.receiveEvent

### DIFF
--- a/React/Base/RCTEventDispatcherProtocol.h
+++ b/React/Base/RCTEventDispatcherProtocol.h
@@ -103,6 +103,11 @@ typedef NS_ENUM(NSInteger, RCTTextEventType) {
                    eventCount:(NSInteger)eventCount;
 
 /**
+ * Notify Observers of event
+ */
+- (void)notifyObserversOfEvent:(id<RCTEvent>)event;
+
+/**
  * Send a pre-prepared event object.
  *
  * Events are sent to JS as soon as the thread is free to process them.

--- a/React/CoreModules/RCTEventDispatcher.mm
+++ b/React/CoreModules/RCTEventDispatcher.mm
@@ -110,7 +110,7 @@ RCT_EXPORT_MODULE()
   [self sendEvent:event];
 }
 
-- (void)sendEvent:(id<RCTEvent>)event
+- (void)notifyObserversOfEvent:(id<RCTEvent>)event
 {
   [_observersLock lock];
 
@@ -119,6 +119,11 @@ RCT_EXPORT_MODULE()
   }
 
   [_observersLock unlock];
+}
+
+- (void)sendEvent:(id<RCTEvent>)event
+{
+  [self notifyObserversOfEvent:event];
 
   [_eventQueueLock lock];
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -73,7 +73,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     [bridge.eventDispatcher sendEvent:scrollEvent];
   } else {
     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:scrollEvent, @"event", nil];
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTSendEventToLegacyEventDispatcher"
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
                                                         object:nil
                                                       userInfo:userInfo];
   }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.70 commit into the current main branch:
https://github.com/facebook/react-native/commit/8dded42b68b

ScrollView sticky headers rely on this bit of code to work:

```
AnimatedImplementation.attachNativeEvent(
  this._scrollViewRef,
  'onScroll',
  [{nativeEvent: {contentOffset: {y: this._scrollAnimatedValue}}}],
);
```

What this code means:

When the ScrollView host component receives the "onScroll" event, assign event.nativeEvent.contentOffSet.y to the this._scrollAnimatedValue AnimatedValue.

How this subscription mechanism is set up:

NativeAnimatedTurboModule subscribes to events dispatched by RCTEventDispatcher sendEvent. Then, whenever RCTEventEmitter sendEvent executes, NativeAnimatedTurboModule also updates the AnimatedValue for that event.

# Problem
Previously, in bridgeless, we started dispatching RCTScrollView via the RCTEventDispatcher sendEvent to update the AnimatedValue for ScrollView. This meant that we started dispatching the onScroll event to JavaScript via RCTEventEmitter.receiveEvent JSModule, which isn't supported in the Fabric renderer.

With this diff, we dialed back that solution. Instead of (1) notifying NativeAnimatedTurboModule and (2) sending the onScroll event to JavaScript, we're only doing (1) (i.e: notifying NativeAnimatedTurboModule).
## Changelog

Changelog: [Internal]

## Test Plan

Try it out:


https://user-images.githubusercontent.com/484044/201446571-a7bc77d0-d974-4e47-b98f-219ede3b1062.mov

