### PR TITLE
[Fabric] Fix unterminated conditional that was breaking Fabric iOS build

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -101,7 +101,6 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
 @end
 
 @implementation RCTModalHostViewComponentView {
-#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   RCTFabricModalHostViewController *_viewController;
   ModalHostViewShadowNode::ConcreteState::Shared _state;
   BOOL _shouldAnimatePresentation;


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

#1533 Added a unterminated conditional that I didn't catch during my testing.
For testing, I build Paper first, then Fabric but for this run I swapped the order.

NOTE: This might be a good reminder that we should setup a CI job to build Fabric for iOS

## Changelog

[FIX] [MacOS] - Fix unterminated conditional that was breaking Fabric iOS build

## Test Plan

Build w/ Fabric
https://user-images.githubusercontent.com/96719/206294852-ee6c39b6-ac92-418d-b156-1c035e9e7394.mp4

Build w/ Paper
https://user-images.githubusercontent.com/96719/206295953-af6af4a1-ba23-4011-b4e6-da3a1190a8a1.mp4


