### PR TITLE
[Fabric] Shim RCTFabricModalHostViewControllerDelegate

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.h
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.h
@@ -15,6 +15,8 @@
 
 @property (nonatomic, weak) id<RCTFabricModalHostViewControllerDelegate> delegate;
 
+#if !TARGET_OS_OSX // [macOS]
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientations;
+#endif // [macOS]
 
 @end

--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -32,6 +32,7 @@
   return self;
 }
 
+#if !TARGET_OS_OSX // [macOS]
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
@@ -81,5 +82,6 @@
   return _supportedInterfaceOrientations;
 }
 #endif // RCT_DEV
+#endif // [macOS]
 
 @end

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -268,7 +268,6 @@ using namespace facebook::react;
   return paragraphProps.isSelectable;
 }
 
-#if !TARGET_OS_OSX
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   auto const &paragraphProps = *std::static_pointer_cast<ParagraphProps const>(_props);
@@ -276,13 +275,13 @@ using namespace facebook::react;
   if (paragraphProps.isSelectable && action == @selector(copy:)) {
     return YES;
   }
+
 #if !TARGET_OS_OSX // [macOS]
   return [self.nextResponder canPerformAction:action withSender:sender];
 #else  // [macOS
   return NO;
 #endif // macOS]
 }
-#endif // [macOS]
 
 - (void)copy:(id)sender
 {

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -268,7 +268,7 @@ using namespace facebook::react;
   return paragraphProps.isSelectable;
 }
 
-#if !TARGET_OS_OSX // [macOS]
+#if !TARGET_OS_OSX  
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   auto const &paragraphProps = *std::static_pointer_cast<ParagraphProps const>(_props);
@@ -276,8 +276,11 @@ using namespace facebook::react;
   if (paragraphProps.isSelectable && action == @selector(copy:)) {
     return YES;
   }
-
+#if !TARGET_OS_OSX // [macOS]
   return [self.nextResponder canPerformAction:action withSender:sender];
+#else  // [macOS
+  return NO;
+#endif // macOS]
 }
 #endif // [macOS]
 

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -268,7 +268,7 @@ using namespace facebook::react;
   return paragraphProps.isSelectable;
 }
 
-#if !TARGET_OS_OSX  
+#if !TARGET_OS_OSX
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   auto const &paragraphProps = *std::static_pointer_cast<ParagraphProps const>(_props);


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Shim RCTFabricModalHostViewControllerDelegate to work w/ Fabric

closes #1558 

## Changelog

[macOS][Added] - Shim RCTFabricModalHostViewControllerDelegate for Fabric

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTFabricModalHostViewControllerDelegate errors
![CleanShot 2023-01-20 at 15 41 01](https://user-images.githubusercontent.com/96719/213828282-0d81f4dc-4909-48f6-a8ef-466fdda427e4.jpg)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2023-01-20 at 15 06 36](https://user-images.githubusercontent.com/96719/213828293-f8030a48-a10a-4116-9b85-797ca1b1bb1f.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2023-01-20 at 16 03 53](https://user-images.githubusercontent.com/96719/213828300-34ab42d5-992b-4c58-b044-5dd383ffd7d2.jpg)

[x] Build RNTester - iOS w/ Paper -
![CleanShot 2023-01-20 at 16 11 30](https://user-images.githubusercontent.com/96719/213828312-90084542-da8e-415c-b366-5878e8782716.jpg)

