### PR TITLE
Remove OS check in RCTMultiPartDataTask.m #1600

### DIFF
--- a/React/Base/RCTMultipartDataTask.m
+++ b/React/Base/RCTMultipartDataTask.m
@@ -11,24 +11,6 @@
 
 @end
 
-// We need this ugly runtime check because [streamTask captureStreams] below fails on iOS version
-// earlier than 9.0. Unfortunately none of the proper ways of checking worked:
-//
-// - NSURLSessionStreamTask class is available and is not Null on iOS 8
-// - [[NSURLSessionStreamTask new] respondsToSelector:@selector(captureStreams)] is always NO
-// - The instance we get in URLSession:dataTask:didBecomeStreamTask: is of __NSCFURLLocalStreamTaskFromDataTask
-//   and it responds to captureStreams on iOS 9+ but doesn't on iOS 8. Which means we can't get direct access
-//   to the streams on iOS 8 and at that point it's too late to change the behavior back to dataTask
-// - The compile-time #ifdef's can't be used because an app compiled for iOS8 can still run on iOS9
-
-static BOOL isStreamTaskSupported() {
-#if !TARGET_OS_OSX // [macOS]
-  return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9,0,0}];
-#else // [macOS
-  return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10,11,0}];
-#endif // macOS]
-}
-
 @implementation RCTMultipartDataTask {
   NSURL *_url;
   RCTMultipartDataTaskCallback _partHandler;


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This was already removed from facebook/react-native early 2019: https://github.com/facebook/react-native/commit/06c6c7c673682629073dbcb3811b6a6806253a74#diff-02c60e5ee54665cfda52b1e88843db83a725867cd8404959fd328adaa6391c7b

It is not linked anywhere in the code at this time

## Changelog

[macOS] [Removed] - Remove OS check in RCTMultiPartDataTask.m

## Test Plan

Compiled and ran rn-tester locally
