### PR TITLE
Cherry-pick: Refactor: Migrate Logbox surface initialization to Fabric when available, in Bridge and Bridgeless modes

### DIFF
--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -6,7 +6,6 @@
  */
 
 #import "RCTSurfaceHostingView.h"
-
 #import "RCTConstants.h"
 #import "RCTDefines.h"
 #import "RCTSurface.h"

--- a/React/CoreModules/RCTLogBoxView.h
+++ b/React/CoreModules/RCTLogBoxView.h
@@ -6,6 +6,7 @@
  */
 
 #import <React/RCTBridge.h>
+#import <React/RCTSurfacePresenterStub.h>
 #import <React/RCTSurfaceView.h>
 #import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
@@ -17,6 +18,8 @@
 
 - (void)createRootViewController:(UIView *)view;
 
+- (instancetype)initWithFrame:(CGRect)frame surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter;
+
 - (instancetype)initWithWindow:(UIWindow *)window bridge:(RCTBridge *)bridge;
 
 - (void)show;
@@ -26,6 +29,8 @@
 #else // [TODO(macOS GH#774)
 
 @interface RCTLogBoxView : NSWindow // TODO(macOS GH#774)
+
+- (instancetype)initWithSurfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter;
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 

--- a/React/CoreModules/RCTLogBoxView.mm
+++ b/React/CoreModules/RCTLogBoxView.mm
@@ -9,6 +9,7 @@
 
 #import <React/RCTLog.h>
 #import <React/RCTSurface.h>
+#import <React/RCTSurfaceHostingView.h>
 
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
 
@@ -32,6 +33,21 @@
   _rootViewController.view.backgroundColor = [UIColor clearColor];
   _rootViewController.modalPresentationStyle = UIModalPresentationFullScreen;
   self.rootViewController = _rootViewController;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
+{
+  if (self = [super initWithFrame:frame]) {
+    id<RCTSurfaceProtocol> surface = [surfacePresenter createFabricSurfaceForModuleName:@"LogBox"
+                                                                      initialProperties:@{}];
+    [surface start];
+    RCTSurfaceHostingView *rootView = [[RCTSurfaceHostingView alloc]
+        initWithSurface:surface
+        sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];
+
+    [self createRootViewController:rootView];
+  }
+  return self;
 }
 
 - (instancetype)initWithWindow:(UIWindow *)window bridge:(RCTBridge *)bridge
@@ -79,6 +95,26 @@
 
 @implementation RCTLogBoxView {
   RCTSurface *_surface;
+}
+
+- (instancetype)initWithSurfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
+{
+  NSRect bounds = NSMakeRect(0, 0, 600, 800);
+  if ((self = [self initWithContentRect:bounds
+                                styleMask:NSWindowStyleMaskTitled
+                                  backing:NSBackingStoreBuffered
+                                    defer:YES])) {
+    id<RCTSurfaceProtocol> surface = [surfacePresenter createFabricSurfaceForModuleName:@"LogBox"
+                                                                        initialProperties:@{}];
+    [surface start];
+    RCTSurfaceHostingView *rootView = [[RCTSurfaceHostingView alloc]
+        initWithSurface:surface
+        sizeMeasureMode:RCTSurfaceSizeMeasureModeWidthExact | RCTSurfaceSizeMeasureModeHeightExact];    
+      
+    self.contentView = rootView;
+    self.contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  }
+  return self;
 }
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge

--- a/React/Fabric/RCTSurfacePresenter.h
+++ b/React/Fabric/RCTSurfacePresenter.h
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) RCTMountingManager *mountingManager;
 @property (readonly, nullable) RCTScheduler *scheduler;
 
+/*
+ * Allow callers to initialize a new fabric surface without adding Fabric as a Buck dependency.
+ */
+- (id<RCTSurfaceProtocol>)createFabricSurfaceForModuleName:(NSString *)moduleName
+                                         initialProperties:(NSDictionary *)initialProperties;
+
 - (nullable RCTFabricSurface *)surfaceForRootTag:(ReactTag)rootTag;
 
 - (BOOL)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag props:(NSDictionary *)props;

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -163,6 +163,14 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   return [_surfaceRegistry surfaceForRootTag:rootTag];
 }
 
+- (id<RCTSurfaceProtocol>)createFabricSurfaceForModuleName:(NSString *)moduleName
+                                         initialProperties:(NSDictionary *)initialProperties
+{
+  return [[RCTFabricSurface alloc] initWithSurfacePresenter:self
+                                                 moduleName:moduleName
+                                          initialProperties:initialProperties];
+}
+
 - (UIView *)findComponentViewWithTag_DO_NOT_USE_DEPRECATED:(NSInteger)tag
 {
   UIView<RCTComponentViewProtocol> *componentView =

--- a/React/Modules/RCTSurfacePresenterStub.h
+++ b/React/Modules/RCTSurfacePresenterStub.h
@@ -10,6 +10,8 @@
 #import <React/RCTBridge.h>
 #import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
+@protocol RCTSurfaceProtocol;
+
 NS_ASSUME_NONNULL_BEGIN
 
 // TODO: Eventually this should go away and files should just include RCTSurfacePresenter.h, but
@@ -27,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol RCTSurfacePresenterStub <NSObject>
 
+- (id<RCTSurfaceProtocol>)createFabricSurfaceForModuleName:(NSString *)moduleName
+                                         initialProperties:(NSDictionary *)initialProperties;
 - (nullable RCTPlatformView *)findComponentViewWithTag_DO_NOT_USE_DEPRECATED:(NSInteger)tag; // TODO(macOS GH#774)
 - (BOOL)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag props:(NSDictionary *)props;
 - (void)addObserver:(id<RCTSurfacePresenterObserver>)observer;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/37e5fa3a6ce2445b17d56dd6fd22fbda926537ef

#### Why
This diff main purpose is to add `RCTErrorNewArchitectureValidation(RCTNotAllowedInAppWideFabric)` in `RCTSurface`, to ensure Paper surfaces are never created in FBiOS.

#### The Situation
Before this diff, in Bridged Fabric, `[RCTLogbox show]` initializes a Paper `RCTSurface`, [using `[RCTLogBoxView initWithWindow]`](https://github.com/facebook/react-native/blob/main/React/CoreModules/RCTLogBoxView.mm#L46))
In this diff,  in Bridged and Bridgeless Fabric, `[RCTLogbox show]` initializes a Fabric `RCTFabricSurface`.

Before this diff, in Bridgeless Fabric,  RCTLogBox posts a "CreateLogBoxSurface" notification to RCTInstance.
In this diff, the notification hack is replaced by the same `RCTFabricSurface` initialization above.
Behavior is the same.

## Changelog

Changelog: [iOS][Internal] Refactor: Migrate Logbox surface initialization to Fabric when available, in Bridge and Bridgeless modes

## Test Plan

LogBox in rn-tester-iOS (no Fabric)

https://user-images.githubusercontent.com/484044/201625046-1472d903-6189-4e79-b028-84aa18acac78.mov

LogBox in rn-tester-macOS (no Fabric)

https://user-images.githubusercontent.com/484044/201625760-7cfcf82b-adda-44d9-94ec-f72b3e677c95.mov

LogBox in rn-tester-iOS (Fabric)

https://user-images.githubusercontent.com/484044/201626782-bea11e1f-2f20-4005-ba43-b18a2eb88cdf.mov



