### PR TITLE
Cherry-pick: Adding missing #import <QuartzCore/QuartzCore.h> imports (#35315)

### DIFF
--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -9,8 +9,6 @@
 
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
 #import <MobileCoreServices/UTCoreTypes.h>
-#else
-#import <Quartz/Quartz.h> // TODO(macOS GH#774) for CATiledLayer
 #endif // TODO(macOS GH#774)
 
 #import <React/RCTAssert.h> // TODO(macOS GH#774)
@@ -20,7 +18,7 @@
 
 #import <React/RCTTextShadowView.h>
 
-#import <QuartzCore/QuartzCore.h> // TODO(macOS GH#774)
+#import <QuartzCore/QuartzCore.h>
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
 

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -8,6 +8,7 @@
 #import "RCTViewComponentView.h"
 
 #import <CoreGraphics/CoreGraphics.h>
+#import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
 
 #import <React/RCTAssert.h>

--- a/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/React/Fabric/Mounting/RCTMountingManager.mm
@@ -7,6 +7,7 @@
 
 #import "RCTMountingManager.h"
 
+#import <QuartzCore/QuartzCore.h>
 #import <butter/map.h>
 
 #import <React/RCTAssert.h>

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -7,7 +7,7 @@
 
 #import "RCTView.h"
 
-#import <QuartzCore/QuartzCore.h> // TODO(macOS GH#774) - import needed on macOS to prevent compiler error on invocation of CAShapeLayer further down
+#import <QuartzCore/QuartzCore.h>
 
 #import "RCTAutoInsetsProtocol.h"
 #import "RCTBorderDrawing.h"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
A cherry-pick from facebook/react-native@0.72:
https://github.com/facebook/react-native/commit/c0f06e8bbac4a962a01ec093b74275415302268f

These headers are needed on react-native-macOS, but not explicitly imported all the time.

It seems that some UIKit header will implicitly import them.

We have other use case in react-native(-iOS) in which we also explicitly importing them - https://github.com/facebook/react-native/search?q=QuartzCore- , hence use following 'that' practice 'here'.


## Changelog

Changelog: [Internal]

## Test Plan

Run rn-tester-macOS:
<img width="669" alt="Screen Shot 2022-11-14 at 4 06 05 PM" src="https://user-images.githubusercontent.com/484044/201694213-e24cfb8b-32c0-49ae-baa1-dbf647a530f6.png">
