### PR TITLE
Cherry-pick: Emit touch-equivalent W3C pointer events on iOS

### DIFF
--- a/Libraries/NativeComponent/PlatformBaseViewConfig.js
+++ b/Libraries/NativeComponent/PlatformBaseViewConfig.js
@@ -1,0 +1,572 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import {Platform} from 'react-native';
+import type {PartialViewConfig} from '../Renderer/shims/ReactNativeTypes';
+import ReactNativeStyleAttributes from '../Components/View/ReactNativeStyleAttributes';
+import {
+  DynamicallyInjectedByGestureHandler,
+  ConditionallyIgnoredEventHandlers,
+} from './ViewConfigIgnore';
+
+type PartialViewConfigWithoutName = $Rest<
+  PartialViewConfig,
+  {uiViewClassName: string},
+>;
+
+const PlatformBaseViewConfig: PartialViewConfigWithoutName =
+  Platform.OS === 'android'
+    ? /**
+       * On Android, Props are derived from a ViewManager and its ShadowNode.
+       *
+       * Where did we find these base platform props from?
+       * - Nearly all component ViewManagers descend from BaseViewManager.
+       * - BaseViewManagers' ShadowNodes descend from LayoutShadowNode.
+       *
+       * So, these ViewConfigs are generated from LayoutShadowNode and BaseViewManager.
+       */
+      {
+        directEventTypes: {
+          topAccessibilityAction: {
+            registrationName: 'onAccessibilityAction',
+          },
+          topPointerEnter: {
+            registrationName: 'onPointerEnter',
+          },
+          topPointerLeave: {
+            registrationName: 'onPointerLeave',
+          },
+          topPointerMove: {
+            registrationName: 'onPointerMove',
+          },
+          onGestureHandlerEvent: DynamicallyInjectedByGestureHandler({
+            registrationName: 'onGestureHandlerEvent',
+          }),
+          onGestureHandlerStateChange: DynamicallyInjectedByGestureHandler({
+            registrationName: 'onGestureHandlerStateChange',
+          }),
+
+          // Direct events from UIManagerModuleConstants.java
+          topContentSizeChange: {
+            registrationName: 'onContentSizeChange',
+          },
+          topScrollBeginDrag: {
+            registrationName: 'onScrollBeginDrag',
+          },
+          topMessage: {
+            registrationName: 'onMessage',
+          },
+          topSelectionChange: {
+            registrationName: 'onSelectionChange',
+          },
+          topLoadingFinish: {
+            registrationName: 'onLoadingFinish',
+          },
+          topMomentumScrollEnd: {
+            registrationName: 'onMomentumScrollEnd',
+          },
+          topClick: {
+            registrationName: 'onClick',
+          },
+          topLoadingStart: {
+            registrationName: 'onLoadingStart',
+          },
+          topLoadingError: {
+            registrationName: 'onLoadingError',
+          },
+          topMomentumScrollBegin: {
+            registrationName: 'onMomentumScrollBegin',
+          },
+          topScrollEndDrag: {
+            registrationName: 'onScrollEndDrag',
+          },
+          topScroll: {
+            registrationName: 'onScroll',
+          },
+          topLayout: {
+            registrationName: 'onLayout',
+          },
+        },
+        bubblingEventTypes: {
+          // Bubbling events from UIManagerModuleConstants.java
+          topChange: {
+            phasedRegistrationNames: {
+              captured: 'onChangeCapture',
+              bubbled: 'onChange',
+            },
+          },
+          topSelect: {
+            phasedRegistrationNames: {
+              captured: 'onSelectCapture',
+              bubbled: 'onSelect',
+            },
+          },
+          topTouchEnd: {
+            phasedRegistrationNames: {
+              captured: 'onTouchEndCapture',
+              bubbled: 'onTouchEnd',
+            },
+          },
+          topTouchCancel: {
+            phasedRegistrationNames: {
+              captured: 'onTouchCancelCapture',
+              bubbled: 'onTouchCancel',
+            },
+          },
+          topTouchStart: {
+            phasedRegistrationNames: {
+              captured: 'onTouchStartCapture',
+              bubbled: 'onTouchStart',
+            },
+          },
+          topTouchMove: {
+            phasedRegistrationNames: {
+              captured: 'onTouchMoveCapture',
+              bubbled: 'onTouchMove',
+            },
+          },
+          topPointerCancel: {
+            phasedRegistrationNames: {
+              captured: 'onPointerCancelCapture',
+              bubbled: 'onPointerCancel',
+            },
+          },
+          topPointerDown: {
+            phasedRegistrationNames: {
+              captured: 'onPointerDownCapture',
+              bubbled: 'onPointerDown',
+            },
+          },
+          topPointerEnter2: {
+            phasedRegistrationNames: {
+              captured: 'onPointerEnter2Capture',
+              bubbled: 'onPointerEnter2',
+              skipBubbling: true,
+            },
+          },
+          topPointerLeave2: {
+            phasedRegistrationNames: {
+              captured: 'onPointerLeave2Capture',
+              bubbled: 'onPointerLeave2',
+              skipBubbling: true,
+            },
+          },
+          topPointerMove2: {
+            phasedRegistrationNames: {
+              captured: 'onPointerMove2Capture',
+              bubbled: 'onPointerMove2',
+            },
+          },
+          topPointerUp: {
+            phasedRegistrationNames: {
+              captured: 'onPointerUpCapture',
+              bubbled: 'onPointerUp',
+            },
+          },
+        },
+        validAttributes: {
+          // @ReactProps from BaseViewManager
+          backgroundColor: {process: require('../StyleSheet/processColor')},
+          transform: true,
+          opacity: true,
+          elevation: true,
+          shadowColor: {process: require('../StyleSheet/processColor')},
+          zIndex: true,
+          renderToHardwareTextureAndroid: true,
+          testID: true,
+          nativeID: true,
+          accessibilityLabelledBy: true,
+          accessibilityLabel: true,
+          accessibilityHint: true,
+          accessibilityLanguage: true,
+          accessibilityRole: true,
+          accessibilityState: true,
+          accessibilityActions: true,
+          accessibilityValue: true,
+          importantForAccessibility: true,
+          rotation: true,
+          scaleX: true,
+          scaleY: true,
+          translateX: true,
+          translateY: true,
+          accessibilityLiveRegion: true,
+
+          // @ReactProps from LayoutShadowNode
+          width: true,
+          minWidth: true,
+          collapsable: true,
+          maxWidth: true,
+          height: true,
+          minHeight: true,
+          maxHeight: true,
+          flex: true,
+          flexGrow: true,
+          flexShrink: true,
+          flexBasis: true,
+          aspectRatio: true,
+          flexDirection: true,
+          flexWrap: true,
+          alignSelf: true,
+          alignItems: true,
+          alignContent: true,
+          justifyContent: true,
+          overflow: true,
+          display: true,
+
+          margin: true,
+          marginVertical: true,
+          marginHorizontal: true,
+          marginStart: true,
+          marginEnd: true,
+          marginTop: true,
+          marginBottom: true,
+          marginLeft: true,
+          marginRight: true,
+
+          padding: true,
+          paddingVertical: true,
+          paddingHorizontal: true,
+          paddingStart: true,
+          paddingEnd: true,
+          paddingTop: true,
+          paddingBottom: true,
+          paddingLeft: true,
+          paddingRight: true,
+
+          borderWidth: true,
+          borderStartWidth: true,
+          borderEndWidth: true,
+          borderTopWidth: true,
+          borderBottomWidth: true,
+          borderLeftWidth: true,
+          borderRightWidth: true,
+
+          start: true,
+          end: true,
+          left: true,
+          right: true,
+          top: true,
+          bottom: true,
+
+          position: true,
+          onLayout: true,
+
+          // Pointer events
+          onPointerEnter: true,
+          onPointerLeave: true,
+          onPointerMove: true,
+
+          // PanResponder handlers
+          onMoveShouldSetResponder: true,
+          onMoveShouldSetResponderCapture: true,
+          onStartShouldSetResponder: true,
+          onStartShouldSetResponderCapture: true,
+          onResponderGrant: true,
+          onResponderReject: true,
+          onResponderStart: true,
+          onResponderEnd: true,
+          onResponderRelease: true,
+          onResponderMove: true,
+          onResponderTerminate: true,
+          onResponderTerminationRequest: true,
+          onShouldBlockNativeResponder: true,
+
+          // Touch events
+          onTouchStart: true,
+          onTouchMove: true,
+          onTouchEnd: true,
+          onTouchCancel: true,
+
+          style: ReactNativeStyleAttributes,
+        },
+      }
+    : /**
+       * On iOS, ViewManagers define all of a component's props.
+       * All ViewManagers extend RCTViewManager, and RCTViewManager declares
+       * these props.
+       */
+      {
+        bubblingEventTypes: {
+          // Generic Events
+          topPress: {
+            phasedRegistrationNames: {
+              bubbled: 'onPress',
+              captured: 'onPressCapture',
+            },
+          },
+          topChange: {
+            phasedRegistrationNames: {
+              bubbled: 'onChange',
+              captured: 'onChangeCapture',
+            },
+          },
+          topFocus: {
+            phasedRegistrationNames: {
+              bubbled: 'onFocus',
+              captured: 'onFocusCapture',
+            },
+          },
+          topBlur: {
+            phasedRegistrationNames: {
+              bubbled: 'onBlur',
+              captured: 'onBlurCapture',
+            },
+          },
+          topSubmitEditing: {
+            phasedRegistrationNames: {
+              bubbled: 'onSubmitEditing',
+              captured: 'onSubmitEditingCapture',
+            },
+          },
+          topEndEditing: {
+            phasedRegistrationNames: {
+              bubbled: 'onEndEditing',
+              captured: 'onEndEditingCapture',
+            },
+          },
+          topKeyPress: {
+            phasedRegistrationNames: {
+              bubbled: 'onKeyPress',
+              captured: 'onKeyPressCapture',
+            },
+          },
+
+          // Touch Events
+          topTouchStart: {
+            phasedRegistrationNames: {
+              bubbled: 'onTouchStart',
+              captured: 'onTouchStartCapture',
+            },
+          },
+          topTouchMove: {
+            phasedRegistrationNames: {
+              bubbled: 'onTouchMove',
+              captured: 'onTouchMoveCapture',
+            },
+          },
+          topTouchCancel: {
+            phasedRegistrationNames: {
+              bubbled: 'onTouchCancel',
+              captured: 'onTouchCancelCapture',
+            },
+          },
+          topTouchEnd: {
+            phasedRegistrationNames: {
+              bubbled: 'onTouchEnd',
+              captured: 'onTouchEndCapture',
+            },
+          },
+
+          // Pointer Events
+          topPointerCancel: {
+            phasedRegistrationNames: {
+              captured: 'onPointerCancelCapture',
+              bubbled: 'onPointerCancel',
+            },
+          },
+          topPointerDown: {
+            phasedRegistrationNames: {
+              captured: 'onPointerDownCapture',
+              bubbled: 'onPointerDown',
+            },
+          },
+          topPointerMove2: {
+            phasedRegistrationNames: {
+              captured: 'onPointerMove2Capture',
+              bubbled: 'onPointerMove2',
+            },
+          },
+          topPointerUp: {
+            phasedRegistrationNames: {
+              captured: 'onPointerUpCapture',
+              bubbled: 'onPointerUp',
+            },
+          },
+        },
+        directEventTypes: {
+          topAccessibilityAction: {
+            registrationName: 'onAccessibilityAction',
+          },
+          topAccessibilityTap: {
+            registrationName: 'onAccessibilityTap',
+          },
+          topMagicTap: {
+            registrationName: 'onMagicTap',
+          },
+          topAccessibilityEscape: {
+            registrationName: 'onAccessibilityEscape',
+          },
+          topLayout: {
+            registrationName: 'onLayout',
+          },
+          onGestureHandlerEvent: DynamicallyInjectedByGestureHandler({
+            registrationName: 'onGestureHandlerEvent',
+          }),
+          onGestureHandlerStateChange: DynamicallyInjectedByGestureHandler({
+            registrationName: 'onGestureHandlerStateChange',
+          }),
+        },
+        validAttributes: {
+          // View Props
+          accessible: true,
+          accessibilityActions: true,
+          accessibilityLabel: true,
+          accessibilityHint: true,
+          accessibilityLanguage: true,
+          accessibilityValue: true,
+          accessibilityViewIsModal: true,
+          accessibilityElementsHidden: true,
+          accessibilityIgnoresInvertColors: true,
+          testID: true,
+          backgroundColor: {process: require('../StyleSheet/processColor')},
+          backfaceVisibility: true,
+          opacity: true,
+          shadowColor: {process: require('../StyleSheet/processColor')},
+          shadowOffset: {diff: require('../Utilities/differ/sizesDiffer')},
+          shadowOpacity: true,
+          shadowRadius: true,
+          needsOffscreenAlphaCompositing: true,
+          overflow: true,
+          shouldRasterizeIOS: true,
+          transform: {diff: require('../Utilities/differ/matricesDiffer')},
+          accessibilityRole: true,
+          accessibilityState: true,
+          nativeID: true,
+          pointerEvents: true,
+          removeClippedSubviews: true,
+          borderRadius: true,
+          borderColor: {process: require('../StyleSheet/processColor')},
+          borderWidth: true,
+          borderStyle: true,
+          hitSlop: {diff: require('../Utilities/differ/insetsDiffer')},
+          collapsable: true,
+
+          borderTopWidth: true,
+          borderTopColor: {process: require('../StyleSheet/processColor')},
+          borderRightWidth: true,
+          borderRightColor: {process: require('../StyleSheet/processColor')},
+          borderBottomWidth: true,
+          borderBottomColor: {process: require('../StyleSheet/processColor')},
+          borderLeftWidth: true,
+          borderLeftColor: {process: require('../StyleSheet/processColor')},
+          borderStartWidth: true,
+          borderStartColor: {process: require('../StyleSheet/processColor')},
+          borderEndWidth: true,
+          borderEndColor: {process: require('../StyleSheet/processColor')},
+
+          borderTopLeftRadius: true,
+          borderTopRightRadius: true,
+          borderTopStartRadius: true,
+          borderTopEndRadius: true,
+          borderBottomLeftRadius: true,
+          borderBottomRightRadius: true,
+          borderBottomStartRadius: true,
+          borderBottomEndRadius: true,
+          display: true,
+          zIndex: true,
+
+          // ShadowView properties
+          top: true,
+          right: true,
+          start: true,
+          end: true,
+          bottom: true,
+          left: true,
+
+          width: true,
+          height: true,
+
+          minWidth: true,
+          maxWidth: true,
+          minHeight: true,
+          maxHeight: true,
+
+          // Also declared as ViewProps
+          // borderTopWidth: true,
+          // borderRightWidth: true,
+          // borderBottomWidth: true,
+          // borderLeftWidth: true,
+          // borderStartWidth: true,
+          // borderEndWidth: true,
+          // borderWidth: true,
+
+          marginTop: true,
+          marginRight: true,
+          marginBottom: true,
+          marginLeft: true,
+          marginStart: true,
+          marginEnd: true,
+          marginVertical: true,
+          marginHorizontal: true,
+          margin: true,
+
+          paddingTop: true,
+          paddingRight: true,
+          paddingBottom: true,
+          paddingLeft: true,
+          paddingStart: true,
+          paddingEnd: true,
+          paddingVertical: true,
+          paddingHorizontal: true,
+          padding: true,
+
+          flex: true,
+          flexGrow: true,
+          flexShrink: true,
+          flexBasis: true,
+          flexDirection: true,
+          flexWrap: true,
+          justifyContent: true,
+          alignItems: true,
+          alignSelf: true,
+          alignContent: true,
+          position: true,
+          aspectRatio: true,
+
+          // Also declared as ViewProps
+          // overflow: true,
+          // display: true,
+
+          direction: true,
+
+          style: ReactNativeStyleAttributes,
+
+          ...ConditionallyIgnoredEventHandlers({
+            onLayout: true,
+            onMagicTap: true,
+            onAccessibilityAction: true,
+            onAccessibilityEscape: true,
+            onAccessibilityTap: true,
+
+            // PanResponder handlers
+            onMoveShouldSetResponder: true,
+            onMoveShouldSetResponderCapture: true,
+            onStartShouldSetResponder: true,
+            onStartShouldSetResponderCapture: true,
+            onResponderGrant: true,
+            onResponderReject: true,
+            onResponderStart: true,
+            onResponderEnd: true,
+            onResponderRelease: true,
+            onResponderMove: true,
+            onResponderTerminate: true,
+            onResponderTerminationRequest: true,
+            onShouldBlockNativeResponder: true,
+
+            // Touch events
+            onTouchStart: true,
+            onTouchMove: true,
+            onTouchEnd: true,
+            onTouchCancel: true,
+          }),
+        },
+      };
+
+export default PlatformBaseViewConfig;

