### PR TITLE
[Fabric] Fix misc rendering & build issues

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -66,8 +66,12 @@ static RCTUIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWith
 
   if (self.window && !_textInput) {
     if (self.nativeId) {
+#if !TARGET_OS_OSX // [macOS]
       _textInput = RCTFindTextInputWithNativeId(self.window, self.nativeId);
       _textInput.inputAccessoryView = _contentView;
+#else // [macOS
+      _textInput = RCTFindTextInputWithNativeId(self.window.contentView, self.nativeId);
+#endif // macOS]
     } else {
       _textInput = RCTFindTextInputWithNativeId(_contentView, nil);
     }

--- a/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -43,7 +43,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
 - (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event // [macOS]
 {
-  RCTUIView *result = [super hitTest:point withEvent:event]; // [macOS]
+  RCTUIView *result = (RCTUIView *)[super hitTest:point withEvent:event]; // [macOS]
 
   if (result == _adapter.paperView) {
     return self;
@@ -197,9 +197,9 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
   for (NSDictionary *mountInstruction in _viewsToBeMounted) {
     NSNumber *index = mountInstruction[kRCTLegacyInteropChildIndexKey];
-    UIView *childView = mountInstruction[kRCTLegacyInteropChildComponentKey];
+    RCTUIView *childView = mountInstruction[kRCTLegacyInteropChildComponentKey]; // [macOS]
     if ([childView isKindOfClass:[RCTLegacyViewManagerInteropComponentView class]]) {
-      UIView *target = ((RCTLegacyViewManagerInteropComponentView *)childView).contentView;
+      RCTUIView *target = ((RCTLegacyViewManagerInteropComponentView *)childView).contentView; // [macOS]
       [_adapter.paperView insertReactSubview:target atIndex:index.integerValue];
     } else {
       [_adapter.paperView insertReactSubview:childView atIndex:index.integerValue];

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -85,7 +85,9 @@ using namespace facebook::react;
   if (self.window && !_didMoveToWindow) {
     auto const &props = *std::static_pointer_cast<TextInputProps const>(_props);
     if (props.autoFocus) {
+#if !TARGET_OS_OSX // [macOS]
       [_backedTextInputView becomeFirstResponder];
+#endif // [macOS]
     }
     _didMoveToWindow = YES;
   }

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -40,7 +40,9 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       // Calling this a bit later, when the main thread is probably idle while JavaScript thread is busy.
+#if !TARGET_OS_OSX // [macOS]
       [self preallocateViewComponents];
+#endif // [macOS]
     });
   }
 

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -103,7 +103,11 @@ using namespace facebook::react;
     } else {
       // Note: Changing `frame` when `layer.transform` is not the `identity transform` is undefined behavior.
       // Therefore, we must use `center` and `bounds`.
+#if !TARGET_OS_OSX // [macOS]
       self.center = CGPoint{CGRectGetMidX(frame), CGRectGetMidY(frame)};
+#else // [macOS
+      self.frame = frame;
+#endif // macOS]
       self.bounds = CGRect{CGPointZero, frame.size};
     }
   }


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Fabric on macOS implementation:
Fix misc rendering & build issues

closes #1573 #1570 #1571 #1566 #1565 

## Changelog

[macOS][Added] - Fix misc rendering & build issues

## Test Plan

[x] Build RNTester-macOS w/ Fabric - doesn’t run yet, but no RCTLegacyViewManagerInteropComponentView errors
![CleanShot 2023-01-23 at 21 54 01](https://user-images.githubusercontent.com/96719/214222075-157d7cd1-1f40-4874-bf7b-70421b52ee99.jpg)

[x] Build RNTester - iOS w/ Fabric
![CleanShot 2023-01-23 at 21 50 43](https://user-images.githubusercontent.com/96719/214222080-13f15a75-2cc4-4bf8-9db2-14b340c3165b.jpg)

[x] Build RNTester-macOS w/ Paper - should work
![CleanShot 2023-01-23 at 22 29 03](https://user-images.githubusercontent.com/96719/214226116-ad0077e5-d28b-4ff3-b746-bfaf2bca6cf9.jpg)

[x] Build RNTester - iOS w/ Paper -
![CleanShot 2023-01-23 at 22 31 40](https://user-images.githubusercontent.com/96719/214226406-f5483ed6-3f8a-4624-abe2-ff005be24e07.jpg)
