### PR TITLE
[Fabric] Enable NewArchitectureExample Fabric example in RNTester iOS

### DIFF
--- a/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
+++ b/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.description     = "my-native-view"
   s.homepage        = "https://github.com/sota000/my-native-view.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "11.0", :tvos => "11.0" }
+  s.platforms       = { :ios => "11.0", :osx => "10.15" } # TODO(macOS GH#774)
   s.compiler_flags  = folly_compiler_flags + ' ' + boost_compiler_flags + ' -Wno-nullability-completeness'
   s.author          = "Facebook, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/my-native-view.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -30,15 +30,13 @@ export default function MyNativeView(props: {}): React.Node {
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
   // [macOS Use this "hack" to only render this example if Fabric is enabled and allow CI to pass
-  const [isFabric, setFabric] = useState(false);
-  const onLayout = React.useCallback(
-    ev => {
-      setFabric(
-        Boolean(ev.currentTarget._internalInstanceHandle?.stateNode?.canonical),
-      );
-    },
-    [setFabric],
-  );
+  // Fabric Detection
+  const isFabric =
+    !!(
+      // An internal transform mangles variables with leading "_" as private.
+      // $FlowFixMe
+      ref._internalInstanceHandle?.stateNode?.canonical
+    );
   if (isFabric) {
     return null;
   }
@@ -46,7 +44,7 @@ export default function MyNativeView(props: {}): React.Node {
 
   // [macOS
   return (
-    <View onLayout={onLayout} style={{flex: 1}}>
+    <View style={{flex: 1}}>
       {isFabric && (
         <>
           <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -29,34 +29,55 @@ const colors = [
 export default function MyNativeView(props: {}): React.Node {
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
+  // [macOS Use this "hack" to only render this example if Fabric is enabled and allow CI to pass
+  const [isFabric, setFabric] = useState(false);
+  const onLayout = React.useCallback(
+    ev => {
+      setFabric(
+        Boolean(ev.currentTarget._internalInstanceHandle?.stateNode?.canonical),
+      );
+    },
+    [setFabric],
+  );
+  if (isFabric) {
+    return null;
+  }
+  // macOS]
+
+  // [macOS
   return (
-    <View style={{flex: 1}}>
-      <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />
-      <Button
-        title="Change Background"
-        onPress={() => {
-          if (ref.current) {
-            RNTMyNativeViewCommands.callNativeMethodToChangeBackgroundColor(
-              ref.current,
-              colors[Math.floor(Math.random() * 5)],
-            );
-          }
-        }}
-      />
-      <Button
-        title="Set Opacity"
-        onPress={() => {
-          setOpacity(Math.random());
-        }}
-      />
-      <Button
-        title="Console.log Measure"
-        onPress={() => {
-          ref.current?.measure((x, y, width, height) => {
-            console.log(x, y, width, height);
-          });
-        }}
-      />
+    <View onLayout={onLayout} style={{flex: 1}}>
+      {isFabric && (
+        <>
+          <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />
+          <Button
+            title="Change Background"
+            onPress={() => {
+              if (ref.current) {
+                RNTMyNativeViewCommands.callNativeMethodToChangeBackgroundColor(
+                  ref.current,
+                  colors[Math.floor(Math.random() * 5)],
+                );
+              }
+            }}
+          />
+          <Button
+            title="Set Opacity"
+            onPress={() => {
+              setOpacity(Math.random());
+            }}
+          />
+          <Button
+            title="Console.log Measure"
+            onPress={() => {
+              ref.current?.measure((x, y, width, height) => {
+                console.log(x, y, width, height);
+              });
+            }}
+          />
+        </>
+      )}
     </View>
+    // macOS]
   );
 }

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -41,12 +41,10 @@ def pods(options = {})
 
   prefix_path = "../.."
 
-  # [macOS don't enable Fabric on RNTester by default until it works on macOS
-  # if ENV['USE_CODEGEN_DISCOVERY'] == '1'
-  #   # Custom fabric component is only supported when using codegen discovery.
-  #   pod 'MyNativeView', :path => "NativeComponentExample"
-  # end
-  # macOS]
+  if ENV['USE_CODEGEN_DISCOVERY'] == '1'
+    # Custom fabric component is only supported when using codegen discovery.
+    pod 'MyNativeView', :path => "NativeComponentExample"
+  end
 
   use_react_native!(
     path: prefix_path,

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -190,14 +190,12 @@ const Components: Array<RNTesterModuleInfo> = [
     category: 'Basic',
     supportsTVOS: true,
   },
-  /* [macOS NewArchitectureExample depends on Fabric, which we don't have on macOS yet
   {
     key: 'NewArchitectureExample',
     category: 'UI',
     module: require('../examples/NewArchitecture/NewArchitectureExample'),
     supportsTVOS: false,
   },
-  macOS] */
 ];
 
 const APIs: Array<RNTesterModuleInfo> = [


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

While we are implementing Fabric for macOS, we need to ensure that we aren't breaking the Fabric for iOS.
We can ensure the `NativeComponentExample` will build for Fabric & be accessible on iOS.
Once Fabric on macOS is working, this Native Example will not throw an error.

To enable the Native Component, run this during installation
`USE_CODEGEN_DISCOVERY=1 USE_FABRIC=1 bundle exec pod install --verbose`

## Changelog

[macOS] [Added] - Enable NewArchitectureExample Fabric example in RNTester iOS 

## Test Plan

#### Fabric iOS

https://user-images.githubusercontent.com/96719/203673083-3852d55f-a1f5-42d2-baa5-77b4e54b25cf.mp4

#### Paper macOS

https://user-images.githubusercontent.com/96719/203673121-09198b4c-9f28-4b2f-9098-ea67d85c58c5.mp4

