### PR TITLE
Remove diff in RCTImageLoader

### DIFF
--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -81,7 +81,7 @@ NSData *UIImagePNGRepresentation(NSImage *image) {
 NSData *UIImageJPEGRepresentation(NSImage *image, CGFloat compressionQuality) {
   return NSImageDataForFileType(image,
 								NSBitmapImageFileTypeJPEG,
-								@{NSImageCompressionFactor: @(1.0)});
+								@{NSImageCompressionFactor: @(compressionQuality)});
 }
 #endif // ]TODO(macOS GH#774)
 

--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -66,8 +66,8 @@ static NSData *NSImageDataForFileType(NSImage *image, NSBitmapImageFileType file
 
   NSBitmapImageRep *imageRep = (NSBitmapImageRep *)image.representations.firstObject;
   if (![imageRep isKindOfClass:[NSBitmapImageRep class]]) {
-	RCTAssert([imageRep isKindOfClass:[NSBitmapImageRep class]], @"We need an NSBitmapImageRep to create an image.");
-	return nil;
+    RCTAssert([imageRep isKindOfClass:[NSBitmapImageRep class]], @"We need an NSBitmapImageRep to create an image.");
+    return nil;
   }
 
   return [imageRep representationUsingType:fileType properties:properties];

--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -1145,20 +1145,10 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
     NSData *imageData = nil;
     if (RCTUIImageHasAlpha(image)) { // TODO(macOS GH#774)
       mimeType = @"image/png";
-#if TARGET_OS_OSX
-      imageData = NSImageDataForFileType(image, NSBitmapImageFileTypePNG, @{});
-#else
       imageData = UIImagePNGRepresentation(image);
-#endif // !TARGET_OS_OSX
     } else {
       mimeType = @"image/jpeg";
-#if TARGET_OS_OSX
-      imageData = NSImageDataForFileType(image,
-                                         NSBitmapImageFileTypeJPEG,
-                                         @{NSImageCompressionFactor : @(1.0)});
-#else
       imageData = UIImageJPEGRepresentation(image, 1.0);
-#endif // !TARGET_OS_OSX
     }
 
     NSURLResponse *response = [[NSURLResponse alloc] initWithURL:request.URL

--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -22,7 +22,6 @@
 #import <React/RCTLog.h>
 #import <React/RCTNetworking.h>
 #import <React/RCTUtils.h>
-#import <React/RCTUIKit.h> // TODO(macOS GH#774)
 
 #import "RCTImagePlugins.h"
 
@@ -54,20 +53,37 @@ static NSInteger RCTImageBytesForImage(UIImage *image)
 #endif // [TODO(macOS GH#774)
 }
 
-#if TARGET_OS_OSX
+#if TARGET_OS_OSX // [TODO(macOS GH#774)
+
+/**
+ *  We can't depend on RCTUIKit here, bcause this file's podspec (React-RCTImage) doesn't take a dependency on RCTUIKit's pod `React-Core`
+ *  Let's just copy the methods we want to shim here
+ */
+
 static NSData *NSImageDataForFileType(NSImage *image, NSBitmapImageFileType fileType, NSDictionary<NSString *, id> *properties)
 {
   RCTAssert(image.representations.count == 1, @"Expected only a single representation since UIImage only supports one.");
 
   NSBitmapImageRep *imageRep = (NSBitmapImageRep *)image.representations.firstObject;
   if (![imageRep isKindOfClass:[NSBitmapImageRep class]]) {
-    RCTAssert([imageRep isKindOfClass:[NSBitmapImageRep class]], @"We need an NSBitmapImageRep to create an image.");
-    return nil;
+	RCTAssert([imageRep isKindOfClass:[NSBitmapImageRep class]], @"We need an NSBitmapImageRep to create an image.");
+	return nil;
   }
 
   return [imageRep representationUsingType:fileType properties:properties];
 }
-#endif // TARGET_OS_OSX
+
+
+NSData *UIImagePNGRepresentation(NSImage *image) {
+  return NSImageDataForFileType(image, NSBitmapImageFileTypePNG, @{});
+}
+
+NSData *UIImageJPEGRepresentation(NSImage *image, CGFloat compressionQuality) {
+  return NSImageDataForFileType(image,
+								NSBitmapImageFileTypeJPEG,
+								@{NSImageCompressionFactor: @(1.0)});
+}
+#endif // ]TODO(macOS GH#774)
 
 static uint64_t monotonicTimeGetCurrentNanoseconds(void)
 {

--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -80,8 +80,8 @@ NSData *UIImagePNGRepresentation(NSImage *image) {
 
 NSData *UIImageJPEGRepresentation(NSImage *image, CGFloat compressionQuality) {
   return NSImageDataForFileType(image,
-								NSBitmapImageFileTypeJPEG,
-								@{NSImageCompressionFactor: @(compressionQuality)});
+                                NSBitmapImageFileTypeJPEG,
+                                @{NSImageCompressionFactor: @(compressionQuality)});
 }
 #endif // ]TODO(macOS GH#774)
 

--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -56,8 +56,8 @@ static NSInteger RCTImageBytesForImage(UIImage *image)
 #if TARGET_OS_OSX // [TODO(macOS GH#774)
 
 /**
- *  We can't depend on RCTUIKit here, bcause this file's podspec (React-RCTImage) doesn't take a dependency on RCTUIKit's pod `React-Core`
- *  Let's just copy the methods we want to shim here
+ * Github #1611 - We can't depend on RCTUIKit here, because this file's podspec (React-RCTImage) doesn't
+ * take a dependency on RCTUIKit's pod `React-Core`. Let's just copy the methods we want to shim here
  */
 
 static NSData *NSImageDataForFileType(NSImage *image, NSBitmapImageFileType fileType, NSDictionary<NSString *, id> *properties)

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -131,7 +131,7 @@ NSData *UIImagePNGRepresentation(NSImage *image) {
 NSData *UIImageJPEGRepresentation(NSImage *image, CGFloat compressionQuality) {
   return NSImageDataForFileType(image,
                                 NSBitmapImageFileTypeJPEG,
-                                @{NSImageCompressionFactor: @(1.0)});
+                                @{NSImageCompressionFactor: @(compressionQuality)});
 }
 
 // UIBezierPath


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This came up during the 0.71 merge. There was an iOS only method we had already shimmed in [RCTUIKit](https://github.com/microsoft/react-native-macos/blob/71e7ccfc29585c438681042c8ef82c38ad1a1736/React/Base/macOS/RCTUIKit.m#L127):

```objective-c
NSData *UIImagePNGRepresentation(NSImage *image) {
  return NSImageDataForFileType(image, NSBitmapImageFileTypePNG, @{});
}

NSData *UIImageJPEGRepresentation(NSImage *image, CGFloat compressionQuality) {
  return NSImageDataForFileType(image,
                                NSBitmapImageFileTypeJPEG,
                                @{NSImageCompressionFactor: @(1.0)});
}
```

As it turns out, we can't depend on RCTUIKit here, because this file's podspec (React-RCTImage) doesn't take a dependency on RCTUIKit's pod React-Core. The #import <React/RCTUIKit.h> most likely worked out of happenstance. I went with copying the methods needed from RCTUIKit to RCTImageLoader as we already had some duplication. 

Let's also fix a bug where compressionQuality was hardcoded.

## Changelog

[macOS] [Fixed] - Remove unnecessary diff in RCTImageLoader

## Test Plan

CI should pass
