### PR TITLE
[Cherry-pick] Pick up upstream fix to NewAppScreen to remove a diff

### DIFF
--- a/packages/rn-tester/js/examples/NewAppScreen/NewAppScreenExample.js
+++ b/packages/rn-tester/js/examples/NewAppScreen/NewAppScreenExample.js
@@ -50,9 +50,7 @@ exports.examples = [
         <View style={{flexDirection: 'row'}}>
           {Object.keys(Colors).map(key => (
             <View
-              key={
-                key /* TODO(OSS Candidate ISS#2710739): contribute this fix upstream */
-              }
+              key={`color-${key}`}
               style={{width: 50, height: 50, backgroundColor: Colors[key]}}
             />
           ))}


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
75f853dd708be9c4f5eb11fa77019f92bce021ad had fixed this all the way back in RN 0.62, but we seemed to never pick it up. Let's pick it up now.


## Changelog

[macOS] [Changed] - Remove a diff around the NewAppScreen example

## Test Plan

CI passes.
