### PR TITLE
Move typdef from RCTImageView -> RCTUIKit

### DIFF
--- a/Libraries/Image/RCTImageView.h
+++ b/Libraries/Image/RCTImageView.h
@@ -6,14 +6,6 @@
  */
 
 #import <React/RCTUIKit.h> // TODO(macOS GH#774)
-#if !TARGET_OS_OSX // [TODO(macOS GH#774)
-#import <UIKit/UIKit.h>
-#else // [TODO(macOS GH#774)
-typedef NS_ENUM(NSInteger, UIImageRenderingMode) {
-    UIImageRenderingModeAlwaysOriginal,
-    UIImageRenderingModeAlwaysTemplate,
-};
-#endif // ]TODO(macOS GH#774)
 #import <React/RCTView.h>
 #import <React/RCTResizeMode.h>
 

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -321,6 +321,11 @@ NS_INLINE NSEdgeInsets UIEdgeInsetsMake(CGFloat top, CGFloat left, CGFloat botto
 // UIImage
 @compatibility_alias UIImage NSImage;
 
+typedef NS_ENUM(NSInteger, UIImageRenderingMode) {
+    UIImageRenderingModeAlwaysOriginal,
+    UIImageRenderingModeAlwaysTemplate,
+};
+
 #ifdef __cplusplus
 extern "C"
 #endif


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This came up while resolving conflicts in the 0.71 merge.
Move a typedef associated with `UIImage` to the macOS part of `RCTUIKit`. Once done, we can remove a `#if !TARGET_OS_OSX` if/else block, since `#import <React/RCTUIKit.h>` will bring in either `Appkit` or `UIKit` based on the platform. 

## Changelog

[macOS] [Changed] - Move typdef from RCTImageView -> RCTUIKit

## Test Plan

CI should pass
