### PR TITLE
Use RCTUISwitch shim in Paper (RCTSwitch)

### DIFF
--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -497,5 +497,10 @@ NS_INLINE CGRect CGRectValue(NSValue *value)
 #define RCTUISwitch UISwitch
 #else
 @interface RCTUISwitch : NSSwitch
+
+@property (nonatomic, assign) BOOL on;
+
+- (void)setOn:(BOOL)on animated:(BOOL)animated;
+
 @end
 #endif // ]TODO(macOS GH#774)

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -494,11 +494,11 @@ NS_INLINE CGRect CGRectValue(NSValue *value)
 // RCTUISwitch
 
 #if !TARGET_OS_OSX // [TODO(macOS GH#774)
-typedef RCTUISwitch UISwitch;
+typedef UISwitch RCTUISwitch;
 #else
 @interface RCTUISwitch : NSSwitch
 
-@property (nonatomic, assign) BOOL on;
+@property (nonatomic, assign, getter=isOn) BOOL on;
 
 - (void)setOn:(BOOL)on animated:(BOOL)animated;
 

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -494,7 +494,7 @@ NS_INLINE CGRect CGRectValue(NSValue *value)
 // RCTUISwitch
 
 #if !TARGET_OS_OSX // [TODO(macOS GH#774)
-#define RCTUISwitch UISwitch
+typedef RCTUISwitch UISwitch
 #else
 @interface RCTUISwitch : NSSwitch
 

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -494,7 +494,7 @@ NS_INLINE CGRect CGRectValue(NSValue *value)
 // RCTUISwitch
 
 #if !TARGET_OS_OSX // [TODO(macOS GH#774)
-typedef RCTUISwitch UISwitch
+typedef RCTUISwitch UISwitch;
 #else
 @interface RCTUISwitch : NSSwitch
 

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -609,3 +609,21 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 }
 
 @end  // ]TODO(macOS GH#774)
+
+@implementation RCTUISwitch
+
+- (void)setOn:(BOOL)on animated:(BOOL)animated {
+	self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
+}
+
+- (BOOL)on
+{
+	return self.state == NSControlStateValueOn;
+}
+
+- (void)setOn:(BOOL)on
+{
+	self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
+}
+
+@end

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -612,11 +612,7 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 @implementation RCTUISwitch
 
-- (void)setOn:(BOOL)on animated:(BOOL)animated {
-	self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
-}
-
-- (BOOL)on
+- (BOOL)isOn
 {
 	return self.state == NSControlStateValueOn;
 }
@@ -625,5 +621,10 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 {
 	self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
 }
+
+- (void)setOn:(BOOL)on animated:(BOOL)animated {
+	self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
+}
+
 
 @end

--- a/React/Views/RCTSwitch.h
+++ b/React/Views/RCTSwitch.h
@@ -11,9 +11,7 @@
 
 @interface RCTSwitch : RCTUISwitch
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
 @property (nonatomic, assign) BOOL wasOn;
-#endif // TODO(macOS GH#774)
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 
 @end

--- a/React/Views/RCTSwitch.h
+++ b/React/Views/RCTSwitch.h
@@ -9,18 +9,11 @@
 
 #import <React/RCTComponent.h>
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
-@interface RCTSwitch : UISwitch
-#else // [TODO(macOS GH#774)
-@interface RCTSwitch : NSSwitch
-#endif // ]TODO(macOS GH#774)
+@interface RCTSwitch : RCTUISwitch
 
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
 @property (nonatomic, assign) BOOL wasOn;
-#else // [TODO(macOS GH#774)
-@property (nonatomic, assign) BOOL on;
-- (void)setOn:(BOOL)on animated:(BOOL)animated;
-#endif // ]TODO(macOS GH#774)
+#endif // TODO(macOS GH#774)
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 
 @end

--- a/React/Views/RCTSwitch.m
+++ b/React/Views/RCTSwitch.m
@@ -11,12 +11,10 @@
 
 @implementation RCTSwitch
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
 - (void)setOn:(BOOL)on animated:(BOOL)animated
 {
   _wasOn = on;
   [super setOn:on animated:animated];
 }
-#endif // TODO(macOS GH#774)
 
 @end

--- a/React/Views/RCTSwitch.m
+++ b/React/Views/RCTSwitch.m
@@ -17,24 +17,6 @@
   _wasOn = on;
   [super setOn:on animated:animated];
 }
-#else // [TODO(macOS GH#774)
-- (void)setOn:(BOOL)on animated:(BOOL)animated {
-  self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
-}
-#endif // ]TODO(macOS GH#774)
-
-#if TARGET_OS_OSX
-
-- (BOOL)on
-{
-  return self.state == NSControlStateValueOn;
-}
-
-- (void)setOn:(BOOL)on
-{
-  self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
-}
-
-#endif // ]TODO(macOS GH#774)
+#endif // TODO(macOS GH#774)
 
 @end

--- a/React/Views/RCTSwitchManager.m
+++ b/React/Views/RCTSwitchManager.m
@@ -30,16 +30,12 @@ RCT_EXPORT_MODULE()
 
 - (void)onChange:(RCTSwitch *)sender
 {
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
   if (sender.wasOn != sender.on) {
     if (sender.onChange) {
       sender.onChange(@{@"value" : @(sender.on)});
     }
     sender.wasOn = sender.on;
   }
-#else // [TODO(macOS GH#774)
-  sender.onChange(@{ @"value": @(sender.on) });
-#endif // ]TODO(macOS GH#774)
 }
 
 RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)viewTag toValue : (BOOL)value)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

While implementing Fabric for React Native macOS, we created a few new shim classes in RCTUIKit that we could potentially use in our paper implementation as well. This change extends the simple `RCTUISwitch` shim to implement what we need for it to work on Paper (aka, use it in RCTSwitch). The end result is a few less macOS diffs and overall cleaner code in my opinion =)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Chenged] - Use RCTUISwitch shim for RCTSwitch

## Test Plan

Test page still works fine. 

https://user-images.githubusercontent.com/6722175/207714665-4b73bb4e-e3ce-4cd5-a03e-809a0577b683.mov



