### PR TITLE
[Fabric] Fix bad merge that removed `RCTUISwitch` definition from #1576

### DIFF
--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -490,3 +490,12 @@ NS_INLINE CGRect CGRectValue(NSValue *value)
 @interface RCTUILabel : NSTextField
 @end
 #endif // ]TODO(macOS GH#774)
+
+// RCTUISwitch
+
+#if !TARGET_OS_OSX // [TODO(macOS GH#774)
+#define RCTUISwitch UISwitch
+#else
+@interface RCTUISwitch : NSSwitch
+@end
+#endif // ]TODO(macOS GH#774)


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

 #1576 overwrote a change from #1527 in `RCTUIKit.h`
building from `main` was broken after it was merged.

## Changelog

[macOS] [Fabric] - Fix bad merge that removed `RCTUISwitch` definition

## Test Plan

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2022-12-12 at 15 20 23](https://user-images.githubusercontent.com/96719/207182022-f99a0ace-2aa6-4a24-b51d-82a4adede6ff.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2022-12-12 at 15 26 42](https://user-images.githubusercontent.com/96719/207182041-614dacd0-e500-49ea-a9ab-62821ab8264b.jpg)

[x] Build RNTester - iOS w/ Paper - should work
![CleanShot 2022-12-12 at 15 30 53](https://user-images.githubusercontent.com/96719/207182050-fd36b15c-95ce-4a21-8120-c690639d0244.jpg)