--- a/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -58,6 +58,11 @@ struct ActiveTouch {
   SharedTouchEventEmitter eventEmitter;
 
   /*
+   * The type of touch received.
+   */
+  UITouchType touchType;
+
+  /*
    * A component view on which the touch was begun.
    */
   __strong UIView<RCTComponentViewProtocol> *componentView = nil;
@@ -97,6 +102,8 @@ static void UpdateActiveTouchWithUITouch(
   if (RCTForceTouchAvailable()) {
     activeTouch.touch.force = RCTZeroIfNaN(uiTouch.force / uiTouch.maximumPossibleForce);
   }
+
+  activeTouch.touchType = uiTouch.type;
 }
 
 static ActiveTouch CreateTouchWithUITouch(UITouch *uiTouch, UIView *rootComponentView, CGPoint rootViewOriginOffset)
@@ -118,6 +125,35 @@ static ActiveTouch CreateTouchWithUITouch(UITouch *uiTouch, UIView *rootComponen
 
   UpdateActiveTouchWithUITouch(activeTouch, uiTouch, rootComponentView, rootViewOriginOffset);
   return activeTouch;
+}
+
+static const char *PointerTypeCStringFromUITouchType(UITouchType type)
+{
+  switch (type) {
+    case UITouchTypeDirect:
+      return "touch";
+    case UITouchTypePencil:
+      return "pen";
+    case UITouchTypeIndirectPointer:
+      return "mouse";
+    case UITouchTypeIndirect:
+    default:
+      return "";
+  }
+}
+
+static PointerEvent CreatePointerEventFromActiveTouch(ActiveTouch activeTouch)
+{
+  Touch touch = activeTouch.touch;
+
+  PointerEvent event = {};
+  event.pointerId = touch.identifier;
+  event.pressure = touch.force;
+  event.pointerType = PointerTypeCStringFromUITouchType(activeTouch.touchType);
+  event.clientPoint = touch.pagePoint;
+  event.target = touch.target;
+  event.timestamp = touch.timestamp;
+  return event;
 }
 
 static BOOL AllTouchesAreCancelledOrEnded(NSSet<UITouch *> *touches)
@@ -272,6 +308,25 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
     changedActiveTouches.insert(activeTouch);
     event.changedTouches.insert(activeTouch.touch);
     uniqueEventEmitters.insert(activeTouch.eventEmitter);
+
+    // emit w3c pointer events
+    if (RCTGetDispatchW3CPointerEvents()) {
+      PointerEvent pointerEvent = CreatePointerEventFromActiveTouch(activeTouch);
+      switch (eventType) {
+        case RCTTouchEventTypeTouchStart:
+          activeTouch.eventEmitter->onPointerDown(pointerEvent);
+          break;
+        case RCTTouchEventTypeTouchMove:
+          activeTouch.eventEmitter->onPointerMove2(pointerEvent);
+          break;
+        case RCTTouchEventTypeTouchEnd:
+          activeTouch.eventEmitter->onPointerUp(pointerEvent);
+          break;
+        case RCTTouchEventTypeTouchCancel:
+          activeTouch.eventEmitter->onPointerCancel(pointerEvent);
+          break;
+      }
+    }
   }
 
   for (const auto &pair : _activeTouches) {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -597,4 +597,35 @@ RCT_EXPORT_SHADOW_PROPERTY(onLayout, RCTDirectEventBlock)
 
 RCT_EXPORT_SHADOW_PROPERTY(direction, YGDirection)
 
+// The events below define the properties that are not used by native directly, but required in the view config for new
+// renderer to function.
+// They can be deleted after Static View Configs are rolled out.
+
+// PanResponder handlers
+RCT_CUSTOM_VIEW_PROPERTY(onMoveShouldSetResponder, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onMoveShouldSetResponderCapture, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onStartShouldSetResponder, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onStartShouldSetResponderCapture, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderGrant, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderReject, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderStart, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderEnd, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderRelease, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderMove, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderTerminate, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onResponderTerminationRequest, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onShouldBlockNativeResponder, BOOL, RCTView) {}
+
+// Touch events
+RCT_CUSTOM_VIEW_PROPERTY(onTouchStart, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onTouchMove, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onTouchEnd, BOOL, RCTView) {}
+RCT_CUSTOM_VIEW_PROPERTY(onTouchCancel, BOOL, RCTView) {}
+
+// Pointer Events
+RCT_EXPORT_VIEW_PROPERTY(onPointerCancel, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPointerDown, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPointerMove2, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPointerUp, RCTBubblingEventBlock)
+
 @end

--- a/ReactCommon/react/renderer/components/view/PointerEvent.cpp
+++ b/ReactCommon/react/renderer/components/view/PointerEvent.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PointerEvent.h"
+
+namespace facebook {
+namespace react {
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+
+std::string getDebugName(PointerEvent const &pointerEvent) {
+  return "PointerEvent";
+}
+
+std::vector<DebugStringConvertibleObject> getDebugProps(
+    PointerEvent const &pointerEvent,
+    DebugStringConvertibleOptions options) {
+  return {
+      {"pointerId", getDebugDescription(pointerEvent.pointerId, options)},
+      {"pressure", getDebugDescription(pointerEvent.pressure, options)},
+      {"pointerType", getDebugDescription(pointerEvent.pointerType, options)},
+      {"clientPoint", getDebugDescription(pointerEvent.clientPoint, options)},
+      {"target", getDebugDescription(pointerEvent.target, options)},
+      {"timestamp", getDebugDescription(pointerEvent.timestamp, options)},
+  };
+}
+
+#endif
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/components/view/PointerEvent.h
+++ b/ReactCommon/react/renderer/components/view/PointerEvent.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
+#include <react/renderer/graphics/Geometry.h>
+
+namespace facebook {
+namespace react {
+
+struct PointerEvent {
+  /*
+   * A unique identifier for the pointer causing the event.
+   */
+  int pointerId;
+  /*
+   * The normalized pressure of the pointer input in the range 0 to 1, where 0
+   * and 1 represent the minimum and maximum pressure the hardware is capable of
+   * detecting, respectively.
+   */
+  Float pressure;
+  /*
+   * Indicates the device type that caused the event (mouse, pen, touch, etc.)
+   */
+  std::string pointerType;
+  /*
+   * Point within the application's viewport at which the event occurred (as
+   * opposed to the coordinate within the page).
+   */
+  Point clientPoint;
+  /*
+   * A reference to the view to which the event was originally dispatched.
+   */
+  Tag target;
+  /*
+   * The time at which the event was created (in milliseconds). By
+   * specification, this value is time since epoch—but in reality, browsers'
+   * definitions vary.
+   */
+  Float timestamp;
+};
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+
+std::string getDebugName(PointerEvent const &pointerEvent);
+std::vector<DebugStringConvertibleObject> getDebugProps(
+    PointerEvent const &pointerEvent,
+    DebugStringConvertibleOptions options);
+
+#endif
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -59,6 +59,20 @@ static jsi::Value touchEventPayload(
   return object;
 }
 
+static jsi::Value pointerEventPayload(
+    jsi::Runtime &runtime,
+    PointerEvent const &event) {
+  auto object = jsi::Object(runtime);
+  object.setProperty(runtime, "pointerId", event.pointerId);
+  object.setProperty(runtime, "pressure", event.pressure);
+  object.setProperty(runtime, "pointerType", event.pointerType);
+  object.setProperty(runtime, "clientX", event.clientPoint.x);
+  object.setProperty(runtime, "clientY", event.clientPoint.y);
+  object.setProperty(runtime, "target", event.target);
+  object.setProperty(runtime, "timestamp", event.timestamp * 1000);
+  return object;
+}
+
 void TouchEventEmitter::dispatchTouchEvent(
     std::string const &type,
     TouchEvent const &event,
@@ -68,6 +82,20 @@ void TouchEventEmitter::dispatchTouchEvent(
       type,
       [event](jsi::Runtime &runtime) {
         return touchEventPayload(runtime, event);
+      },
+      priority,
+      category);
+}
+
+void TouchEventEmitter::dispatchPointerEvent(
+    std::string type,
+    PointerEvent const &event,
+    EventPriority priority,
+    RawEvent::Category category) const {
+  dispatchEvent(
+      std::move(type),
+      [event](jsi::Runtime &runtime) {
+        return pointerEventPayload(runtime, event);
       },
       priority,
       category);
@@ -98,6 +126,36 @@ void TouchEventEmitter::onTouchEnd(TouchEvent const &event) const {
 void TouchEventEmitter::onTouchCancel(TouchEvent const &event) const {
   dispatchTouchEvent(
       "touchCancel",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
+void TouchEventEmitter::onPointerCancel(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerCancel",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
+void TouchEventEmitter::onPointerDown(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerDown",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onPointerMove2(const PointerEvent &event) const {
+  dispatchUniqueEvent("pointerMove2", [event](jsi::Runtime &runtime) {
+    return pointerEventPayload(runtime, event);
+  });
+}
+
+void TouchEventEmitter::onPointerUp(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerUp",
       event,
       EventPriority::AsynchronousBatched,
       RawEvent::Category::ContinuousEnd);

--- a/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/renderer/components/view/PointerEvent.h>
 #include <react/renderer/components/view/TouchEvent.h>
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/LayoutMetrics.h>
@@ -29,10 +30,20 @@ class TouchEventEmitter : public EventEmitter {
   void onTouchEnd(TouchEvent const &event) const;
   void onTouchCancel(TouchEvent const &event) const;
 
+  void onPointerCancel(PointerEvent const &event) const;
+  void onPointerDown(PointerEvent const &event) const;
+  void onPointerMove2(PointerEvent const &event) const;
+  void onPointerUp(PointerEvent const &event) const;
+
  private:
   void dispatchTouchEvent(
       std::string const &type,
       TouchEvent const &event,
+      EventPriority priority,
+      RawEvent::Category category) const;
+  void dispatchPointerEvent(
+      std::string type,
+      PointerEvent const &event,
       EventPriority priority,
       RawEvent::Category category) const;
 };


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/179c24e2551

Emit touch-equivalent W3C pointer events on iOS

## Changelog

Summary: Changelog: [Internal] 
[CATEGORY] [TYPE] - Message

## Test Plan

Builds with Fabric (screenshoot) and w/o (CircleCI)

<img width="1459" alt="image" src="https://user-images.githubusercontent.com/484044/201543748-12a771ef-30ab-424f-8975-1a88b6b1fc95.png">

