### PR TITLE
Cherry-pick: BUCK: define GLOG_NO_ABBREVIATED_SEVERITIES everywhere

### DIFF
--- a/ReactCommon/react/debug/react_native_assert.h
+++ b/ReactCommon/react/debug/react_native_assert.h
@@ -55,7 +55,7 @@ void react_native_assert_fail(
 #define react_native_assert(cond)                           \
   if (!(cond)) {                                            \
     LOG(ERROR) << "react_native_assert failure: " << #cond; \
-    google::FlushLogFiles(google::INFO);                    \
+    google::FlushLogFiles(google::GLOG_INFO);               \
     assert(cond);                                           \
   }
 

--- a/ReactCommon/react/renderer/mounting/StubViewTree.cpp
+++ b/ReactCommon/react/renderer/mounting/StubViewTree.cpp
@@ -250,7 +250,7 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
 
   // For iOS especially: flush logs because some might be lost on iOS if an
   // assert is hit right after this.
-  google::FlushLogFiles(google::INFO);
+  google::FlushLogFiles(google::GLOG_INFO);
 }
 
 bool operator==(StubViewTree const &lhs, StubViewTree const &rhs) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/facebook/react-native/commit/ece1dd4ed9b6b3cbf367f9b3d0380db6349e588e

This is only defined on Windows, and thus code that compiles on all platforms may successfully build on Linux/macOS, but not on Windows, making it potentially harder to detect and debug. Let's unify all platforms to solve this.

## Changelog

Changelog: [Internal]

## Test Plan

Build rn-tester-iOS with Fabric enabled

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/484044/201705199-b7a97186-8574-43fe-82c2-9e87da1479dc.png">
