### PR TITLE
Cherry-pick: Delete preemptive view allocation on iOS

### DIFF
--- a/React/Base/RCTConstants.h
+++ b/React/Base/RCTConstants.h
@@ -11,12 +11,6 @@ RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotification;
 RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey;
 
 /*
- * Preemptive View Allocation
- */
-RCT_EXTERN BOOL RCTExperimentGetPreemptiveViewAllocationDisabled(void);
-RCT_EXTERN void RCTExperimentSetPreemptiveViewAllocationDisabled(BOOL value);
-
-/*
  * W3C Pointer Events
  */
 RCT_EXTERN BOOL RCTGetDispatchW3CPointerEvents(void);

--- a/React/Base/RCTConstants.m
+++ b/React/Base/RCTConstants.m
@@ -11,21 +11,6 @@ NSString *const RCTUserInterfaceStyleDidChangeNotification = @"RCTUserInterfaceS
 NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey = @"traitCollection";
 
 /*
- * Preemptive View Allocation
- */
-static BOOL RCTExperimentPreemptiveViewAllocationDisabled = NO;
-
-BOOL RCTExperimentGetPreemptiveViewAllocationDisabled()
-{
-  return RCTExperimentPreemptiveViewAllocationDisabled;
-}
-
-void RCTExperimentSetPreemptiveViewAllocationDisabled(BOOL value)
-{
-  RCTExperimentPreemptiveViewAllocationDisabled = value;
-}
-
-/*
  * W3C Pointer Events
  */
 static BOOL RCTDispatchW3CPointerEvents = NO;

--- a/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -71,13 +71,6 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   dispatch_once(&onceToken, ^{
     componentViewFactory = [RCTComponentViewFactory new];
     [componentViewFactory registerComponentViewClass:[RCTRootComponentView class]];
-    [componentViewFactory registerComponentViewClass:[RCTViewComponentView class]];
-    [componentViewFactory registerComponentViewClass:[RCTParagraphComponentView class]];
-    [componentViewFactory registerComponentViewClass:[RCTTextInputComponentView class]];
-
-    Class<RCTComponentViewProtocol> imageClass = RCTComponentViewClassWithName("Image");
-    [componentViewFactory registerComponentViewClass:imageClass];
-
     componentViewFactory->_providerRegistry.setComponentDescriptorProviderRequest(
         [](ComponentName requestedComponentName) {
           [componentViewFactory registerComponentIfPossible:requestedComponentName];

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.h
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.h
@@ -50,11 +50,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable UIView<RCTComponentViewProtocol> *)findComponentViewWithTag:(facebook::react::Tag)tag;
 
-/**
- * Creates a component view with a given type and puts it to the recycle pool.
- */
-- (void)optimisticallyCreateComponentViewWithComponentHandle:(facebook::react::ComponentHandle)componentHandle;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -35,40 +35,9 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
                                              selector:@selector(handleApplicationDidReceiveMemoryWarningNotification)
                                                  name:UIApplicationDidReceiveMemoryWarningNotification
                                                object:nil];
-
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      // Calling this a bit later, when the main thread is probably idle while JavaScript thread is busy.
-      [self preallocateViewComponents];
-    });
   }
 
   return self;
-}
-
-- (void)preallocateViewComponents
-{
-  if (RCTExperimentGetPreemptiveViewAllocationDisabled()) {
-    return;
-  }
-
-  // This data is based on empirical evidence which should represent the reality pretty well.
-  // Regular `<View>` has magnitude equals to `1` by definition.
-  std::vector<std::pair<ComponentHandle, float>> componentMagnitudes = {
-      {[RCTViewComponentView componentDescriptorProvider].handle, 1},
-      {[RCTImageComponentView componentDescriptorProvider].handle, 0.3},
-      {[RCTParagraphComponentView componentDescriptorProvider].handle, 0.3},
-  };
-
-  // `complexity` represents the complexity of a typical surface in a number of `<View>` components (with Flattening
-  // enabled).
-  float complexity = 100;
-
-  // The whole process should not take more than 10ms in the worst case, so there is no need to split it up.
-  for (const auto &componentMagnitude : componentMagnitudes) {
-    for (int i = 0; i < complexity * componentMagnitude.second; i++) {
-      [self optimisticallyCreateComponentViewWithComponentHandle:componentMagnitude.first];
-    }
-  }
 }
 
 - (RCTComponentViewDescriptor const &)dequeueComponentViewWithComponentHandle:(ComponentHandle)componentHandle
@@ -98,14 +67,6 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   _registry.erase(tag);
   componentViewDescriptor.view.tag = 0;
   [self _enqueueComponentViewWithComponentHandle:componentHandle componentViewDescriptor:componentViewDescriptor];
-}
-
-- (void)optimisticallyCreateComponentViewWithComponentHandle:(ComponentHandle)componentHandle
-{
-  RCTAssertMainQueue();
-  [self _enqueueComponentViewWithComponentHandle:componentHandle
-                         componentViewDescriptor:[self.componentViewFactory
-                                                     createComponentViewWithComponentHandle:componentHandle]];
 }
 
 - (RCTComponentViewDescriptor const &)componentViewDescriptorWithTag:(Tag)tag

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -252,10 +252,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 {
   auto reactNativeConfig = _contextContainer->at<std::shared_ptr<ReactNativeConfig const>>("ReactNativeConfig");
 
-  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:preemptive_view_allocation_disabled_ios")) {
-    RCTExperimentSetPreemptiveViewAllocationDisabled(YES);
-  }
-
   if (reactNativeConfig && reactNativeConfig->getBool("rn_convergence:dispatch_pointer_events")) {
     RCTSetDispatchW3CPointerEvents(YES);
   }

--- a/React/Tests/Mounting/RCTComponentViewRegistryTests.mm
+++ b/React/Tests/Mounting/RCTComponentViewRegistryTests.mm
@@ -22,6 +22,7 @@ using namespace facebook::react;
 {
   [super setUp];
   _componentViewRegistry = [RCTComponentViewRegistry new];
+  [_componentViewRegistry.componentViewFactory registerComponentViewClass:[RCTViewComponentView class]];
 }
 
 - (void)testComponentViewDescriptorWithTag


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry-pick a react-native@0.70 commit into the current main branch:
https://github.com/facebook/react-native/commit/71dd83afcab

preemtive view allocation has been disabled on iOS for over a year. We kept the code in but didn't do anything with it. This diff removes the code and related mobile config.


## Changelog

changelog: [internal]

## Test Plan

Just deleting code