### PR TITLE
Remove faulty logic in ScrollView

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -339,21 +339,6 @@
 #endif // TODO(macOS GH#774)
 
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
-- (BOOL)canBecomeFirstResponder
-{
-	return YES;
-}
-
-- (BOOL)becomeFirstResponder
-{
-	return YES;
-}
-
-- (BOOL)resignFirstResponder
-{
-	return YES;
-}
-
 - (void)setAccessibilityLabel:(NSString *)accessibilityLabel
 {
   [super setAccessibilityLabel:accessibilityLabel];
@@ -536,21 +521,6 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 - (RCTUIView *)contentView // TODO(macOS ISS#3536887)
 {
   return _scrollView.documentView;
-}
-
-- (BOOL)canBecomeFirstResponder
-{
-  return [_scrollView canBecomeFirstResponder];
-}
-
-- (BOOL)becomeFirstResponder
-{
-  return [_scrollView becomeFirstResponder];
-}
-
-- (BOOL)resignFirstResponder
-{
-  return [_scrollView resignFirstResponder];
 }
 
 - (void)setAccessibilityLabel:(NSString *)accessibilityLabel


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

RCTScrollView forwards some of its methods to its underlying `_scrollView` of type RCTCustomScrollView. Some of these always return YES, instead of properly implementing the logic. Let's remove the faulty forwarding, so that instead inherited superclass implementation (RCTView) is used. 

## Background

Normally, you expect a 1:1 mapping between the JS and native component (e.g: `<View>` maps to `RCTView`). There are notable exceptions, like `<ScrollView>`.

`<ScrollView>`maps to `RCTScrollView` which is a subclass of `RCTView`, not `UIScrollView / NSScrollView`. So how does `RCTScrollView` do its scrolling logic if the underlying component is just a subclass of `RCTView`? It turns out,`RCTScrollView` contains a member variable `_scrollView` (the _real_ NSScrollView / UIScrollView). It then forwards appropriate methods / variables to the underlying "real" `_scrollView`.


_(Side note): That's a little simplified. The real inheritance / ownership relationship looks like:_
```
RCTScrollView **has-a** RCTCustomScrollView 
RCTCustomScrollView **is-a** RCTUIScrollView 
RCTUIScrollView  **is-a** UIScrollView (iOS) / NSScrollView (macOS)
```

The issue is that in the case of accepting/forwarding first responder status, this didn't work. RCTScrollView would forward the calls to `canBecomeFirstResponder / becomeFirstResponder / resignFirstResponder` to it's underlying `_scrollView`, which were overridden to always YES. This is bad because:

1) The `_scrollView` always accepted first responder status, even when its outer RCTScrollView didn't want it (e.g: `focusable={false}`). This blocked https://github.com/microsoft/fluentui-react-native/pull/2329 , because the `_scrollView` would receive focus even when JS told it to not to.

2) Even though RCTScrollView forwards the call to `becomeFirstResponder` to its `_scrollView`, that didn't actually cause `_scrollView` to become first responder. It would just return `YES`, and Appkit would proceed with making the outer RCTScrollView first responder anyway.  

I see an issue that `_scrollView` never actually becomes first responder, but instead an `NSView` wrapping it does. However, It think that's a much bigger fix and, the outer view managing first responder status has worked in production for a while.  Let's just remove the faulty logic implying the inner `_scrollView` does get first responder status for now. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Fixed] - Don't override responder methods in ScrollView

## Test Plan

I tested the ScrollViewSimpleExample, ScrollView, and Flatlist test pages to make sure that the key view loop was the same and that you could still tab to a ScrollView and scroll it with PageUp/Down.

Video of Flatlist test page:

https://user-images.githubusercontent.com/6722175/201998272-ad0640a5-676d-4e6f-899c-7b1fe3097091.mov



