### PR TITLE
Back port 1619 and 1288 to 0.68: Fix coordinates of touch.pageX/pageY coordinates when RCTRootView is not at the origin of the NSWindow

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -224,8 +224,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 #else // [TODO(macOS GH#774)
   NSEvent *nativeTouch = _nativeTouches[touchIndex];
   CGPoint location = nativeTouch.locationInWindow;
-  CGPoint rootViewLocation = CGPointMake(location.x, CGRectGetHeight(self.view.window.frame) - location.y);
-  CGPoint touchViewLocation = rootViewLocation;
+  RCTAssert(_cachedRootView, @"We were unable to find a root view for the touch");
+  CGPoint rootViewLocation = [_cachedRootView.window.contentView convertPoint:location toView:_cachedRootView];
+
+  NSView *touchView = _touchViews[touchIndex];
+  CGPoint touchViewLocation = [touchView convertPoint:location fromView:nil];
 #endif // ]TODO(macOS GH#774)
 
   NSMutableDictionary *reactTouch = _reactTouches[touchIndex];

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -226,7 +226,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
   CGPoint location = nativeTouch.locationInWindow;
   RCTAssert(_cachedRootView, @"We were unable to find a root view for the touch");
   CGPoint rootViewLocation = [_cachedRootView.window.contentView convertPoint:location toView:_cachedRootView];
-
   NSView *touchView = _touchViews[touchIndex];
   CGPoint touchViewLocation = [touchView convertPoint:location fromView:nil];
 #endif // ]TODO(macOS GH#774)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This is a back port of the recent change to master: [1619](https://github.com/microsoft/react-native-macos/pull/1619) Fix coordinates of touch.pageX/pageY coordinates when RCTRootView is not at the origin of the NSWindow.

The change touches the same code where a similar fix for touch.locationX/locationY: [1288](https://github.com/microsoft/react-native-macos/pull/1288) Fix event.locationX/Y to be in view's coordinate space

Both changes are back ported in this change.

f the `RCTRootView` is not positioned at the origin of the `NSWindow`, then `touch.pageX/pageY` events will not have the correct coordinates. This can make it difficult for a user to click on Touchable and Pressable components unless there are no mouse moves between the mouse down and the mouse up events. The touch down and up events use the `touch.locationX/locationY` which are computed correctly, but after a touch down if the user move the mouse the `touch.pageX/pageY` coordinates are used and if the `RCTRootView` is not at the window origin, these coordinates will be offset. The result is the user will see touch feedback for a moment and then it disappears.

## Changelog

[macOS] [Fix] - Back port 1619 to 0.68: Fix coordinates of touch.pageX/pageY coordinates when RCTRootView is not at the origin of the NSWindow

## Test Plan

This issue only manifests if the `RCTRootView` is not at the origin of the `NSWindow`. To test this bug, I modified `packages/rn-tester/RNTester-macOS/ViewController.m` adding `[rootView setFrameOrigin:(NSPoint){0,-100}];` at the end of `viewDidLoad`.

In the "Pressable" page, click on the first "Press Me" button and notice that it correctly changes to "Pressed!" back to "Press Me" if the mouse is dragged out of the Pressable.  The various Touchable pages and other pages were tested
