### PR TITLE
Cherry-pick: Update iOS LogBox to render its UIWindow with the key window's UIWindowScene

### DIFF
--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -52,8 +52,7 @@ RCT_EXPORT_METHOD(show)
       if (strongSelf->_bridge) {
         if (strongSelf->_bridge.valid) {
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
-          strongSelf->_view = [[RCTLogBoxView alloc] initWithFrame:RCTKeyWindow().frame bridge:strongSelf->_bridge];
-
+          strongSelf->_view = [[RCTLogBoxView alloc] initWithWindow:RCTKeyWindow() bridge:strongSelf->_bridge];
 #else // [TODO(macOS GH#774)
           strongSelf->_view = [[RCTLogBoxView alloc] initWithBridge:self->_bridge]; // TODO(macOS GH#774)
 #endif // ]TODO(macOS GH#774)

--- a/React/CoreModules/RCTLogBoxView.h
+++ b/React/CoreModules/RCTLogBoxView.h
@@ -17,7 +17,7 @@
 
 - (void)createRootViewController:(UIView *)view;
 
-- (instancetype)initWithFrame:(CGRect)frame bridge:(RCTBridge *)bridge;
+- (instancetype)initWithWindow:(UIWindow *)window bridge:(RCTBridge *)bridge;
 
 - (void)show;
 

--- a/React/CoreModules/RCTLogBoxView.mm
+++ b/React/CoreModules/RCTLogBoxView.mm
@@ -34,22 +34,25 @@
   self.rootViewController = _rootViewController;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame bridge:(RCTBridge *)bridge
+- (instancetype)initWithWindow:(UIWindow *)window bridge:(RCTBridge *)bridge
 {
-  if ((self = [super initWithFrame:frame])) {
-    self.windowLevel = UIWindowLevelStatusBar - 1;
-    self.backgroundColor = [UIColor clearColor];
-
-    _surface = [[RCTSurface alloc] initWithBridge:bridge moduleName:@"LogBox" initialProperties:@{}];
-    [_surface setSize:frame.size];
-    [_surface start];
-
-    if (![_surface synchronouslyWaitForStage:RCTSurfaceStageSurfaceDidInitialMounting timeout:1]) {
-      RCTLogInfo(@"Failed to mount LogBox within 1s");
-    }
-
-    [self createRootViewController:(UIView *)_surface.view];
+  if (@available(iOS 13.0, *)) {
+    self = [super initWithWindowScene:window.windowScene];
+  } else {
+    self = [super initWithFrame:window.frame];
   }
+
+  self.windowLevel = UIWindowLevelStatusBar - 1;
+  self.backgroundColor = [UIColor clearColor];
+
+  _surface = [[RCTSurface alloc] initWithBridge:bridge moduleName:@"LogBox" initialProperties:@{}];
+  [_surface start];
+
+  if (![_surface synchronouslyWaitForStage:RCTSurfaceStageSurfaceDidInitialMounting timeout:1]) {
+    RCTLogInfo(@"Failed to mount LogBox within 1s");
+  }
+  [self createRootViewController:(UIView *)_surface.view];
+
   return self;
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Cherry-pick a react-native@0.69 commit into the current main branch:
https://github.com/microsoft/react-native-macos/commit/55c4a7f2dd2a03ebbb6d84a93815210ee2699501

If an RN app is embedded in a Mac Catalyst app that uses the UIWindowScene API to manage multiple windows, LogBox would fail to render because it didn't know which UIWindowScene to render to. This diff fixes that situation by ensuring that the LogBox window gets rendered in the key window's scene.

## Changelog

[iOS][Fixed] - Update iOS LogBox to render its UIWindow with the key window's UIWindowScene

## Test Plan

Open LogBox on rn-tester w/o Fabric enabled


https://user-images.githubusercontent.com/484044/202144881-4fa97eff-2111-4b5a-9194-69165eafd455.mov

