### PR TITLE
[Cherry-pick] Delete RuntimeScheduler yielding mobile config

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -289,8 +289,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   auto weakRuntimeScheduler = _contextContainer->find<std::weak_ptr<RuntimeScheduler>>("RuntimeScheduler");
   auto runtimeScheduler = weakRuntimeScheduler.has_value() ? weakRuntimeScheduler.value().lock() : nullptr;
   if (runtimeScheduler) {
-    runtimeScheduler->setEnableYielding(
-        reactNativeConfig->getBool("react_native_new_architecture:runtimescheduler_enable_yielding_ios"));
     runtimeExecutor = [runtimeScheduler](std::function<void(jsi::Runtime & runtime)> &&callback) {
       runtimeScheduler->scheduleWork(std::move(callback));
     };

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.cpp
@@ -388,8 +388,6 @@ void Binding::installFabricUIManager(
   if (runtimeSchedulerHolder) {
     auto runtimeScheduler = runtimeSchedulerHolder->cthis()->get().lock();
     if (runtimeScheduler) {
-      runtimeScheduler->setEnableYielding(config->getBool(
-          "react_native_new_architecture:runtimescheduler_enable_yielding_android"));
       runtimeExecutor =
           [runtimeScheduler](
               std::function<void(jsi::Runtime & runtime)> &&callback) {

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -65,10 +65,6 @@ RuntimeSchedulerTimePoint RuntimeScheduler::now() const noexcept {
   return now_();
 }
 
-void RuntimeScheduler::setEnableYielding(bool enableYielding) {
-  enableYielding_ = enableYielding;
-}
-
 void RuntimeScheduler::executeNowOnTheSameThread(
     std::function<void(jsi::Runtime &runtime)> callback) {
   runtimeAccessRequests_ += 1;

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -144,15 +144,6 @@ class RuntimeScheduler final {
   mutable std::atomic_bool isWorkLoopScheduled_{false};
 
   /*
-   * Flag indicating if yielding is enabled.
-   *
-   * If set to true and Concurrent Mode is enabled on the surface,
-   * React Native will ask React to yield in case any work has been scheduled.
-   * Default value is false
-   */
-  bool enableYielding_{false};
-
-  /*
    * This flag is set while performing work, to prevent re-entrancy.
    */
   mutable std::atomic_bool isPerformingWork_{false};

--- a/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -325,7 +325,7 @@ TEST_F(RuntimeSchedulerTest, scheduleWork) {
 
   EXPECT_FALSE(wasCalled);
 
-  EXPECT_FALSE(runtimeScheduler_->getShouldYield());
+  EXPECT_TRUE(runtimeScheduler_->getShouldYield());
 
   EXPECT_EQ(stubQueue_->size(), 1);
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Building fabric for iOS is broken.
![CleanShot 2023-01-18 at 06 39 03](https://user-images.githubusercontent.com/96719/213208654-77eb59ad-6828-4edd-8e0f-668088071b01.jpg)

3552ff056263cd2d77224b909cc6fc2f81ad66cf removed experimental feature. 
Upstream change to fix Fabric builds on iOS

## Changelog

[macOS] [CHANGED] -  Delete RuntimeScheduler yielding mobile config

## Test Plan

App builds w/ Fabric enabled: `USE_FABRIC=1 bundle exec pod install`
![CleanShot 2023-01-18 at 07 10 40](https://user-images.githubusercontent.com/96719/213208216-290318b5-130f-4cfd-b633-6ed69337a5bd.jpg)
