### PR TITLE
Cherry-pick: Replace SharedProps with Props::Shared

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -43,7 +43,7 @@ using namespace facebook::react;
   return self;
 }
 
-- (facebook::react::SharedProps)props
+- (facebook::react::Props::Shared)props
 {
   return _props;
 }

--- a/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -114,7 +114,7 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
 /*
  * Read the last props used to update the view.
  */
-- (facebook::react::SharedProps)props;
+- (facebook::react::Props::Shared)props;
 
 - (BOOL)isJSResponder;
 - (void)setIsJSResponder:(BOOL)isJSResponder;

--- a/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/React/Fabric/Mounting/RCTMountingManager.mm
@@ -298,8 +298,8 @@ static void RCTPerformMountInstructions(
   RCTAssertMainQueue();
   UIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag];
   SurfaceId surfaceId = RCTSurfaceIdForView(componentView);
-  SharedProps oldProps = [componentView props];
-  SharedProps newProps = componentDescriptor.cloneProps(
+  Props::Shared oldProps = [componentView props];
+  Props::Shared newProps = componentDescriptor.cloneProps(
       PropsParserContext{surfaceId, *_contextContainer.get()}, oldProps, RawProps(convertIdToFollyDynamic(props)));
 
   NSSet<NSString *> *propKeys = componentView.propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN ?: [NSSet new];

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)prepareForRecycle;
 
-- (facebook::react::SharedProps)props;
+- (facebook::react::Props::Shared)props;
 
 - (void)setIsJSResponder:(BOOL)isJSResponder;
 

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -129,7 +129,7 @@ using namespace facebook::react;
   // Default implementation does nothing.
 }
 
