### PR TITLE
[Fabric] Replace UIKit with RCTUIKit shim

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ActivityIndicator/RCTActivityIndicatorViewComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.h
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 @interface RCTInputAccessoryContentView : UIView
 

--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.h
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 @protocol RCTFabricModalHostViewControllerDelegate <NSObject>
 - (void)boundsDidChange:(CGRect)newBounds;

--- a/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Root/RCTRootComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTGenericDelegateSplitter.h>
 #import <React/RCTViewComponentView.h>

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTDefines.h>
 #import <React/RCTGenericDelegateSplitter.h>

--- a/React/Fabric/Mounting/ComponentViews/Slider/RCTSliderComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Slider/RCTSliderComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.h
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.h
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <react/renderer/attributedstring/AttributedString.h>
 #import <react/renderer/attributedstring/ParagraphAttributes.h>

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <optional>
 

--- a/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/UnimplementedComponent/RCTUnimplementedNativeComponentView.h
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
+#import "React/RCTUITextView.h"
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/UnimplementedView/RCTUnimplementedViewComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTViewComponentView.h>
 

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTComponentViewProtocol.h>
 #import <React/RCTConstants.h>

--- a/React/Fabric/Mounting/RCTComponentViewClassDescriptor.h
+++ b/React/Fabric/Mounting/RCTComponentViewClassDescriptor.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTComponentViewProtocol.h>
 

--- a/React/Fabric/Mounting/RCTComponentViewDescriptor.h
+++ b/React/Fabric/Mounting/RCTComponentViewDescriptor.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTComponentViewProtocol.h>
 

--- a/React/Fabric/Mounting/RCTComponentViewFactory.h
+++ b/React/Fabric/Mounting/RCTComponentViewFactory.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTComponentViewDescriptor.h>
 #import <React/RCTComponentViewProtocol.h>

--- a/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 #import <react/renderer/core/EventEmitter.h>

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.h
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTComponentViewDescriptor.h>
 #import <React/RCTComponentViewFactory.h>

--- a/React/Fabric/Mounting/RCTMountingManager.h
+++ b/React/Fabric/Mounting/RCTMountingManager.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTMountingManagerDelegate.h>
 #import <React/RCTPrimitives.h>

--- a/React/Fabric/Mounting/RCTMountingManagerDelegate.h
+++ b/React/Fabric/Mounting/RCTMountingManagerDelegate.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTPrimitives.h>
 

--- a/React/Fabric/Mounting/RCTMountingTransactionObserving.h
+++ b/React/Fabric/Mounting/RCTMountingTransactionObserving.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #include <react/renderer/mounting/MountingTransaction.h>
 

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTComponentViewProtocol.h>
 

--- a/React/Fabric/RCTConversions.h
+++ b/React/Fabric/RCTConversions.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <react/renderer/components/view/AccessibilityPrimitives.h>
 #import <react/renderer/components/view/primitives.h>

--- a/React/Fabric/RCTImageResponseDelegate.h
+++ b/React/Fabric/RCTImageResponseDelegate.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/React/Fabric/RCTLocalizationProvider.h
+++ b/React/Fabric/RCTLocalizationProvider.h
@@ -6,7 +6,7 @@
  */
 
 #import <React/RCTDefines.h>
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 @protocol RCTLocalizationProtocol <NSObject>
 

--- a/React/Fabric/RCTScheduler.h
+++ b/React/Fabric/RCTScheduler.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 #import <memory>
 
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>

--- a/React/Fabric/RCTSurfacePresenter.h
+++ b/React/Fabric/RCTSurfacePresenter.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTPrimitives.h>
 #import <React/RCTSurfacePresenterStub.h>

--- a/React/Fabric/RCTSurfacePresenterBridgeAdapter.h
+++ b/React/Fabric/RCTSurfacePresenterBridgeAdapter.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import <ReactCommon/RuntimeExecutor.h>
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 #import <react/utils/ContextContainer.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/React/Fabric/RCTSurfaceRegistry.h
+++ b/React/Fabric/RCTSurfaceRegistry.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTPrimitives.h>
 

--- a/React/Fabric/RCTSurfaceTouchHandler.h
+++ b/React/Fabric/RCTSurfaceTouchHandler.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/React/Fabric/RCTTouchableComponentViewProtocol.h
+++ b/React/Fabric/RCTTouchableComponentViewProtocol.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 #import <react/renderer/components/view/TouchEventEmitter.h>
 
 @protocol RCTTouchableComponentViewProtocol <NSObject>

