### PR TITLE
Remove comment on merging stable branches -> main

### DIFF
--- a/Libraries/Core/ReactNativeVersion.js
+++ b/Libraries/Core/ReactNativeVersion.js
@@ -9,11 +9,6 @@
  * @flow strict
  */
 
-
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 exports.version = {
   major: 0,
   minor: 0,

--- a/React/Base/RCTVersion.m
+++ b/React/Base/RCTVersion.m
@@ -14,10 +14,6 @@ NSString* const RCTVersionMinor = @"minor";
 NSString* const RCTVersionPatch = @"patch";
 NSString* const RCTVersionPrerelease = @"prerelease";
 
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 NSDictionary* RCTGetReactNativeVersion(void)
 {
   static NSDictionary* __rnVersion;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -13,10 +13,6 @@ import com.facebook.react.common.MapBuilder;
 
 import java.util.Map;
 
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,

--- a/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -14,10 +14,6 @@
 
 namespace facebook::react {
 
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 0;

--- a/scripts/versiontemplates/RCTVersion.m.template
+++ b/scripts/versiontemplates/RCTVersion.m.template
@@ -15,10 +15,6 @@ NSString* const RCTVersionPatch = @"patch";
 NSString* const RCTVersionPrerelease = @"prerelease";
 
 
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 NSDictionary* RCTGetReactNativeVersion(void)
 {
   static NSDictionary* __rnVersion;

--- a/scripts/versiontemplates/ReactNativeVersion.h.template
+++ b/scripts/versiontemplates/ReactNativeVersion.h.template
@@ -14,10 +14,6 @@
 
 namespace facebook::react {
 
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 constexpr struct {
   int32_t Major = ${major};
   int32_t Minor = ${minor};

--- a/scripts/versiontemplates/ReactNativeVersion.java.template
+++ b/scripts/versiontemplates/ReactNativeVersion.java.template
@@ -13,10 +13,6 @@ import com.facebook.react.common.MapBuilder;
 
 import java.util.Map;
 
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", ${major},

--- a/scripts/versiontemplates/ReactNativeVersion.js.template
+++ b/scripts/versiontemplates/ReactNativeVersion.js.template
@@ -9,10 +9,6 @@
  * @flow strict
  */
 
-// [TODO(macOS GH#944)
-// Note: Be careful not to override these version numbers
-// when we merge upstream stable branches into main
-// TODO(macOS GH#944)]
 exports.version = {
   major: ${major},
   minor: ${minor},


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Back in #944 , I had added a comment about merging _stable branches_ into our main branch. We have then since learned [and documented](https://github.com/microsoft/react-native-macos/blob/main/docs/GitFlow.md) that we shouldn't be doing that: main should merge to main, and stable should either have merges from upstream stable, or cherry picks. 

Let's remove the comment, removing another diff from our repo. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Removed] - Remove comment on merging stable branches -> main

## Test Plan

Removing a comment, nothing should be affected.
