### PR TITLE
Fabric/remove ios specific apis

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.h
@@ -13,6 +13,7 @@
  */
 @interface RCTModalHostViewComponentView : RCTViewComponentView <RCTMountingTransactionObserving>
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 /**
  * Subclasses may override this method and present the modal on different view controller.
  * Default implementation presents the modal on `[self reactViewController]`.
@@ -28,5 +29,6 @@
 - (void)dismissViewController:(UIViewController *)modalViewController
                      animated:(BOOL)animated
                    completion:(void (^)(void))completion;
+#endif // ]TODO(macOS GH#774)
 
 @end

--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -21,6 +21,7 @@
 
 using namespace facebook::react;
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 static UIInterfaceOrientationMask supportedOrientationsMask(ModalHostViewSupportedOrientationsMask mask)
 {
   UIInterfaceOrientationMask supportedOrientations = 0;
@@ -93,20 +94,24 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
       : ModalHostViewEventEmitter::OnOrientationChangeOrientation::Landscape;
   return {orientation};
 }
+#endif // ]TODO(macOS GH#774)
 
 @interface RCTModalHostViewComponentView () <RCTFabricModalHostViewControllerDelegate>
 
 @end
 
 @implementation RCTModalHostViewComponentView {
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   RCTFabricModalHostViewController *_viewController;
   ModalHostViewShadowNode::ConcreteState::Shared _state;
   BOOL _shouldAnimatePresentation;
   BOOL _shouldPresent;
   BOOL _isPresented;
   UIView *_modalContentsSnapshot;
+#endif // ]TODO(macOS GH#774)
 }
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
@@ -278,6 +283,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
 {
   [childComponentView removeFromSuperview];
 }
+#endif // ]TODO(macOS GH#774)
 
 @end
 

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -8,7 +8,10 @@
 #import "RCTParagraphComponentView.h"
 #import "RCTParagraphComponentAccessibilityProvider.h"
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 #import <MobileCoreServices/UTCoreTypes.h>
+#endif // ]TODO(macOS GH#774)
+
 #import <react/renderer/components/text/ParagraphComponentDescriptor.h>
 #import <react/renderer/components/text/ParagraphProps.h>
 #import <react/renderer/components/text/ParagraphState.h>

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -31,10 +31,12 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   if (self = [super init]) {
     _componentViewFactory = [RCTComponentViewFactory currentComponentViewFactory];
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleApplicationDidReceiveMemoryWarningNotification)
                                                  name:UIApplicationDidReceiveMemoryWarningNotification
                                                object:nil];
+#endif // ]TODO(macOS GH#774)
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       // Calling this a bit later, when the main thread is probably idle while JavaScript thread is busy.


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Disable iOS/Mobile specific api's

* RCTModalHostViewComponentView
* UIApplicationDidReceiveMemoryWarningNotification
* MobileCoreServices/UTCoreTypes

## Changelog

[macOS][Fabric] - Disable iOS/Mobile specific api's

## Test Plan

[x] Build RNTester-macOS w/ Fabric - builds w/ errors
![CleanShot 2022-11-30 at 17 12 16](https://user-images.githubusercontent.com/96719/204943601-98fbbc90-bc61-4f47-91eb-c99f95a16fe3.jpg)

Build errors: 
[Build RNTester-macOS_2022-11-30T17-10-39.txt](https://github.com/facebook/react-native/files/10128481/Build.RNTester-macOS_2022-11-30T17-10-39.txt)

[x] Build RNTester - iOS w/ Fabric - New architecture example should work
https://user-images.githubusercontent.com/96719/204943642-15f05350-9a28-4a95-8a5e-93f7d4e07c61.mp4

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2022-11-30 at 17 20 27](https://user-images.githubusercontent.com/96719/204943652-25c1a92a-4e19-45f6-b9f9-3da05c784474.jpg)

[x] Build RNTester - iOS w/ Paper - should work
![CleanShot 2022-11-30 at 17 22 11](https://user-images.githubusercontent.com/96719/204943670-c31e3381-4052-4ff2-bf6d-b025e4280016.jpg)
