### PR TITLE
[Fabric] Shim RCTSwitchComponentView

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -34,9 +34,16 @@ using namespace facebook::react;
 
     _switchView = [[RCTUISwitch alloc] initWithFrame:self.bounds]; // [macOS]
 
+#if !TARGET_OS_OSX // [macOS]
     [_switchView addTarget:self action:@selector(onChange:) forControlEvents:UIControlEventValueChanged];
+#endif
 
+#if !TARGET_OS_OSX // [macOS]
     self.contentView = _switchView;
+#else // [macOS
+    self.contentView = [[RCTUIView alloc] initWithFrame:frame];
+    [self.contentView addSubview:_switchView];
+#endif // macOS]
   }
 
   return self;
@@ -72,6 +79,7 @@ using namespace facebook::react;
     _switchView.enabled = !newSwitchProps.disabled;
   }
 
+#if !TARGET_OS_OSX // [macOS]
   // `tintColor`
   if (oldSwitchProps.tintColor != newSwitchProps.tintColor) {
     _switchView.tintColor = RCTUIColorFromSharedColor(newSwitchProps.tintColor);
@@ -86,6 +94,7 @@ using namespace facebook::react;
   if (oldSwitchProps.thumbTintColor != newSwitchProps.thumbTintColor) {
     _switchView.thumbTintColor = RCTUIColorFromSharedColor(newSwitchProps.thumbTintColor);
   }
+#endif
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -36,7 +36,7 @@ using namespace facebook::react;
 
 #if !TARGET_OS_OSX // [macOS]
     [_switchView addTarget:self action:@selector(onChange:) forControlEvents:UIControlEventValueChanged];
-#endif
+#endif // [macOS]
 
 #if !TARGET_OS_OSX // [macOS]
     self.contentView = _switchView;
@@ -94,7 +94,7 @@ using namespace facebook::react;
   if (oldSwitchProps.thumbTintColor != newSwitchProps.thumbTintColor) {
     _switchView.thumbTintColor = RCTUIColorFromSharedColor(newSwitchProps.thumbTintColor);
   }
-#endif
+#endif // [macOS]
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -82,17 +82,17 @@ using namespace facebook::react;
 #if !TARGET_OS_OSX // [macOS]
   // `tintColor`
   if (oldSwitchProps.tintColor != newSwitchProps.tintColor) {
-    _switchView.tintColor = RCTUIColorFromSharedColor(newSwitchProps.tintColor);
+    _switchView.tintColor = RCTUIColorFromSharedColor(newSwitchProps.tintColor); // [macOS]
   }
 
   // `onTintColor
   if (oldSwitchProps.onTintColor != newSwitchProps.onTintColor) {
-    _switchView.onTintColor = RCTUIColorFromSharedColor(newSwitchProps.onTintColor);
+    _switchView.onTintColor = RCTUIColorFromSharedColor(newSwitchProps.onTintColor); // [macOS]
   }
 
   // `thumbTintColor`
   if (oldSwitchProps.thumbTintColor != newSwitchProps.thumbTintColor) {
-    _switchView.thumbTintColor = RCTUIColorFromSharedColor(newSwitchProps.thumbTintColor);
+    _switchView.thumbTintColor = RCTUIColorFromSharedColor(newSwitchProps.thumbTintColor); // [macOS]
   }
 #endif // [macOS]
 


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Shim RCTSwitchComponentView to work w/ Fabric

closes #1559 

## Changelog

[macOS][Added] - Shim RCTSwitchComponentView for Fabric

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTSwitchComponentView errors
![CleanShot 2023-01-20 at 17 16 32](https://user-images.githubusercontent.com/96719/213831790-aed7ef09-ca82-443a-8341-f03bc671c1fb.jpg)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2023-01-20 at 17 19 50](https://user-images.githubusercontent.com/96719/213831798-b293da6d-5fe9-4660-8707-d3d1460f03d8.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2023-01-20 at 17 23 57](https://user-images.githubusercontent.com/96719/213831905-ebdabf8c-c7d1-4d94-8f26-84ce17af0a61.jpg)

[x] Build RNTester - iOS w/ Paper -
![CleanShot 2023-01-20 at 17 26 55](https://user-images.githubusercontent.com/96719/213832004-8fa3d042-941d-4987-adb2-c48851badfad.jpg)

