### PR TITLE
Add ScrollView Indicator Overlay style

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -481,6 +481,12 @@ export type Props = $ReadOnly<{|
    */
   horizontal?: ?boolean,
   /**
+   * When true, the scroll view's inidicator style is an overlay
+   * that does not take up content view space
+   * https://developer.apple.com/documentation/appkit/nsscrollerstyle/nsscrollerstyleoverlay
+   */
+  hasOverlayStyleIndicator?: ?boolean,
+  /**
    * If sticky headers should stick at the bottom instead of the top of the
    * ScrollView. This is usually used with inverted ScrollViews.
    */

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -481,11 +481,11 @@ export type Props = $ReadOnly<{|
    */
   horizontal?: ?boolean,
   /**
-   * When true, the scroll view's inidicator style is an overlay
-   * that does not take up content view space
-   * https://developer.apple.com/documentation/appkit/nsscrollerstyle/nsscrollerstyleoverlay
+   * When true, the scroll view's indicator is shown in an overlay. // [macOS
+   * This does does not take up any content view space.
+   * https://developer.apple.com/documentation/appkit/nsscrollerstyle/nsscrollerstyleoverlay // macOS]
    */
-  hasOverlayStyleIndicator?: ?boolean,
+  hasOverlayStyleIndicator?: ?boolean, // [macOS]
   /**
    * If sticky headers should stick at the bottom instead of the top of the
    * ScrollView. This is usually used with inverted ScrollViews.

--- a/Libraries/Components/ScrollView/ScrollViewViewConfig.js
+++ b/Libraries/Components/ScrollView/ScrollViewViewConfig.js
@@ -46,6 +46,7 @@ const ScrollViewViewConfig = {
     fadingEdgeLength: true,
     indicatorStyle: true,
     inverted: true,
+    hasOverlayStyleIndicator: true,
     keyboardDismissMode: true,
     maintainVisibleContentPosition: true,
     maximumZoomScale: true,

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -55,7 +55,7 @@
 @property (nonatomic, assign) BOOL snapToEnd;
 @property (nonatomic, copy) NSString *snapToAlignment;
 @property (nonatomic, assign) BOOL inverted;
-@property (nonatomic, assign) BOOL hasOverlayStyleIndicator;
+@property (nonatomic, assign) BOOL hasOverlayStyleIndicator; // [macOS]
 
 // NOTE: currently these event props are only declared so we can export the
 // event names to JS - we don't call the blocks directly because scroll events

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -55,6 +55,7 @@
 @property (nonatomic, assign) BOOL snapToEnd;
 @property (nonatomic, copy) NSString *snapToAlignment;
 @property (nonatomic, assign) BOOL inverted;
+@property (nonatomic, assign) BOOL hasOverlayStyleIndicator;
 
 // NOTE: currently these event props are only declared so we can export the
 // event names to JS - we don't call the blocks directly because scroll events

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -541,6 +541,15 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     _onInvertedDidChange(@{});
   }
 }
+
+- (void)setHasOverlayStyleIndicator:(BOOL)hasOverlayStyle
+{
+  if (hasOverlayStyle == true) {
+    self.scrollView.scrollerStyle = NSScrollerStyleOverlay;
+  } else {
+    self.scrollView.scrollerStyle = NSScrollerStyleLegacy;
+  }
+}
 #endif // macOS]
 
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -102,7 +102,7 @@ RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_OSX_VIEW_PROPERTY(onInvertedDidChange, RCTDirectEventBlock) // [macOS]
 RCT_EXPORT_OSX_VIEW_PROPERTY(onPreferredScrollerStyleDidChange, RCTDirectEventBlock) // [macOS]
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(hasOverlayStyleIndicator, BOOL)
+RCT_EXPORT_OSX_VIEW_PROPERTY(hasOverlayStyleIndicator, BOOL)
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustsScrollIndicatorInsets, BOOL)
 #endif

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -102,6 +102,7 @@ RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_OSX_VIEW_PROPERTY(onInvertedDidChange, RCTDirectEventBlock) // [macOS]
 RCT_EXPORT_OSX_VIEW_PROPERTY(onPreferredScrollerStyleDidChange, RCTDirectEventBlock) // [macOS]
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(hasOverlayStyleIndicator, BOOL)
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustsScrollIndicatorInsets, BOOL)
 #endif

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -500,6 +500,14 @@ if (Platform.OS === 'macos') {
     render: function (): React.Node {
       return <InvertedContentExample />;
     },
+  },
+  {
+    title: '<ScrollView> (hasOverlayStyleIndicator = true/false)\n',
+    description:
+      "You can display <ScrollView>'s indicator using overlay style",
+    render: function (): React.Node {
+      return <ScrollIndicatorOverlayExample />;
+    },
   });
 }
 
@@ -529,6 +537,27 @@ const InvertedContentExample = () => {
         }}
       />
     </>
+  );
+};
+
+const ScrollIndicatorOverlayExample = () => {
+  const [hasOverlayStyleIndicator, setHasOverlayStyleIndicator] = useState(true);
+  return (
+    <View>
+      <ScrollView
+        style={[styles.scrollView, {height: 200}]}
+        hasOverlayStyleIndicator={hasOverlayStyleIndicator}
+        nestedScrollEnabled>
+        {ITEMS.map(createItemRow)}
+      </ScrollView>
+      <Button
+        label={
+          'showsOverlayStyleIndicator: ' +
+          hasOverlayStyleIndicator.toString()
+        }
+        onPress={() => setHasOverlayStyleIndicator(!hasOverlayStyleIndicator)}
+      />
+    </View>
   );
 };
 // macOS]

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -493,22 +493,24 @@ exports.examples = examples;
 
 // [macOS
 if (Platform.OS === 'macos') {
-  examples.push({
-    title: '<ScrollView> (inverted = true/false)\n',
-    description:
-      "You can display <ScrollView>'s child components in inverted order",
-    render: function (): React.Node {
-      return <InvertedContentExample />;
+  examples.push(
+    {
+      title: '<ScrollView> (inverted = true/false)\n',
+      description:
+        "You can display <ScrollView>'s child components in inverted order",
+      render: function (): React.Node {
+        return <InvertedContentExample />;
+      },
     },
-  },
-  {
-    title: '<ScrollView> (hasOverlayStyleIndicator = true/false)\n',
-    description:
-      "You can display <ScrollView>'s indicator using overlay style",
-    render: function (): React.Node {
-      return <ScrollIndicatorOverlayExample />;
+    {
+      title: '<ScrollView> (hasOverlayStyleIndicator = true/false)\n',
+      description:
+        "You can display <ScrollView>'s indicator using overlay style",
+      render: function (): React.Node {
+        return <ScrollIndicatorOverlayExample />;
+      },
     },
-  });
+  );
 }
 
 const InvertedContentExample = () => {
@@ -541,7 +543,8 @@ const InvertedContentExample = () => {
 };
 
 const ScrollIndicatorOverlayExample = () => {
-  const [hasOverlayStyleIndicator, setHasOverlayStyleIndicator] = useState(true);
+  const [hasOverlayStyleIndicator, setHasOverlayStyleIndicator] =
+    useState(true);
   return (
     <View>
       <ScrollView
@@ -552,8 +555,7 @@ const ScrollIndicatorOverlayExample = () => {
       </ScrollView>
       <Button
         label={
-          'showsOverlayStyleIndicator: ' +
-          hasOverlayStyleIndicator.toString()
+          'showsOverlayStyleIndicator: ' + hasOverlayStyleIndicator.toString()
         }
         onPress={() => setHasOverlayStyleIndicator(!hasOverlayStyleIndicator)}
       />


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

NSScrollView can have overlay style explicitly set.
https://developer.apple.com/documentation/appkit/nsscrollerstyle/nsscrollerstyleoverlay

Overlay style will **not** take up any space in the ContentView so content can be flush with insets.

Default uses the legacy style, not the overlay.

## Changelog

[macOS] [ADDED] - Add ScrollView Indicator Overlay style 

## Test Plan

Overlay style can be enable/disabled 

https://user-images.githubusercontent.com/96719/213046667-0b09b0f9-a0ad-4758-9ad8-7dfefa729d71.mp4