--- a/React/Fabric/Utils/RCTGenericDelegateSplitter.h
+++ b/React/Fabric/Utils/RCTGenericDelegateSplitter.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/React/Views/RCTMaskedView.h
+++ b/React/Views/RCTMaskedView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTView.h>
 

--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTInvalidating.h>
 #import <React/RCTModalHostViewManager.h>

--- a/React/Views/RCTModalHostViewController.h
+++ b/React/Views/RCTModalHostViewController.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 @interface RCTModalHostViewController : UIViewController
 

--- a/React/Views/RCTModalManager.h
+++ b/React/Views/RCTModalManager.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>

--- a/React/Views/RCTWrapperViewController.h
+++ b/React/Views/RCTWrapperViewController.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 @class RCTWrapperViewController;
 

--- a/React/Views/RefreshControl/RCTRefreshControl.h
+++ b/React/Views/RefreshControl/RCTRefreshControl.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTComponent.h>
 #import <React/RCTScrollableProtocol.h>

--- a/React/Views/RefreshControl/RCTRefreshableProtocol.h
+++ b/React/Views/RefreshControl/RCTRefreshableProtocol.h
@@ -6,7 +6,7 @@
  */
 
 #import <React/RCTComponent.h>
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 /**
  * Protocol used to dispatch commands in `RCTRefreshControlManager.h`.

--- a/React/Views/SafeAreaView/RCTSafeAreaView.h
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTView.h>
 

--- a/React/Views/SafeAreaView/RCTSafeAreaViewLocalData.h
+++ b/React/Views/SafeAreaView/RCTSafeAreaViewLocalData.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
+++ b/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
@@ -6,7 +6,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 #include <folly/dynamic.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
+++ b/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTUtils.h>
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #include <string>
 

--- a/ReactCommon/react/renderer/imagemanager/platform/ios/RCTImageManager.h
+++ b/ReactCommon/react/renderer/imagemanager/platform/ios/RCTImageManager.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <RCTImageManagerProtocol.h>
 

--- a/ReactCommon/react/renderer/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
+++ b/ReactCommon/react/renderer/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <React/RCTImageLoader.h>
 #import <react/renderer/imagemanager/primitives.h>

--- a/ReactCommon/react/renderer/imagemanager/platform/ios/RCTSyncImageManager.h
+++ b/ReactCommon/react/renderer/imagemanager/platform/ios/RCTSyncImageManager.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <RCTImageManagerProtocol.h>
 

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/NSTextStorage+FontScaling.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/NSTextStorage+FontScaling.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 @interface NSTextStorage (FontScaling)
 

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/AttributedStringBox.h>

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTFontProperties.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTFontProperties.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTFontUtils.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTFontUtils.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <react/renderer/textlayoutmanager/RCTFontProperties.h>
 

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import <react/renderer/attributedstring/AttributedString.h>
 #import <react/renderer/attributedstring/ParagraphAttributes.h>

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextPrimitivesConversions.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextPrimitivesConversions.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #include <react/renderer/textlayoutmanager/RCTFontProperties.h>
 #include <react/renderer/textlayoutmanager/RCTFontUtils.h>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:

Replacing references of UIKit to RCTUIKit shim

## Changelog

[macOS][Fabric] - Replacing references of UIKit to RCTUIKit shim

## Test Plan

Fabric build errors on main: 
[Build RNTester-macOS_2022-11-22T14-56-31.txt](https://github.com/microsoft/react-native-macos/files/10071838/Build.RNTester-macOS_2022-11-22T14-56-31.txt)

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no UIKit errors
![CleanShot 2022-11-22 at 15 07 52](https://user-images.githubusercontent.com/96719/203441799-06f2d839-b3fb-4120-9d35-00021da7fd2d.jpg)
[Build RNTester-macOS_2022-11-22T14-46-02.txt](https://github.com/microsoft/react-native-macos/files/10071840/Build.RNTester-macOS_2022-11-22T14-46-02.txt)

[x] Build RNTester - iOS w/ Fabric - should work

https://user-images.githubusercontent.com/96719/203441815-fcfd4523-e534-495a-b5ff-39f0055e9205.mp4

[x] Build RNTester-macOS w/ Paper - should work

https://user-images.githubusercontent.com/96719/203442564-c5d0df70-d00c-41a3-b3ed-f629c43aafee.mp4

[x] Build RNTester - iOS w/ Paper - should work

https://user-images.githubusercontent.com/96719/203442929-255de707-b4c1-46c4-b511-a9d006c88643.mp4