### PR TITLE
GH#1395 Fixes caret changing sizes if text field is empty

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -124,6 +124,9 @@
 #if TARGET_OS_OSX // [macOS
   [self setAttributedText:[[NSAttributedString alloc] initWithString:[self text]
                                                           attributes:[self defaultTextAttributes]]];
+  if([[self text] length] == 0) {
+    self.font = [[self defaultTextAttributes] objectForKey:NSFontAttributeName];
+  }
 #endif // macOS]
 }
 
@@ -322,6 +325,8 @@
 #if TARGET_OS_OSX // [macOS
   [self setAttributedText:[[NSAttributedString alloc] initWithString:[self text]
                                                           attributes:[self defaultTextAttributes]]];
+
+  self.font = [[self defaultTextAttributes] objectForKey:NSFontAttributeName];
 #endif // macOS]
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Takes care of [#1395](https://github.com/microsoft/react-native-macos/issues/1395)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fixes caret changing sizes if text field is empty

## Test Plan

Set a larger font size on a single line text field and watch the caret change sizes when the field is empty
