### PR TITLE
[Fabric] Shim RCTScrollViewComponentView

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
@@ -40,7 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
  * resilient to other code as possible: even if something else nil the delegate, other delegates that were subscribed
  * via the splitter will continue working.
  */
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 @property (nonatomic, strong, readonly) RCTGenericDelegateSplitter<id<UIScrollViewDelegate>> *delegateSplitter;
+#endif // ]TODO(macOS GH#774)
 
 @property (nonatomic, weak) id<RCTEnhancedScrollViewOverridingDelegate> overridingDelegate;
 @property (nonatomic, assign) BOOL pinchGestureEnabled;

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -7,12 +7,24 @@
 
 #import "RCTEnhancedScrollView.h"
 #import <React/RCTUtils.h>
+#import <React/RCTScrollableProtocol.h>
+#import <React/RCTAutoInsetsProtocol.h>
 
-@interface RCTEnhancedScrollView () <UIScrollViewDelegate>
+@interface RCTEnhancedScrollView () <
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
+    UIScrollViewDelegate
+#else
+    RCTScrollableProtocol, RCTAutoInsetsProtocol
+#endif
+> // ]TODO(macOS GH#774)
 @end
 
 @implementation RCTEnhancedScrollView {
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   __weak id<UIScrollViewDelegate> _publicDelegate;
+#else
+  __weak id<RCTScrollableProtocol, RCTAutoInsetsProtocol> _publicDelegate;
+#endif // ]TODO(macOS GH#774)
   BOOL _isSetContentOffsetDisabled;
 }
 
@@ -30,6 +42,8 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
+  // TODO - Fabric: Enable Delegate Splitter
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     // We set the default behavior to "never" so that iOS
     // doesn't do weird things to UIScrollView insets automatically
     // and keeps it as an opt-in behavior.
@@ -45,6 +59,7 @@
       [weakSelf setPrivateDelegate:delegate];
     }];
     [_delegateSplitter addDelegate:self];
+#endif // ]TODO(macOS GH#774)
   }
 
   return self;
@@ -88,6 +103,7 @@
       RCTSanitizeNaNValue(contentOffset.y, @"scrollView.contentOffset.y"));
 }
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 - (BOOL)touchesShouldCancelInContentView:(RCTUIView *)view // TODO(macOS GH#774)
 {
   if ([_overridingDelegate respondsToSelector:@selector(touchesShouldCancelInContentView:)]) {
@@ -127,6 +143,8 @@
     [_delegateSplitter addDelegate:_publicDelegate];
   }
 }
+
+#endif // ]TODO(macOS GH#774)
 
 #pragma mark - UIScrollViewDelegate
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -24,7 +24,9 @@ using namespace facebook::react;
 @end
 
 @implementation RCTPullToRefreshViewComponentView {
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   UIRefreshControl *_refreshControl;
+#endif // ]TODO(macOS GH#774)
   RCTScrollViewComponentView *__weak _scrollViewComponentView;
 }
 
@@ -39,10 +41,12 @@ using namespace facebook::react;
     static auto const defaultProps = std::make_shared<PullToRefreshViewProps const>();
     _props = defaultProps;
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     _refreshControl = [UIRefreshControl new];
     [_refreshControl addTarget:self
                         action:@selector(handleUIControlEventValueChanged)
               forControlEvents:UIControlEventValueChanged];
+#endif // ]TODO(macOS GH#774)
   }
 
   return self;
@@ -61,11 +65,13 @@ using namespace facebook::react;
   auto const &newConcreteProps = *std::static_pointer_cast<PullToRefreshViewProps const>(props);
 
   if (newConcreteProps.refreshing != oldConcreteProps.refreshing) {
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     if (newConcreteProps.refreshing) {
       [_refreshControl beginRefreshing];
     } else {
       [_refreshControl endRefreshing];
     }
+#endif // ]TODO(macOS GH#774)
   }
 
   BOOL needsUpdateTitle = NO;
