### PR TITLE
Cherry-pick: Minor: Move RCTLogNewArchitectureValidation in RCTLegacyViewManagerInteropComponentView

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -109,14 +109,6 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
 + (BOOL)isSupported:(NSString *)componentName
 {
-  RCTLogNewArchitectureValidation(
-      RCTNotAllowedInBridgeless,
-      self,
-      [NSString
-          stringWithFormat:
-              @"Legacy ViewManagers should be migrated to Fabric ComponentViews in the new architecture to reduce risk. Component using interop layer: %@",
-              componentName]);
-
   // Step 1: check if ViewManager with specified name is supported.
   BOOL isComponentNameSupported =
       [[RCTLegacyViewManagerInteropComponentView supportedViewManagers] containsObject:componentName];

--- a/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -110,7 +110,16 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   }
 
   // Fallback 2: Try to use Paper Interop.
-  if ([RCTLegacyViewManagerInteropComponentView isSupported:RCTNSStringFromString(name)]) {
+  NSString *componentNameString = RCTNSStringFromString(name);
+  if ([RCTLegacyViewManagerInteropComponentView isSupported:componentNameString]) {
+    RCTLogNewArchitectureValidation(
+        RCTNotAllowedInBridgeless,
+        self,
+        [NSString
+            stringWithFormat:
+                @"Legacy ViewManagers should be migrated to Fabric ComponentViews in the new architecture to reduce risk. Component using interop layer: %@",
+                componentNameString]);
+
     auto flavor = std::make_shared<std::string const>(name);
     auto componentName = ComponentName{flavor->c_str()};
     auto componentHandle = reinterpret_cast<ComponentHandle>(componentName);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.70 commit into the current main branch:
https://github.com/facebook/react-native/commit/b834d5869fd

## Changelog

Changelog: [Internal][iOS]
## Test Plan
Build rn-tester-iOS with Fabric enabled:


<img width="945" alt="Screen Shot 2022-11-14 at 8 12 12 AM" src="https://user-images.githubusercontent.com/484044/201597532-f27db94b-26c4-4821-877b-822db6e269a8.png">
