### PR TITLE
[Fabric] Shim RCTTextInput

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -30,7 +30,11 @@ using namespace facebook::react;
 
 @implementation RCTTextInputComponentView {
   TextInputShadowNode::ConcreteState::Shared _state;
-  RCTUIView<RCTBackedTextInputViewProtocol> *_backedTextInputView; // [macOS]
+#if !TARGET_OS_OSX // [macOS]
+  RCTUIView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
+#else // [macOS
+  RCTUITextView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
+#endif // macOS]
   NSUInteger _mostRecentEventCount;
   NSAttributedString *_lastStringStateWasUpdatedWith;
 
@@ -67,7 +71,11 @@ using namespace facebook::react;
     _props = defaultProps;
     auto &props = *defaultProps;
 
+#if !TARGET_OS_OSX // [macOS]
     _backedTextInputView = props.traits.multiline ? [RCTUITextView new] : [RCTUITextField new];
+#else // [macOS
+    _backedTextInputView = [RCTUITextView new];
+#endif // macOS]
     _backedTextInputView.textInputDelegate = self;
     _ignoreNextTextInputCall = NO;
     _comingFromJS = NO;
@@ -478,25 +486,23 @@ using namespace facebook::react;
 
 - (void)setDefaultInputAccessoryView
 {
+#if !TARGET_OS_OSX // [macOS]
   // InputAccessoryView component sets the inputAccessoryView when inputAccessoryViewID exists
   if (_backedTextInputView.inputAccessoryViewID) {
     if (_backedTextInputView.isFirstResponder) {
-#if !TARGET_OS_OSX // [macOS]
       [_backedTextInputView reloadInputViews];
-#endif // [macOS]
     }
     return;
   }
 
-#if !TARGET_OS_OSX // [macOS]
   UIKeyboardType keyboardType = _backedTextInputView.keyboardType;
 
   // These keyboard types (all are number pads) don't have a "Done" button by default,
   // so we create an `inputAccessoryView` with this button for them.
   BOOL shouldHaveInputAccesoryView =
-      (keyboardType == UIKeyboardTypeNumberPad || keyboardType == UIKeyboardTypePhonePad ||
-       keyboardType == UIKeyboardTypeDecimalPad || keyboardType == UIKeyboardTypeASCIICapableNumberPad) &&
-      _backedTextInputView.returnKeyType == UIReturnKeyDone;
+  (keyboardType == UIKeyboardTypeNumberPad || keyboardType == UIKeyboardTypePhonePad ||
+   keyboardType == UIKeyboardTypeDecimalPad || keyboardType == UIKeyboardTypeASCIICapableNumberPad) &&
+  _backedTextInputView.returnKeyType == UIReturnKeyDone;
 
   if ((_backedTextInputView.inputAccessoryView != nil) == shouldHaveInputAccesoryView) {
     return;
@@ -506,32 +512,30 @@ using namespace facebook::react;
     UIToolbar *toolbarView = [UIToolbar new];
     [toolbarView sizeToFit];
     UIBarButtonItem *flexibleSpace =
-        [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+    [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     UIBarButtonItem *doneButton =
-        [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
-                                                      target:self
-                                                      action:@selector(handleInputAccessoryDoneButton)];
+    [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                  target:self
+                                                  action:@selector(handleInputAccessoryDoneButton)];
     toolbarView.items = @[ flexibleSpace, doneButton ];
     _backedTextInputView.inputAccessoryView = toolbarView;
   } else {
     _backedTextInputView.inputAccessoryView = nil;
   }
-#endif // [macOS]
-
+  
   if (_backedTextInputView.isFirstResponder) {
-#if !TARGET_OS_OSX // [macOS]
     [_backedTextInputView reloadInputViews];
-#endif // [macOS]
   }
+#endif // [macOS]
 }
 
 - (void)handleInputAccessoryDoneButton
 {
-  if ([self textInputShouldReturn]) {
 #if !TARGET_OS_OSX // [macOS]
+  if ([self textInputShouldReturn]) {
     [_backedTextInputView endEditing:YES];
-#endif // [macOS]
   }
+#endif // [macOS]
 }
 
 #pragma mark - Other
@@ -633,7 +637,11 @@ using namespace facebook::react;
 - (void)_setMultiline:(BOOL)multiline
 {
   [_backedTextInputView removeFromSuperview];
-  RCTUIView<RCTBackedTextInputViewProtocol> *backedTextInputView = multiline ? [RCTUITextView new] : [RCTUITextField new]; // [macOS]
+#if !TARGET_OS_OSX // [macOS]
+  RCTUIView<RCTBackedTextInputViewProtocol> *backedTextInputView = multiline ? [RCTUITextView new] : [RCTUITextField new];
+#else // [macOS
+  RCTUITextView<RCTBackedTextInputViewProtocol> *backedTextInputView = [RCTUITextView new];
+#endif // macOS]
   backedTextInputView.frame = _backedTextInputView.frame;
   RCTCopyBackedTextInput(_backedTextInputView, backedTextInputView);
   _backedTextInputView = backedTextInputView;
@@ -663,17 +671,19 @@ using namespace facebook::react;
                    }];
 
   BOOL shouldFallbackToBareTextComparison =
-      [_backedTextInputView.textInputMode.primaryLanguage isEqualToString:@"dictation"] ||
 #if !TARGET_OS_OSX // [macOS]
-      [_backedTextInputView.textInputMode.primaryLanguage isEqualToString:@"ko-KR"] ||
-      _backedTextInputView.markedTextRange || _backedTextInputView.isSecureTextEntry || fontHasBeenUpdatedBySystem;
+  [_backedTextInputView.textInputMode.primaryLanguage isEqualToString:@"dictation"] ||
+  [_backedTextInputView.textInputMode.primaryLanguage isEqualToString:@"ko-KR"] ||
+  _backedTextInputView.markedTextRange ||
+  _backedTextInputView.isSecureTextEntry ||
 #else // [macOS
-    // There are multiple Korean input sources (2-Set, 3-Set, etc). Check substring instead instead
-    [[[self.backedTextInputView inputContext] selectedKeyboardInputSource] containsString:@"com.apple.inputmethod.Korean"] ||
-    [self.backedTextInputView hasMarkedText] ||
-    [self.backedTextInputView isKindOfClass:[NSSecureTextField class]] ||
-    fontHasBeenUpdatedBySystem;
+  // There are multiple Korean input sources (2-Set, 3-Set, etc). Check substring instead instead
+  [[[_backedTextInputView inputContext] selectedKeyboardInputSource] containsString:@"com.apple.inputmethod.Korean"] ||
+  [_backedTextInputView hasMarkedText] ||
+  [_backedTextInputView isKindOfClass:[NSSecureTextField class]] ||
 #endif // macOS]
+  fontHasBeenUpdatedBySystem;
+
   if (shouldFallbackToBareTextComparison) {
     return ([newText.string isEqualToString:oldText.string]);
   } else {

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
@@ -4,10 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+#import <optional>
 
 #import <React/RCTUIKit.h> // [macOS]
-
-#import <optional>
+#import <React/RCTUITextField.h> // [macOS]
+#import <React/RCTUITextView.h> // [macOS]
 
 #import <React/RCTBackedTextInputViewProtocol.h>
 #import <react/renderer/components/iostextinput/primitives.h>
@@ -15,10 +16,16 @@
 NS_ASSUME_NONNULL_BEGIN
 
 void RCTCopyBackedTextInput(
-    RCTUIView<RCTBackedTextInputViewProtocol> *fromTextInput, // [macOS]
-    RCTUIView<RCTBackedTextInputViewProtocol> *toTextInput); // [macOS]
+#if !TARGET_OS_OSX // [macOS]
+    RCTUIView<RCTBackedTextInputViewProtocol> *fromTextInput,
+    RCTUIView<RCTBackedTextInputViewProtocol> *toTextInput
+#else // [macOS
+    RCTUITextView<RCTBackedTextInputViewProtocol> *fromTextInput,
+    RCTUITextView<RCTBackedTextInputViewProtocol> *toTextInput
+#endif // macOS]
+);
 
-#if !TARGET_OS_OSX  // [macOS]
+#if !TARGET_OS_OSX // [macOS]
 UITextAutocorrectionType RCTUITextAutocorrectionTypeFromOptionalBool(std::optional<bool> autoCorrect);
 
 UITextAutocapitalizationType RCTUITextAutocapitalizationTypeFromAutocapitalizationType(
@@ -41,6 +48,6 @@ UITextContentType RCTUITextContentTypeFromString(std::string const &contentType)
 
 API_AVAILABLE(ios(12.0))
 UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(std::string const &passwordRules);
-#endif  // [macOS]
+#endif // [macOS]
 
 NS_ASSUME_NONNULL_END

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -19,8 +19,14 @@ static NSAttributedString *RCTSanitizeAttributedString(NSAttributedString *attri
 }
 
 void RCTCopyBackedTextInput(
+#if !TARGET_OS_OSX // [macOS]
     RCTUIView<RCTBackedTextInputViewProtocol> *fromTextInput,
-    RCTUIView<RCTBackedTextInputViewProtocol> *toTextInput) // [macOS]
+    RCTUIView<RCTBackedTextInputViewProtocol> *toTextInput
+#else // [macOS
+    RCTUITextView<RCTBackedTextInputViewProtocol> *fromTextInput,
+    RCTUITextView<RCTBackedTextInputViewProtocol> *toTextInput
+#endif // macOS]
+)
 {
   toTextInput.attributedText = RCTSanitizeAttributedString(fromTextInput.attributedText);
   toTextInput.placeholder = fromTextInput.placeholder;


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Shim RCTTextInput to work w/ Fabric

closes #1547 

## Changelog

[macOS][Added] - Shim RCTTextInput for Fabric

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTTextInput errors
![CleanShot 2023-01-23 at 16 51 43](https://user-images.githubusercontent.com/96719/214192183-21d242e6-9f36-423a-9aab-44256912807d.jpg)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2023-01-23 at 16 53 04](https://user-images.githubusercontent.com/96719/214192194-83d4b9b3-89fe-4d87-bfab-aa42d3a92a53.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2023-01-23 at 16 59 48](https://user-images.githubusercontent.com/96719/214192208-97803045-9090-43ca-881a-73c8a242312a.jpg)

[x] Build RNTester - iOS w/ Paper -
![CleanShot 2023-01-23 at 16 58 23](https://user-images.githubusercontent.com/96719/214192220-905d1b35-aad9-46f9-8051-3dd7e53272a6.jpg)