@@ -97,7 +103,9 @@ using namespace facebook::react;
   auto const &concreteProps = *std::static_pointer_cast<PullToRefreshViewProps const>(_props);
 
   if (concreteProps.title.empty()) {
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     _refreshControl.attributedTitle = nil;
+#endif // ]TODO(macOS GH#774)
     return;
   }
 
@@ -106,8 +114,10 @@ using namespace facebook::react;
     attributes[NSForegroundColorAttributeName] = RCTUIColorFromSharedColor(concreteProps.titleColor);
   }
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   _refreshControl.attributedTitle =
       [[NSAttributedString alloc] initWithString:RCTNSStringFromString(concreteProps.title) attributes:attributes];
+#endif // ]TODO(macOS GH#774)
 }
 
 #pragma mark - Attaching & Detaching
@@ -132,9 +142,11 @@ using namespace facebook::react;
     return;
   }
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   if (@available(macOS 13.0, *)) {
     _scrollViewComponentView.scrollView.refreshControl = _refreshControl;
   }
+#endif // ]TODO(macOS GH#774)
 }
 
 - (void)_detach
@@ -144,11 +156,13 @@ using namespace facebook::react;
   }
 
   // iOS requires to end refreshing before unmounting.
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   [_refreshControl endRefreshing];
 
   if (@available(macOS 13.0, *)) {
     _scrollViewComponentView.scrollView.refreshControl = nil;
   }
+#endif // ]TODO(macOS GH#774)
   _scrollViewComponentView = nil;
 }
 
@@ -161,11 +175,13 @@ using namespace facebook::react;
 
 - (void)setNativeRefreshing:(BOOL)refreshing
 {
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   if (refreshing) {
     [_refreshControl beginRefreshing];
   } else {
     [_refreshControl endRefreshing];
   }
+#endif // ]TODO(macOS GH#774)
 }
 
 #pragma mark - RCTRefreshableProtocol

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
@@ -45,8 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Returns a delegate splitter that can be used to subscribe for UIScrollView delegate.
  */
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
 @property (nonatomic, strong, readonly)
     RCTGenericDelegateSplitter<id<UIScrollViewDelegate>> *scrollViewDelegateSplitter;
+#endif
 
 @end
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -28,6 +28,7 @@ using namespace facebook::react;
 
 static CGFloat const kClippingLeeway = 44.0;
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(ScrollViewProps const &props)
 {
   switch (props.keyboardDismissMode) {
@@ -78,9 +79,12 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
                                                       userInfo:userInfo];
   }
 }
+#endif // ]TODO(macOS GH#774)
 
 @interface RCTScrollViewComponentView () <
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     UIScrollViewDelegate,
+#endif // ]TODO(macOS GH#774)
     RCTScrollViewProtocol,
     RCTScrollableProtocol,
     RCTEnhancedScrollViewOverridingDelegate>
@@ -105,7 +109,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 + (RCTScrollViewComponentView *_Nullable)findScrollViewComponentViewForView:(RCTUIView *)view // TODO(macOS GH#774)
 {
   do {
-    view = view.superview;
+    view = (RCTUIView *)view.superview;
   } while (view != nil && ![view isKindOfClass:[RCTScrollViewComponentView class]]);
   return (RCTScrollViewComponentView *)view;
 }
@@ -118,7 +122,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 
     _scrollView = [[RCTEnhancedScrollView alloc] initWithFrame:self.bounds];
     _scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     _scrollView.delaysContentTouches = NO;
+#endif // ]TODO(macOS GH#774)
     ((RCTEnhancedScrollView *)_scrollView).overridingDelegate = self;
     _isUserTriggeredScrolling = NO;
     _shouldUpdateContentInsetAdjustmentBehavior = YES;
@@ -126,8 +132,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 
     _containerView = [[RCTUIView alloc] initWithFrame:CGRectZero]; // TODO(macOS GH#774)
     [_scrollView addSubview:_containerView];
-
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     [self.scrollViewDelegateSplitter addDelegate:self];
+#endif // ]TODO(macOS GH#774)
 
     _scrollEventThrottle = INFINITY;
   }
