### PR TITLE
fix: cannot resolve `@react-native-community/cli-tools` (#1529)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@react-native-community/cli": "^7.0.3",
     "@react-native-community/cli-platform-android": "^7.0.1",
     "@react-native-community/cli-platform-ios": "^7.0.1",
+    "@react-native-community/cli-tools": "^7.0.1",
     "@react-native/assets": "1.0.0",
     "@react-native/normalize-color": "2.0.0",
     "@react-native/polyfills": "2.0.0",


### PR DESCRIPTION
#### Please select one of the following

- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry-pick of #1529.

Resolves #1190.

## Changelog

[General] [Fixed] - Fixed missing dependency `@react-native-community/cli-tools`

## Test Plan

n/a