### PR TITLE
[Fabric] Shim RCTImage

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -358,7 +358,21 @@ CGSize RCTScreenSize()
 
   return size;
 }
-#endif // [macOS]
+#else // [macOS
+CGFloat RCTScreenScale()
+{
+  return [NSScreen mainScreen].backingScaleFactor;
+}
+
+CGFloat RCTFontSizeMultiplier() {
+  return 1.0;
+}
+
+CGSize RCTScreenSize()
+{
+  return [NSScreen mainScreen].frame.size;
+}
+#endif // macOS]
 
 #if !TARGET_OS_OSX // [macOS]
 CGSize RCTViewportSize()
@@ -385,6 +399,12 @@ CGFloat RCTFloorPixelValue(CGFloat value)
   return floor(value * scale) / scale;
 }
 #else // [macOS
+CGSize RCTViewportSize()
+{
+  NSScreen* screen = [NSScreen mainScreen];
+  return screen ? screen.frame.size : RCTScreenSize();
+}
+
 CGFloat RCTRoundPixelValue(CGFloat value, CGFloat scale)
 {
   return round(value * scale) / scale;

--- a/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -31,14 +31,21 @@ using namespace facebook::react;
     _props = defaultProps;
 
     _imageView = [RCTUIImageViewAnimated new];
+#if !TARGET_OS_OSX // [macOS]
     _imageView.clipsToBounds = YES;
     _imageView.contentMode = RCTContentModeFromImageResizeMode(defaultProps->resizeMode);
+#endif // [macOS]
     _imageView.layer.minificationFilter = kCAFilterTrilinear;
     _imageView.layer.magnificationFilter = kCAFilterTrilinear;
 
     _imageResponseObserverProxy = RCTImageResponseObserverProxy(self);
 
+#if !TARGET_OS_OSX // [macOS]
     self.contentView = _imageView;
+#else // [macOS
+    self.contentView = [RCTUIView new];
+    [self.contentView addSubview:_imageView];
+#endif // macOS]
   }
 
   return self;
@@ -56,6 +63,7 @@ using namespace facebook::react;
   auto const &oldImageProps = *std::static_pointer_cast<ImageProps const>(_props);
   auto const &newImageProps = *std::static_pointer_cast<ImageProps const>(props);
 
+#if !TARGET_OS_OSX // [macOS]
   // `resizeMode`
   if (oldImageProps.resizeMode != newImageProps.resizeMode) {
     _imageView.contentMode = RCTContentModeFromImageResizeMode(newImageProps.resizeMode);
@@ -65,6 +73,7 @@ using namespace facebook::react;
   if (oldImageProps.tintColor != newImageProps.tintColor) {
     _imageView.tintColor = RCTUIColorFromSharedColor(newImageProps.tintColor);
   }
+#endif // [macOS]
 
   [super updateProps:props oldProps:oldProps];
 }
@@ -132,6 +141,7 @@ using namespace facebook::react;
 
   const auto &imageProps = *std::static_pointer_cast<ImageProps const>(_props);
 
+#if !TARGET_OS_OSX // [macOS]
   if (imageProps.tintColor) {
     image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   }
@@ -144,6 +154,7 @@ using namespace facebook::react;
     image = [image resizableImageWithCapInsets:RCTUIEdgeInsetsFromEdgeInsets(imageProps.capInsets)
                                   resizingMode:UIImageResizingModeStretch];
   }
+#endif // [macOS]
 
   if (imageProps.blurRadius > __FLT_EPSILON__) {
     // Blur on a background thread to avoid blocking interaction.

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTViewComponentView.h"
+#import <QuartzCore/QuartzCore.h> // [macOS] - prevent compiler error on invocation of CAShapeLayer
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <QuartzCore/QuartzCore.h>
@@ -626,9 +627,14 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       CGRect contentsCenter = CGRect{
           CGPoint{imageCapInsets.left / imageSize.width, imageCapInsets.top / imageSize.height},
           CGSize{(CGFloat)1.0 / imageSize.width, (CGFloat)1.0 / imageSize.height}};
-
-      _borderLayer.contents = (id)image.CGImage;
-      _borderLayer.contentsScale = image.scale;
+        
+#if !TARGET_OS_OSX // [macOS]
+        _borderLayer.contents = (id)image.CGImage;
+        _borderLayer.contentsScale = image.scale;
+#else // [macOS
+        _borderLayer.contents = [image layerContentsForContentsScale:scaleFactor];
+        _borderLayer.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
+#endif // macOS]
 
       BOOL isResizable = !UIEdgeInsetsEqualToEdgeInsets(image.capInsets, UIEdgeInsetsZero);
       if (isResizable) {

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -6,7 +6,6 @@
  */
 
 #import "RCTViewComponentView.h"
-#import <QuartzCore/QuartzCore.h> // [macOS] - prevent compiler error on invocation of CAShapeLayer
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <QuartzCore/QuartzCore.h>

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -14,7 +14,7 @@
 #import <React/RCTAssert.h>
 #import <React/RCTBorderDrawing.h>
 #import <React/RCTConversions.h>
-#import <React/RCTUtils.h>
+#import <React/RCTUtils.h> // [macOS]
 #import <react/renderer/components/view/ViewComponentDescriptor.h>
 #import <react/renderer/components/view/ViewEventEmitter.h>
 #import <react/renderer/components/view/ViewProps.h>

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -15,6 +15,7 @@
 #import <React/RCTAssert.h>
 #import <React/RCTBorderDrawing.h>
 #import <React/RCTConversions.h>
+#import <React/RCTUtils.h>
 #import <react/renderer/components/view/ViewComponentDescriptor.h>
 #import <react/renderer/components/view/ViewEventEmitter.h>
 #import <react/renderer/components/view/ViewProps.h>
@@ -633,7 +634,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
         _borderLayer.contentsScale = image.scale;
 #else // [macOS
         _borderLayer.contents = [image layerContentsForContentsScale:scaleFactor];
-        _borderLayer.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
+        _borderLayer.contentsScale = RCTScreenScale();
 #endif // macOS]
 
       BOOL isResizable = !UIEdgeInsetsEqualToEdgeInsets(image.capInsets, UIEdgeInsetsZero);


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Shim RCTImage to work w/ Fabric

closes #1564 

## Changelog

[macOS][Added] - Shim RCTImage

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTImage errors
![CleanShot 2023-01-20 at 18 28 31](https://user-images.githubusercontent.com/96719/213839926-ca84dc84-6662-440b-8858-f33699551c55.jpg)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2023-01-20 at 18 25 30](https://user-images.githubusercontent.com/96719/213839899-6d9ec981-9425-4563-ae06-9379036230d8.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2023-01-20 at 18 33 08](https://user-images.githubusercontent.com/96719/213840076-1c961067-dfdf-491d-9481-d7a808fdc53e.jpg)

[x] Build RNTester - iOS w/ Paper - should work
![CleanShot 2023-01-20 at 18 35 49](https://user-images.githubusercontent.com/96719/213840149-f45283ce-5406-4e87-97cc-1e30744dbcb6.jpg)