@@ -139,13 +146,17 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 {
   // Removing all delegates from the splitter nils the actual delegate which prevents a crash on UIScrollView
   // deallocation.
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   [self.scrollViewDelegateSplitter removeAllDelegates];
+#endif // ]TODO(macOS GH#774)
 }
 
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
 - (RCTGenericDelegateSplitter<id<UIScrollViewDelegate>> *)scrollViewDelegateSplitter
 {
   return ((RCTEnhancedScrollView *)_scrollView).delegateSplitter;
 }
+#endif // ]TODO(macOS GH#774)
 
 #pragma mark - RCTMountingTransactionObserving
 
@@ -172,7 +183,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
         : CGAffineTransformMakeScale(-1, 1);
 
     _containerView.transform = transform;
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     _scrollView.transform = transform;
+#endif // ]TODO(macOS GH#774)
   }
 }
 
@@ -195,19 +208,25 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
   // FIXME: Commented props are not supported yet.
   MAP_SCROLL_VIEW_PROP(alwaysBounceHorizontal);
   MAP_SCROLL_VIEW_PROP(alwaysBounceVertical);
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   MAP_SCROLL_VIEW_PROP(bounces);
   MAP_SCROLL_VIEW_PROP(bouncesZoom);
   MAP_SCROLL_VIEW_PROP(canCancelContentTouches);
+#endif // ]TODO(macOS GH#774)
   MAP_SCROLL_VIEW_PROP(centerContent);
   // MAP_SCROLL_VIEW_PROP(automaticallyAdjustContentInsets);
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   MAP_SCROLL_VIEW_PROP(decelerationRate);
   MAP_SCROLL_VIEW_PROP(directionalLockEnabled);
   MAP_SCROLL_VIEW_PROP(maximumZoomScale);
   MAP_SCROLL_VIEW_PROP(minimumZoomScale);
+#endif // ]TODO(macOS GH#774)
   MAP_SCROLL_VIEW_PROP(scrollEnabled);
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   MAP_SCROLL_VIEW_PROP(pagingEnabled);
   MAP_SCROLL_VIEW_PROP(pinchGestureEnabled);
   MAP_SCROLL_VIEW_PROP(scrollsToTop);
+#endif // ]TODO(macOS GH#774)
   MAP_SCROLL_VIEW_PROP(showsHorizontalScrollIndicator);
   MAP_SCROLL_VIEW_PROP(showsVerticalScrollIndicator);
 
@@ -216,7 +235,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
   }
 
   if (oldScrollViewProps.indicatorStyle != newScrollViewProps.indicatorStyle) {
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
     _scrollView.indicatorStyle = RCTUIScrollViewIndicatorStyleFromProps(newScrollViewProps);
+#endif // ]TODO(macOS GH#774)
   }
 
   if (oldScrollViewProps.scrollEventThrottle != newScrollViewProps.scrollEventThrottle) {
@@ -260,6 +281,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
     scrollView.snapToOffsets = snapToOffsets;
   }
 
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
   if (@available(iOS 13.0, *)) {
     if (oldScrollViewProps.automaticallyAdjustsScrollIndicatorInsets !=
         newScrollViewProps.automaticallyAdjustsScrollIndicatorInsets) {
@@ -282,12 +304,15 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
     }
     _shouldUpdateContentInsetAdjustmentBehavior = NO;
   }
-
+#endif
+    
   MAP_SCROLL_VIEW_PROP(disableIntervalMomentum);
   MAP_SCROLL_VIEW_PROP(snapToInterval);
 
   if (oldScrollViewProps.keyboardDismissMode != newScrollViewProps.keyboardDismissMode) {
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
     scrollView.keyboardDismissMode = RCTUIKeyboardDismissModeFromProps(newScrollViewProps);
+#endif
   }
 
   [super updateProps:props oldProps:oldProps];
