### PR TITLE
Cherry-pick: Permanently enable yielding in runtime scheduler

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -269,7 +269,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   auto weakRuntimeScheduler = _contextContainer->find<std::weak_ptr<RuntimeScheduler>>("RuntimeScheduler");
   auto runtimeScheduler = weakRuntimeScheduler.hasValue() ? weakRuntimeScheduler.value().lock() : nullptr;
   if (runtimeScheduler) {
-    runtimeScheduler->setEnableYielding(true);
     runtimeExecutor = [runtimeScheduler](std::function<void(jsi::Runtime & runtime)> &&callback) {
       runtimeScheduler->scheduleWork(std::move(callback));
     };

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -22,10 +22,11 @@ RuntimeScheduler::RuntimeScheduler(
 
 void RuntimeScheduler::scheduleWork(
     std::function<void(jsi::Runtime &)> callback) const {
-  shouldYield_ = true;
+  runtimeAccessRequests_ += 1;
+
   runtimeExecutor_(
       [this, callback = std::move(callback)](jsi::Runtime &runtime) {
-        shouldYield_ = false;
+        runtimeAccessRequests_ -= 1;
         callback(runtime);
         startWorkLoop(runtime);
       });

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -106,6 +106,12 @@ class RuntimeScheduler final {
   RuntimeExecutor const runtimeExecutor_;
   mutable SchedulerPriority currentPriority_{SchedulerPriority::NormalPriority};
   mutable std::atomic_bool shouldYield_{false};
+
+  /*
+   * Counter indicating how many access to the runtime have been requested.
+   */
+  mutable std::atomic<uint_fast8_t> runtimeAccessRequests_{0};
+
   mutable std::atomic_bool isSynchronous_{false};
 
   void startWorkLoop(jsi::Runtime &runtime) const;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/83631848d2a

## Changelog
Summary: Changelog: [Internal] Emit touch-equivalent W3C pointer events on iOS

## Test Plan

Run rn-tester-iOS with Fabric enabled:

https://user-images.githubusercontent.com/484044/201482049-72b404f1-cbd4-4ab7-a1e5-04454e9e2f78.mov

