### PR TITLE
[Fabric] Fix NativeComponentExample not rendering on Fabric

### DIFF
--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -29,6 +29,22 @@ const colors = [
 export default function MyNativeView(props: {}): React.Node {
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
+  const [isFabric, setIsFabric] = useState<boolean>(false);
+
+  const callbackRef = (ref: React.ElementRef<typeof View> | null): void => {
+    if (ref == null) {
+      return;
+    }
+    // Avoid dot notation because at Meta, private properties are obfuscated.
+    // $FlowFixMe[prop-missing]
+    const _internalInstanceHandler = ref['_internalInstanceHandle']; // eslint-disable-line dot-notation
+    setIsFabric(Boolean(_internalInstanceHandler?.stateNode?.canonical));
+  };
+
+  if (!isFabric) {
+    return <View ref={callbackRef} />
+  }
+
   return (
     <View style={{flex: 1}}>
       <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -29,53 +29,34 @@ const colors = [
 export default function MyNativeView(props: {}): React.Node {
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
-  // [macOS Use this "hack" to only render this example if Fabric is enabled and allow CI to pass
-  // Fabric Detection
-  const isFabric =
-    !!(
-      // An internal transform mangles variables with leading "_" as private.
-      // $FlowFixMe
-      ref._internalInstanceHandle?.stateNode?.canonical
-    );
-  if (isFabric) {
-    return null;
-  }
-  // macOS]
-
-  // [macOS
   return (
     <View style={{flex: 1}}>
-      {isFabric && (
-        <>
-          <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />
-          <Button
-            title="Change Background"
-            onPress={() => {
-              if (ref.current) {
-                RNTMyNativeViewCommands.callNativeMethodToChangeBackgroundColor(
-                  ref.current,
-                  colors[Math.floor(Math.random() * 5)],
-                );
-              }
-            }}
-          />
-          <Button
-            title="Set Opacity"
-            onPress={() => {
-              setOpacity(Math.random());
-            }}
-          />
-          <Button
-            title="Console.log Measure"
-            onPress={() => {
-              ref.current?.measure((x, y, width, height) => {
-                console.log(x, y, width, height);
-              });
-            }}
-          />
-        </>
-      )}
+      <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />
+      <Button
+        title="Change Background"
+        onPress={() => {
+          if (ref.current) {
+            RNTMyNativeViewCommands.callNativeMethodToChangeBackgroundColor(
+              ref.current,
+              colors[Math.floor(Math.random() * 5)],
+            );
+          }
+        }}
+      />
+      <Button
+        title="Set Opacity"
+        onPress={() => {
+          setOpacity(Math.random());
+        }}
+      />
+      <Button
+        title="Console.log Measure"
+        onPress={() => {
+          ref.current?.measure((x, y, width, height) => {
+            console.log(x, y, width, height);
+          });
+        }}
+      />
     </View>
-    // macOS]
   );
 }

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -29,8 +29,10 @@ const colors = [
 export default function MyNativeView(props: {}): React.Node {
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
-  const [isFabric, setIsFabric] = useState<boolean>(false);
 
+  // [macOS Use this "hack" to only render this example if Fabric is enabled and allow CI to pass
+  // Fabric Detection
+  const [isFabric, setIsFabric] = useState<boolean>(false);
   const callbackRef = (ref: React.ElementRef<typeof View> | null): void => {
     if (ref == null) {
       return;
@@ -42,8 +44,9 @@ export default function MyNativeView(props: {}): React.Node {
   };
 
   if (!isFabric) {
-    return <View ref={callbackRef} />
+    return <View ref={callbackRef} />;
   }
+  // macOS]
 
   return (
     <View style={{flex: 1}}>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

The `NativeComponentExample` is currently not rendering when building for fabric on iOS.

`ref._internalInstanceHandle?.stateNode?.canonical` is undefined.
https://github.com/microsoft/react-native-macos/blob/main/packages/rn-tester/NativeComponentExample/js/MyNativeView.js#L38

Upstreamed the latest `MyNativeView.js` from https://github.com/facebook/react-native/blob/main/packages/rn-tester/NativeComponentExample/js/MyNativeView.js

## Changelog

[macOS][Fabric] - Fix NativeComponentExample to render correctly

## Test Plan
 
**Before**

https://user-images.githubusercontent.com/96719/213311648-2b5641cd-7754-4048-8808-2ee6f5f061e9.mp4

**After**

https://user-images.githubusercontent.com/96719/213311320-097131ab-1978-4376-951f-76fc20c70460.mp4