@@ -350,7 +375,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
  */
 - (BOOL)_shouldDisableScrollInteraction
 {
-  RCTUIView *ancestorView = self.superview;  // TODO(macOS GH#774)
+  RCTUIView *ancestorView = (RCTUIView *)self.superview;  // TODO(macOS GH#774)
 
   while (ancestorView) {
     if ([ancestorView respondsToSelector:@selector(isJSResponder)]) {
@@ -360,7 +385,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
       }
     }
 
-    ancestorView = ancestorView.superview;
+    ancestorView = (RCTUIView *)ancestorView.superview;
   }
 
   return NO;
@@ -397,7 +422,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
   // We set the default behavior to "never" so that iOS
   // doesn't do weird things to UIScrollView insets automatically
   // and keeps it as an opt-in behavior.
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
   _scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+#endif // ]TODO(macOS GH#774)
   _shouldUpdateContentInsetAdjustmentBehavior = YES;
   _state.reset();
   _isUserTriggeredScrolling = NO;
@@ -428,8 +455,11 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
     if (_eventEmitter) {
       std::static_pointer_cast<ScrollViewEventEmitter const>(_eventEmitter)->onScroll([self _scrollViewMetrics]);
     }
-
+    // Once Fabric implements proper NativeAnimationDriver, this should be removed.
+    // This is just a workaround to allow animations based on onScroll event.
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
     RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag);
+#endif
   }
 
   [self _remountChildrenIfNeeded];
@@ -563,7 +593,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 
 - (void)flashScrollIndicators
 {
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
   [_scrollView flashScrollIndicators];
+#endif
 }
 
 - (void)scrollTo:(double)x y:(double)y animated:(BOOL)animated
@@ -631,8 +663,10 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 
 - (void)_remountChildren
 {
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
   [_scrollView updateClippedSubviewsWithClipRect:CGRectInset(_scrollView.bounds, -kClippingLeeway, -kClippingLeeway)
                                   relativeToView:_scrollView];
+#endif
 }
 
 #pragma mark - RCTScrollableProtocol
@@ -660,7 +694,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
     offset.x = self.contentSize.width - _scrollView.frame.size.width - offset.x;
   }
 
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
   [_scrollView setContentOffset:offset animated:animated];
+#endif
 
   if (!animated) {
     // When not animated, the expected workflow in ``scrollViewDidEndScrollingAnimation`` after scrolling is not going
@@ -671,9 +707,12 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 
 - (void)zoomToRect:(CGRect)rect animated:(BOOL)animated
 {
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
   [_scrollView zoomToRect:rect animated:animated];
+#endif
 }
 
+#if !TARGET_OS_OSX // TODO(macOS GH#774)
 - (void)addScrollListener:(NSObject<UIScrollViewDelegate> *)scrollListener
 {
   [self.scrollViewDelegateSplitter addDelegate:scrollListener];
@@ -683,6 +722,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
 {
   [self.scrollViewDelegateSplitter removeDelegate:scrollListener];
 }
+#endif
 
 @end
 


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Shim RCTScrollViewComponentView to work w/ Fabric

## Changelog

[macOS][Fabric] - Shim RCTScrollViewComponentView for Fabric

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTScrollViewComponentView errors
![CleanShot 2022-12-09 at 16 25 21](https://user-images.githubusercontent.com/96719/206819612-2979377c-e4dc-4c8e-9de2-c8136106fd9e.jpg)

Build errors: 
[Build RNTester-macOS_2022-12-09T16-25-02.txt](https://github.com/microsoft/react-native-macos/files/10198891/Build.RNTester-macOS_2022-12-09T16-25-02.txt)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2022-12-09 at 16 20 01](https://user-images.githubusercontent.com/96719/206819638-8242820e-f805-438d-815c-998872222ba5.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2022-12-09 at 16 45 17](https://user-images.githubusercontent.com/96719/206819668-aef812e3-11d7-47ea-b97e-aec8285a73fb.jpg)

[x] Build RNTester - iOS w/ Paper -
![CleanShot 2022-12-09 at 16 57 19](https://user-images.githubusercontent.com/96719/206820556-776c627b-df02-49cf-b9b0-114599ef5b67.jpg)
 should work
