### PR TITLE
Remove deprecated prop-types reference for Text

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -182,12 +182,6 @@ const Text: React.AbstractComponent<
 Text.displayName = 'Text';
 
 /**
- * Switch to `deprecated-react-native-prop-types` for compatibility with future
- * releases. This is deprecated and will be removed in the future.
- */
-Text.propTypes = require('deprecated-react-native-prop-types').TextPropTypes;
-
-/**
  * Returns false until the first time `newValue` is true, after which this will
  * always return true. This is necessary to lazily initialize `Pressability` so
  * we do not eagerly create one for every pressable `Text` component.


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The PropTypes package is deprecated on RN Core.
To help folks get off of the package, this deprecation path was left in place.

Removing the reference fixes #1433 

NOTE: This was recently un-deprecated by the core team to allow more time for folks to migrate: https://github.com/facebook/react-native/commit/b966d297245a4c1e2c744cfe571396cfa7e5ffd3
I'm assuming desktop doesn't have the same legacy issues so I think it's fine to remove.

## Changelog

[macOS] [Fix] - Remove reference to deprecated package in TextView

## Test Plan

### Before

https://user-images.githubusercontent.com/96719/202828000-c3b32a27-25b3-4397-acea-1bcbc1538df2.mp4

### After

https://user-images.githubusercontent.com/96719/202828373-943d5b15-8311-41c9-b275-ff47cd517697.mp4

