### PR TITLE
[Fabric] Shim missing properties + font name

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -67,7 +67,9 @@ static RCTUIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWith
   if (self.window && !_textInput) {
     if (self.nativeId) {
       _textInput = RCTFindTextInputWithNativeId(self.window, self.nativeId);
+#if !TARGET_OS_OSX // [macOS]
       _textInput.inputAccessoryView = _contentView;
+#endif // [macOS]
     } else {
       _textInput = RCTFindTextInputWithNativeId(_contentView, nil);
     }

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -103,16 +103,20 @@ using namespace facebook::react;
     } else {
       // Note: Changing `frame` when `layer.transform` is not the `identity transform` is undefined behavior.
       // Therefore, we must use `center` and `bounds`.
+#if !TARGET_OS_OSX // [macOS]
       self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
+#endif // [macOS]
       self.bounds = CGRect{CGPointZero, frame.size};
     }
   }
 
+#if !TARGET_OS_OSX // [macOS]
   if (forceUpdate || (layoutMetrics.layoutDirection != oldLayoutMetrics.layoutDirection)) {
     self.semanticContentAttribute = layoutMetrics.layoutDirection == LayoutDirection::RightToLeft
         ? UISemanticContentAttributeForceRightToLeft
         : UISemanticContentAttributeForceLeftToRight;
   }
+#endif // [macOS]
 
   if (forceUpdate || (layoutMetrics.displayType != oldLayoutMetrics.displayType)) {
     self.hidden = layoutMetrics.displayType == DisplayType::None;

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTFontUtils.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTFontUtils.mm
@@ -118,7 +118,11 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties)
     // the specific metrics of the standard system font as closely as possible.
     font = RCTDefaultFontWithFontProperties(fontProperties);
   } else {
+#if !TARGET_OS_OSX // [macOS]
     NSArray<NSString *> *fontNames = [UIFont fontNamesForFamilyName:fontProperties.family];
+#else // [macOS
+    NSArray<NSString *> *fontNames = @[];
+#endif // macOS]
 
     if (fontNames.count == 0) {
       // Gracefully handle being given a font name rather than font family, for


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Shim missing properties + font name to work w/ Fabric

closes #1562 #1563

## Changelog

[macOS][Added] - Shim missing properties + font name

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTFabricModalHostViewControllerDelegate errors
![CleanShot 2023-01-20 at 17 59 12](https://user-images.githubusercontent.com/96719/213836765-1bcffd23-8527-42c6-b2e6-cff060329b4f.jpg)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2023-01-20 at 17 56 38](https://user-images.githubusercontent.com/96719/213836774-04a6a24b-dbbb-4166-a198-84d0d28f10cf.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2023-01-20 at 18 06 21](https://user-images.githubusercontent.com/96719/213837998-ed19330f-544a-459a-98a7-2a71c0313916.jpg)

[x] Build RNTester - iOS w/ Paper - should work
![CleanShot 2023-01-20 at 18 09 23](https://user-images.githubusercontent.com/96719/213838622-f8e45272-bb46-4de7-bd82-3164345c6878.jpg)



