### PR TITLE
Fix compilation error in Schedule.cpp when building for rn-iOS + Fabric

### DIFF
--- a/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -61,7 +61,7 @@ Scheduler::Scheduler(
       contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
           "RuntimeScheduler");
   auto runtimeScheduler =
-      (enableCallImmediates && weakRuntimeScheduler.hasValue())
+      (enableCallImmediates && weakRuntimeScheduler.has_value())
       ? weakRuntimeScheduler.value().lock()
       : nullptr;
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Due to an early cherry-pick from a more recent facebook/react-native version > https://github.com/microsoft/react-native-macos/pull/1498 this broke.

In https://github.com/microsoft/react-native-macos/pull/1498 I must have only build for rn-iOS + Paper. I think we need a CircleCI job now for rn-iOS + Fabric

Here is the fix.
- std::optional's function signature is has_value()
- where as folly::Optional used hasValue()

## Changelog

[macOS] [Fixed] - Fix compilation error in Schedule.cpp when building for rn-iOS + Fabric

## Test Plan

In packages/rn-tester I ran:
```
USE_FABRIC=1 pod install
```
And then build and launched the app

<img width="1592" alt="Screenshot 2023-01-12 at 10 11 28 AM" src="https://user-images.githubusercontent.com/484044/212026790-763f33e3-47e7-47b0-a9b6-2014b9bdec20.png">