-- (facebook::react::SharedProps)props
+- (facebook::react::Props::Shared)props
 {
   RCTAssert(NO, @"props access should be implemented by RCTViewComponentView.");
   return nullptr;

--- a/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -20,9 +20,9 @@ namespace react {
  */
 static inline void interpolateViewProps(
     Float animationProgress,
-    const SharedProps &oldPropsShared,
-    const SharedProps &newPropsShared,
-    SharedProps &interpolatedPropsShared) {
+    const Props::Shared &oldPropsShared,
+    const Props::Shared &newPropsShared,
+    Props::Shared &interpolatedPropsShared) {
   ViewProps const *oldViewProps =
       static_cast<ViewProps const *>(oldPropsShared.get());
   ViewProps const *newViewProps =

--- a/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -102,20 +102,20 @@ class ComponentDescriptor {
    * will be used.
    * Must return an object which is NOT pointer equal to `props`.
    */
-  virtual SharedProps cloneProps(
+  virtual Props::Shared cloneProps(
       const PropsParserContext &context,
-      const SharedProps &props,
+      const Props::Shared &props,
       const RawProps &rawProps) const = 0;
 
   /*
    * Creates a new `Props` of a particular type with all values interpolated
    * between `props` and `newProps`.
    */
-  virtual SharedProps interpolateProps(
+  virtual Props::Shared interpolateProps(
       const PropsParserContext &context,
       Float animationProgress,
-      const SharedProps &props,
-      const SharedProps &newProps) const = 0;
+      const Props::Shared &props,
+      const Props::Shared &newProps) const = 0;
 
   /*
    * Create an initial State object that represents (and contains) an initial

--- a/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -94,9 +94,9 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     concreteNonConstParentShadowNode->appendChild(childShadowNode);
   }
 
-  virtual SharedProps cloneProps(
+  virtual Props::Shared cloneProps(
       const PropsParserContext &context,
-      const SharedProps &props,
+      const Props::Shared &props,
       const RawProps &rawProps) const override {
     // Optimization:
     // Quite often nodes are constructed with default/empty props: the base
@@ -112,19 +112,19 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     return ShadowNodeT::Props(context, rawProps, props);
   };
 
-  SharedProps interpolateProps(
+  Props::Shared interpolateProps(
       const PropsParserContext &context,
       Float animationProgress,
-      const SharedProps &props,
-      const SharedProps &newProps) const override {
+      const Props::Shared &props,
+      const Props::Shared &newProps) const override {
 #ifdef ANDROID
     // On Android only, the merged props should have the same RawProps as the
     // final props struct
-    SharedProps interpolatedPropsShared =
+    Props::Shared interpolatedPropsShared =
         (newProps != nullptr ? cloneProps(context, newProps, newProps->rawProps)
                              : cloneProps(context, newProps, {}));
 #else
-    SharedProps interpolatedPropsShared = cloneProps(context, newProps, {});
+    Props::Shared interpolatedPropsShared = cloneProps(context, newProps, {});
 #endif
 
     if (ConcreteShadowNode::BaseTraits().check(

--- a/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -72,8 +72,8 @@ class ConcreteShadowNode : public BaseShadowNodeT {
   static SharedConcreteProps Props(
       const PropsParserContext &context,
       RawProps const &rawProps,
-      SharedProps const &baseProps = nullptr) {
-    return std::make_shared<PropsT const>(
+      Props::Shared const &baseProps = nullptr) {
+    return std::make_shared<PropsT>(
         context,
         baseProps ? static_cast<PropsT const &>(*baseProps) : PropsT(),
         rawProps);

--- a/ReactCommon/react/renderer/core/Props.h
+++ b/ReactCommon/react/renderer/core/Props.h
@@ -18,10 +18,6 @@
 namespace facebook {
 namespace react {
 
-class Props;
-
-using SharedProps = std::shared_ptr<Props const>;
-
 /*
  * Represents the most generic props object.
  */

--- a/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -36,7 +36,7 @@ SharedShadowNodeSharedList ShadowNode::emptySharedShadowNodeSharedList() {
  * Background Executor and should be removed once reimplementation of JNI layer
  * is finished.
  */
-SharedProps ShadowNode::propsForClonedShadowNode(
+Props::Shared ShadowNode::propsForClonedShadowNode(
     ShadowNode const &sourceShadowNode,
     Props::Shared const &props) {
 #ifdef ANDROID
@@ -139,7 +139,7 @@ ShadowNodeTraits ShadowNode::getTraits() const {
   return traits_;
 }
 
-const SharedProps &ShadowNode::getProps() const {
+const Props::Shared &ShadowNode::getProps() const {
   return props_;
 }
 

--- a/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/ReactCommon/react/renderer/core/ShadowNode.h
@@ -127,8 +127,8 @@ class ShadowNode : public Sealable, public DebugStringConvertible {
    */
   ShadowNodeTraits getTraits() const;
 
-  SharedProps const &getProps() const;
-  SharedShadowNodeList const &getChildren() const;
+  Props::Shared const &getProps() const;
+  ListOfShared const &getChildren() const;
   SharedEventEmitter const &getEventEmitter() const;
   Tag getTag() const;
   SurfaceId getSurfaceId() const;
@@ -195,8 +195,8 @@ class ShadowNode : public Sealable, public DebugStringConvertible {
 #endif
 
  protected:
-  SharedProps props_;
-  SharedShadowNodeSharedList children_;
+  Props::Shared props_;
+  SharedListOfShared children_;
   State::Shared state_;
   int orderIndex_;
 
@@ -216,7 +216,7 @@ class ShadowNode : public Sealable, public DebugStringConvertible {
 
   mutable std::atomic<bool> hasBeenMounted_{false};
 
-  static SharedProps propsForClonedShadowNode(
+  static Props::Shared propsForClonedShadowNode(
       ShadowNode const &sourceShadowNode,
       Props::Shared const &props);
 

--- a/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
+++ b/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
@@ -27,7 +27,7 @@ TEST(ComponentDescriptorTest, createShadowNode) {
   PropsParserContext parserContext{-1, contextContainer};
 
   const auto &raw = RawProps(folly::dynamic::object("nativeID", "abc"));
-  SharedProps props = descriptor->cloneProps(parserContext, nullptr, raw);
+  Props::Shared props = descriptor->cloneProps(parserContext, nullptr, raw);
 
   auto family = descriptor->createFamily(
       ShadowNodeFamilyFragment{
@@ -61,7 +61,7 @@ TEST(ComponentDescriptorTest, cloneShadowNode) {
   PropsParserContext parserContext{-1, contextContainer};
 
   const auto &raw = RawProps(folly::dynamic::object("nativeID", "abc"));
-  SharedProps props = descriptor->cloneProps(parserContext, nullptr, raw);
+  Props::Shared props = descriptor->cloneProps(parserContext, nullptr, raw);
   auto family = descriptor->createFamily(
       ShadowNodeFamilyFragment{
           /* .tag = */ 9,
@@ -96,7 +96,7 @@ TEST(ComponentDescriptorTest, appendChild) {
   PropsParserContext parserContext{-1, contextContainer};
 
   const auto &raw = RawProps(folly::dynamic::object("nativeID", "abc"));
-  SharedProps props = descriptor->cloneProps(parserContext, nullptr, raw);
+  Props::Shared props = descriptor->cloneProps(parserContext, nullptr, raw);
   auto family1 = descriptor->createFamily(
       ShadowNodeFamilyFragment{
           /* .tag = */ 1,

--- a/ReactCommon/react/renderer/mounting/StubView.h
+++ b/ReactCommon/react/renderer/mounting/StubView.h
@@ -35,7 +35,7 @@ class StubView final {
   ComponentHandle componentHandle;
   SurfaceId surfaceId;
   Tag tag;
-  SharedProps props;
+  Props::Shared props;
   SharedEventEmitter eventEmitter;
   LayoutMetrics layoutMetrics;
   State::Shared state;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.70 commit into the current main branch:
https://github.com/facebook/react-native/commit/a42170e0f8d

Similarly to https://github.com/facebook/react-native/commit/13a0556aaa3976245ec065b0da68ef865bd03b70, standardize on one type to refer to this.

## Changelog
Changelog: [Internal]

## Test Plan
CircleCI
