### PR TITLE
Add default handling of Space and Enter to Pressable

### DIFF
--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -221,8 +221,6 @@ type Props = $ReadOnly<{|
  */
 function Pressable(props: Props, forwardedRef): React.Node {
   const {
-    acceptsFirstMouse, // [TODO(macOS GH#774)
-    enableFocusRing, // ]TODO(macOS GH#774)
     accessible,
     android_disableSound,
     android_ripple,
@@ -240,10 +238,13 @@ function Pressable(props: Props, forwardedRef): React.Node {
     onPressIn,
     onPressOut,
     // [TODO(macOS GH#774)
+    acceptsFirstMouse,
+    enableFocusRing,
     onFocus,
     onBlur,
     onKeyDown,
     onKeyUp,
+    validKeysDown,
     // ]TODO(macOS GH#774)
     pressRetentionOffset,
     style,
@@ -269,12 +270,15 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const restPropsWithDefaults: React.ElementConfig<typeof View> = {
     ...restProps,
     ...android_rippleConfig?.viewProps,
-    acceptsFirstMouse: acceptsFirstMouse !== false && !disabled, // [TODO(macOS GH#774)
-    enableFocusRing: enableFocusRing !== false && !disabled,
-    accessible: accessible !== false,
-    focusable: focusable !== false && !disabled, // ]TODO(macOS GH#774)
     accessibilityState,
     hitSlop,
+    // [TODO(macOS GH#774)
+    acceptsFirstMouse: acceptsFirstMouse !== false && !disabled,
+    enableFocusRing: enableFocusRing !== false && !disabled,
+    accessible: accessible !== false,
+    focusable: focusable !== false && !disabled,
+    validKeysDown: validKeysDown ?? ['Space', 'Enter'],
+    // ]TODO(macOS GH#774)
   };
 
   const config = useMemo(

--- a/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
+++ b/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
@@ -18,6 +18,12 @@ exports[`<Pressable /> should render as expected: should deep render when mocked
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -41,6 +47,12 @@ exports[`<Pressable /> should render as expected: should deep render when not mo
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -81,6 +93,12 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -109,6 +127,12 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -153,6 +177,12 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -181,6 +211,12 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -228,6 +264,12 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -257,6 +299,12 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -311,6 +359,12 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -339,6 +393,12 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>

--- a/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -26,6 +26,12 @@ exports[`TextInput tests should render as expected: should deep render when mock
   selection={null}
   text=""
   underlineColorAndroid="transparent"
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 />
 `;
 
@@ -55,6 +61,12 @@ exports[`TextInput tests should render as expected: should deep render when not 
   selection={null}
   text=""
   underlineColorAndroid="transparent"
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 />
 `;
 

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -16,6 +16,12 @@ exports[`TouchableHighlight renders correctly 1`] = `
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
   style={Object {}}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <Text>
     Touchable
@@ -43,6 +49,12 @@ exports[`TouchableHighlight with disabled state should be disabled when disabled
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -68,6 +80,12 @@ exports[`TouchableHighlight with disabled state should be disabled when disabled
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -93,6 +111,12 @@ exports[`TouchableHighlight with disabled state should disable button when acces
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -119,6 +143,12 @@ exports[`TouchableHighlight with disabled state should keep accessibilityState w
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>
@@ -144,6 +174,12 @@ exports[`TouchableHighlight with disabled state should overwrite accessibilitySt
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View />
 </View>

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
@@ -21,6 +21,12 @@ exports[`TouchableOpacity renders correctly 1`] = `
       "opacity": 1,
     }
   }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <Text>
     Touchable
@@ -54,6 +60,12 @@ exports[`TouchableOpacity renders in disabled state when a disabled prop is pass
       "opacity": 1,
     }
   }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <Text>
     Touchable
@@ -86,6 +98,12 @@ exports[`TouchableOpacity renders in disabled state when a key disabled in acces
     Object {
       "opacity": 1,
     }
+  }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
   }
 >
   <Text>

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableWithoutFeedback-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableWithoutFeedback-test.js.snap
@@ -15,6 +15,12 @@ exports[`TouchableWithoutFeedback renders correctly 1`] = `
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   Touchable
 </Text>
@@ -40,6 +46,12 @@ exports[`TouchableWithoutFeedback with disabled state should be disabled when di
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 />
 `;
 
@@ -63,6 +75,12 @@ exports[`TouchableWithoutFeedback with disabled state should be disabled when di
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 />
 `;
 
@@ -86,6 +104,12 @@ exports[`TouchableWithoutFeedback with disabled state should disable button when
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 />
 `;
 
@@ -110,6 +134,12 @@ exports[`TouchableWithoutFeedback with disabled state should keep accessibilityS
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 />
 `;
 
@@ -133,5 +163,11 @@ exports[`TouchableWithoutFeedback with disabled state should overwrite accessibi
   onResponderTerminate={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 />
 `;

--- a/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
+++ b/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
@@ -27,6 +27,12 @@ exports[`<Button /> should be disabled and it should set accessibilityState to d
       "opacity": 1,
     }
   }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View
     style={
@@ -84,6 +90,12 @@ exports[`<Button /> should be disabled when disabled is empty and accessibilityS
     Object {
       "opacity": 1,
     }
+  }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
   }
 >
   <View
@@ -143,6 +155,12 @@ exports[`<Button /> should be disabled when disabled={true} and accessibilitySta
       "opacity": 1,
     }
   }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View
     style={
@@ -201,6 +219,12 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
       "opacity": 1,
     }
   }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View
     style={
@@ -254,6 +278,12 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
     Object {
       "opacity": 1,
     }
+  }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
   }
 >
   <View
@@ -309,6 +339,12 @@ exports[`<Button /> should overwrite accessibilityState with value of disabled p
       "opacity": 1,
     }
   }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
+  }
 >
   <View
     style={
@@ -361,6 +397,12 @@ exports[`<Button /> should render as expected 1`] = `
     Object {
       "opacity": 1,
     }
+  }
+  validKeysDown={
+    Array [
+      "Space",
+      "Enter",
+    ]
   }
 >
   <View

--- a/Libraries/Pressability/Pressability.js
+++ b/Libraries/Pressability/Pressability.js
@@ -649,7 +649,7 @@ export default class Pressability {
         if (
           (event.nativeEvent.code === 'Space' ||
             event.nativeEvent.code === 'Enter') &&
-          event.defaultPrevented != true &&
+          event.defaultPrevented != true
         ) {
           const {onPressOut, onPress} = this._config;
           // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead

--- a/Libraries/Pressability/Pressability.js
+++ b/Libraries/Pressability/Pressability.js
@@ -623,16 +623,41 @@ export default class Pressability {
 
     // [TODO(macOS GH#774)
     const keyboardEventHandlers = {
-      onKeyDown: (event: KeyEvent): void => {
-        const {onKeyDown} = this._config;
-        if (onKeyDown != null) {
-          onKeyDown(event);
-        }
-      },
+      /** 
+       * Keyboard events are only sent to JS if validKeysUp / validKeysDown is specified.
+       * Let's only implement default handling of onKeyUp / onKeyDown if we aren't passed in validKeysUp / validKeysDown.
+       */
+      validKeysDown: this._config.validKeysDown ?? ['Space', 'Enter'],
       onKeyUp: (event: KeyEvent): void => {
         const {onKeyUp} = this._config;
-        if (onKeyUp != null) {
-          onKeyUp(event);
+        onKeyUp && onKeyUp(event);
+
+        if (
+          (event.nativeEvent.code === 'Space' ||
+            event.nativeEvent.code === 'Enter') &&
+          event.defaultPrevented != true
+        ) {
+          const {onPressOut, onPress} = this._config;
+          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+          onPressOut && onPressOut(event);
+        }
+      },
+      onKeyDown: (event: KeyEvent): void => {
+        const {onKeyDown} = this._config;
+        onKeyDown && onKeyDown(event);
+
+        if (
+          (event.nativeEvent.code === 'Space' ||
+            event.nativeEvent.code === 'Enter') &&
+          event.defaultPrevented != true &&
+        ) {
+          const {onPressOut, onPress} = this._config;
+          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+          onPressOut && onPressOut(event);
+
+          // macOS natively tends to perform actions on keyDown rather than keyUp
+          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+          onPress && onPress(event);
         }
       },
     };

--- a/Libraries/Pressability/Pressability.js
+++ b/Libraries/Pressability/Pressability.js
@@ -653,7 +653,7 @@ export default class Pressability {
         ) {
           const {onPressOut, onPress} = this._config;
           // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
-          onPressOut && onPressOut(event);
+          onPressIn && onPressIn(event);
 
           // macOS natively tends to perform actions on keyDown rather than keyUp
           // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead

--- a/Libraries/Pressability/Pressability.js
+++ b/Libraries/Pressability/Pressability.js
@@ -623,21 +623,16 @@ export default class Pressability {
 
     // [TODO(macOS GH#774)
     const keyboardEventHandlers = {
-      /** 
-       * Keyboard events are only sent to JS if validKeysUp / validKeysDown is specified.
-       * Let's only implement default handling of onKeyUp / onKeyDown if we aren't passed in validKeysUp / validKeysDown.
-       */
-      validKeysDown: this._config.validKeysDown ?? ['Space', 'Enter'],
       onKeyUp: (event: KeyEvent): void => {
         const {onKeyUp} = this._config;
         onKeyUp && onKeyUp(event);
 
         if (
-          (event.nativeEvent.code === 'Space' ||
-            event.nativeEvent.code === 'Enter') &&
-          event.defaultPrevented != true
+          (event.nativeEvent.key === 'Space' ||
+            event.nativeEvent.key === 'Enter') &&
+          event.defaultPrevented !== true
         ) {
-          const {onPressOut, onPress} = this._config;
+          const {onPressOut} = this._config;
           // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
           onPressOut && onPressOut(event);
         }
@@ -647,11 +642,11 @@ export default class Pressability {
         onKeyDown && onKeyDown(event);
 
         if (
-          (event.nativeEvent.code === 'Space' ||
-            event.nativeEvent.code === 'Enter') &&
-          event.defaultPrevented != true
+          (event.nativeEvent.key === 'Space' ||
+            event.nativeEvent.key === 'Enter') &&
+          event.defaultPrevented !== true
         ) {
-          const {onPressOut, onPress} = this._config;
+          const {onPressIn, onPress} = this._config;
           // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
           onPressIn && onPressIn(event);
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

In React Native Windows, Pressable will by default handle `onKeyUp / onKeyDown` to call `onPress / onPressIn / onPressOut`. We were missing that in React Native macOS, due to differences in our keyboard event API. React Native Windows sends _all_ keyboard events to JS, whereas React Native macOS only sends keyboard events to JS if `validKeysUp / validKeysDown` is specified.

Let's implement this default keyboard handling for Pressable in React Native macOS as well. The logic added is mostly a copy of the [logic in React Native Windows](https://github.com/microsoft/react-native-windows/blob/a6fa3905a11cdb3c184fecc074ef93bee9d984e6/vnext/src/Libraries/Pressability/Pressability.windows.js#L616) with a few key differences:

1) We add a default `validKeysDown` prop if the calling code doesn't specify one. This is needed due the API difference mentioned above.
2) We fire `onPress`  with `onKeyDown` instead of `onKeyUp`. This is a platform difference between Windows and macOS. In Windows natively, button presses are preferred to be fired with `onKeyUp`. Furthermore, you can "cancel" a button press  by pressing Tab in between your keyDown and your keyUp. This quirk is not present in native macOS. 
3) Because of (2), I chose not to port the following change, where one can cancel the onPress https://github.com/microsoft/react-native-windows/commit/ed1e85ecf40c9261ffb4f479775e373e4b566f21

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [Changed] - Add default handling of Space and Enter to Pressable

## Test Plan

In progress...
