### PR TITLE
[Fabric] Shim RCTComponentViewDescriptor

### DIFF
--- a/React/Fabric/Mounting/RCTComponentViewDescriptor.h
+++ b/React/Fabric/Mounting/RCTComponentViewDescriptor.h
@@ -22,7 +22,7 @@ class RCTComponentViewDescriptor final {
    * Associated (and owned) native view instance.
    */
   __strong RCTUIView<RCTComponentViewProtocol> *view = nil; // [macOS]
-  NSInteger tag = 0; // default is 0 // [macOS]
+  NSInteger tag = 0; // [macOS] default is 0
   /*
    * Indicates a requirement to call on the view methods from
    * `RCTMountingTransactionObserving` protocol.

--- a/React/Fabric/Mounting/RCTComponentViewDescriptor.h
+++ b/React/Fabric/Mounting/RCTComponentViewDescriptor.h
@@ -22,7 +22,7 @@ class RCTComponentViewDescriptor final {
    * Associated (and owned) native view instance.
    */
   __strong RCTUIView<RCTComponentViewProtocol> *view = nil; // [macOS]
-
+  NSInteger tag = 0; // default is 0 // [macOS]
   /*
    * Indicates a requirement to call on the view methods from
    * `RCTMountingTransactionObserving` protocol.

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -83,7 +83,11 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
       @"RCTComponentViewRegistry: Attempt to dequeue already registered component.");
 
   auto componentViewDescriptor = [self _dequeueComponentViewWithComponentHandle:componentHandle];
+#if !TARGET_OS_OSX // [macOS]
   componentViewDescriptor.view.tag = tag;
+#else // [macOS
+  componentViewDescriptor.tag = tag;
+#endif // macOS]
   auto it = _registry.insert({tag, componentViewDescriptor});
   return it.first->second;
 }
@@ -98,7 +102,11 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
       _registry.find(tag) != _registry.end(), @"RCTComponentViewRegistry: Attempt to enqueue unregistered component.");
 
   _registry.erase(tag);
+#if !TARGET_OS_OSX // [macOS]
   componentViewDescriptor.view.tag = 0;
+#else // [macOS
+  componentViewDescriptor.tag = 0;
+#endif // macOS]
   [self _enqueueComponentViewWithComponentHandle:componentHandle componentViewDescriptor:componentViewDescriptor];
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Shim RCTComponentViewDescriptor to work w/ Fabric

closes #1543 

## Changelog

[macOS][Added] - Shim RCTComponentViewDescriptor for Fabric

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTComponentViewDescriptor errors
![CleanShot 2023-01-23 at 21 20 49](https://user-images.githubusercontent.com/96719/214218120-3d400e1d-ad05-4c8b-900e-7dc979780d52.jpg)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2023-01-23 at 21 08 15](https://user-images.githubusercontent.com/96719/214218136-207cec59-99d0-4ed1-9001-a93fa4a32b13.jpg)

[x] Build RNTester-macOS w/ Paper
![CleanShot 2023-01-23 at 21 02 54](https://user-images.githubusercontent.com/96719/214218155-8612abad-6c89-4f1c-a9c3-a03463357e21.jpg)

[x] Build RNTester - iOS w/ Paper
![CleanShot 2023-01-23 at 21 01 28](https://user-images.githubusercontent.com/96719/214218179-b7aae349-255e-4cde-98e2-76d8a6227ff5.jpg)
