### PR TITLE
[Fabric] RCTSurfaceTouchHandler for macOS

### DIFF
--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -414,7 +414,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 /**
  * The z-index of the view.
  */
-@property (nonatomic, assign) NSInteger reactZIndex; // [macOS]
+@property (nonatomic, assign) NSInteger reactZIndex;
 
 @end
 

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -388,6 +388,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 - (void)layoutIfNeeded;
 
 - (void)layoutSubviews;
+- (NSArray<RCTUIView *> *)reactZIndexSortedSubviews; // [macOS]
 
 - (void)setNeedsDisplay;
 
@@ -410,7 +411,10 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
  * Specifies whether focus ring should be drawn when the view has the first responder status.
  */
 @property (nonatomic, assign) BOOL enableFocusRing;
-
+/**
+ * The z-index of the view.
+ */
+@property (nonatomic, assign) NSInteger reactZIndex; // [macOS]
 
 @end
 

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -402,17 +402,17 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
   [super layout];
 }
 
-- (NSArray<RCTUIView *> *)reactZIndexSortedSubviews // [macOS
+- (NSArray<RCTUIView *> *)reactZIndexSortedSubviews
 {
   // Check if sorting is required - in most cases it won't be.
   BOOL sortingRequired = NO;
-  for (RCTUIView *subview in self.subviews) { // TODO(macOS ISS#3536887)
+  for (RCTUIView *subview in self.subviews) {
     if (subview.reactZIndex != 0) {
       sortingRequired = YES;
       break;
     }
   }
-  return sortingRequired ? [self.subviews sortedArrayUsingComparator:^NSComparisonResult(RCTUIView *a, RCTUIView *b) { // TODO(macOS ISS#3536887)
+  return sortingRequired ? [self.subviews sortedArrayUsingComparator:^NSComparisonResult(RCTUIView *a, RCTUIView *b) {
     if (a.reactZIndex > b.reactZIndex) {
       return NSOrderedDescending;
     } else {
@@ -420,9 +420,8 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
       // that original order is preserved.
       return NSOrderedAscending;
     }
-  }]
-                         : self.subviews;
-} // macOS]
+  }] : self.subviews;
+}
 
 - (void)setNeedsDisplay
 {

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -402,6 +402,28 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
   [super layout];
 }
 
+- (NSArray<RCTUIView *> *)reactZIndexSortedSubviews // [macOS
+{
+  // Check if sorting is required - in most cases it won't be.
+  BOOL sortingRequired = NO;
+  for (RCTUIView *subview in self.subviews) { // TODO(macOS ISS#3536887)
+    if (subview.reactZIndex != 0) {
+      sortingRequired = YES;
+      break;
+    }
+  }
+  return sortingRequired ? [self.subviews sortedArrayUsingComparator:^NSComparisonResult(RCTUIView *a, RCTUIView *b) { // TODO(macOS ISS#3536887)
+    if (a.reactZIndex > b.reactZIndex) {
+      return NSOrderedDescending;
+    } else {
+      // Ensure sorting is stable by treating equal zIndex as ascending so
+      // that original order is preserved.
+      return NSOrderedAscending;
+    }
+  }]
+                         : self.subviews;
+} // macOS]
+
 - (void)setNeedsDisplay
 {
   self.needsDisplay = YES;

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -448,8 +448,7 @@ using namespace facebook::react;
 }
 
 #if !TARGET_OS_OSX // [macOS]
-
-- (RCTUIView *)betterHitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)betterHitTest:(CGPoint)point withEvent:(UIEvent *)event // [macOS]
 {
   // This is a classic textbook implementation of `hitTest:` with a couple of improvements:
   //   * It does not stop algorithm if some touch is outside the view
@@ -475,8 +474,8 @@ using namespace facebook::react;
     return nil;
   }
 
-  for (RCTUIView *subview in [self.subviews reverseObjectEnumerator]) {
-    RCTUIView *hitView = [subview hitTest:[subview convertPoint:point fromView:self] withEvent:event];
+  for (RCTUIView *subview in [self.subviews reverseObjectEnumerator]) { // [macOS]
+    RCTUIView *hitView = [subview hitTest:[subview convertPoint:point fromView:self] withEvent:event]; // [macOS]
     if (hitView) {
       return hitView;
     }
@@ -485,7 +484,7 @@ using namespace facebook::react;
   return isPointInside ? self : nil;
 }
 
-- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event // [macOS]
 {
   switch (_props->pointerEvents) {
     case PointerEventsMode::Auto:
@@ -495,14 +494,13 @@ using namespace facebook::react;
     case PointerEventsMode::BoxOnly:
       return [self pointInside:point withEvent:event] ? self : nil;
     case PointerEventsMode::BoxNone:
-      RCTUIView *view = [self betterHitTest:point withEvent:event];
+      RCTUIView *view = [self betterHitTest:point withEvent:event]; // [macOS]
       return view != self ? view : nil;
   }
 }
-
 #else // [macOS
 
-- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event // [macOS]
 {
   BOOL canReceiveTouchEvents = ([self isUserInteractionEnabled] && ![self isHidden]);
   if (!canReceiveTouchEvents) {
@@ -511,12 +509,12 @@ using namespace facebook::react;
 
   // `hitSubview` is the topmost subview which was hit. The hit point can
   // be outside the bounds of `view` (e.g., if -clipsToBounds is NO).
-  RCTUIView *hitSubview = nil;
+  RCTUIView *hitSubview = nil; // [macOS]
   BOOL isPointInside = [self pointInside:point withEvent:event];
   BOOL needsHitSubview = !(_props->pointerEvents == PointerEventsMode::None || _props->pointerEvents == PointerEventsMode::BoxOnly);
   if (needsHitSubview && (![self clipsToBounds] || isPointInside)) {
     // Take z-index into account when calculating the touch target.
-    NSArray<RCTUIView *> *sortedSubviews = [self reactZIndexSortedSubviews]; // TODO(macOS ISS#3536887)
+    NSArray<RCTUIView *> *sortedSubviews = [self reactZIndexSortedSubviews]; // [macOS]
 
     // The default behaviour of UIKit is that if a view does not contain a point,
     // then no subviews will be returned from hit testing, even if they contain
@@ -524,21 +522,21 @@ using namespace facebook::react;
     // the strict containment policy (i.e., UIKit guarantees that every ancestor
     // of the hit view will return YES from -pointInside:withEvent:). See:
     //  - https://developer.apple.com/library/ios/qa/qa2013/qa1812.html
-    for (RCTUIView *subview in [sortedSubviews reverseObjectEnumerator]) { // TODO(macOS ISS#3536887)
+    for (RCTUIView *subview in [sortedSubviews reverseObjectEnumerator]) { // [macOS]
       CGPoint pointForHitTest = CGPointZero;
-      if ([subview isKindOfClass:[RCTUIView class]]) {
+      if ([subview isKindOfClass:[RCTUIView class]]) { // [macOS]
         pointForHitTest = [subview convertPoint:point fromView:self];
       } else {
         pointForHitTest = point;
       }
-      hitSubview = (RCTUIView *)[subview hitTest:pointForHitTest]; // TODO(macOS ISS#3536887)
+      hitSubview = (RCTUIView *)[subview hitTest:pointForHitTest]; // [macOS]
       if (hitSubview != nil) {
         break;
       }
     }
   }
 
-  RCTUIView *hitView = (isPointInside ? self : nil);
+  RCTUIView *hitView = (isPointInside ? self : nil); // [macOS]
 
   switch (_props->pointerEvents) {
     case PointerEventsMode::None:
@@ -553,7 +551,6 @@ using namespace facebook::react;
       return hitSubview ?: hitView;
   }
 }
-
 #endif // macOS]
 
 static RCTCornerRadii RCTCornerRadiiFromBorderRadii(BorderRadii borderRadii)

--- a/React/Fabric/Mounting/RCTComponentViewDescriptor.h
+++ b/React/Fabric/Mounting/RCTComponentViewDescriptor.h
@@ -22,7 +22,6 @@ class RCTComponentViewDescriptor final {
    * Associated (and owned) native view instance.
    */
   __strong RCTUIView<RCTComponentViewProtocol> *view = nil; // [macOS]
-  NSInteger tag = 0; // [macOS] default is 0
   /*
    * Indicates a requirement to call on the view methods from
    * `RCTMountingTransactionObserving` protocol.

--- a/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -119,6 +119,9 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
 - (BOOL)isJSResponder;
 - (void)setIsJSResponder:(BOOL)isJSResponder;
 
+- (NSNumber *)reactTag; // [macOS]
+- (void)setReactTag:(NSNumber *)reactTag; // [macOS]
+
 /*
  * This is broken. Do not use.
  */

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -89,6 +89,7 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   componentViewDescriptor.view.tag = tag;
 #else // [macOS
   componentViewDescriptor.tag = tag;
+  componentViewDescriptor.view.reactTag = @(tag);
 #endif // macOS]
   auto it = _registry.insert({tag, componentViewDescriptor});
   return it.first->second;
@@ -108,6 +109,7 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   componentViewDescriptor.view.tag = 0;
 #else // [macOS
   componentViewDescriptor.tag = 0;
+  componentViewDescriptor.view.reactTag = @0;
 #endif // macOS]
   [self _enqueueComponentViewWithComponentHandle:componentHandle componentViewDescriptor:componentViewDescriptor];
 }

--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -88,7 +88,6 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
 #if !TARGET_OS_OSX // [macOS]
   componentViewDescriptor.view.tag = tag;
 #else // [macOS
-  componentViewDescriptor.tag = tag;
   componentViewDescriptor.view.reactTag = @(tag);
 #endif // macOS]
   auto it = _registry.insert({tag, componentViewDescriptor});
@@ -108,7 +107,6 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
 #if !TARGET_OS_OSX // [macOS]
   componentViewDescriptor.view.tag = 0;
 #else // [macOS
-  componentViewDescriptor.tag = 0;
   componentViewDescriptor.view.reactTag = @0;
 #endif // macOS]
   [self _enqueueComponentViewWithComponentHandle:componentHandle componentViewDescriptor:componentViewDescriptor];

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
@@ -41,6 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setIsJSResponder:(BOOL)isJSResponder;
 
+- (NSNumber *)reactTag; // [macOS]
+- (void)setReactTag:(NSNumber *)reactTag; // [macOS]
+
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(nullable NSSet<NSString *> *)props;
 - (nullable NSSet<NSString *> *)propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -7,6 +7,8 @@
 
 #import "UIView+ComponentViewProtocol.h"
 
+#import <objc/runtime.h> // [macOS]
+
 #import <React/RCTAssert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
@@ -150,6 +152,16 @@ using namespace facebook::react;
 - (void)setIsJSResponder:(BOOL)isJSResponder
 {
   // Default implementation does nothing.
+}
+
+- (NSNumber *)reactTag // [macOS]
+{
+  return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setReactTag:(NSNumber *)reactTag // [macOS]
+{
+  objc_setAssociatedObject(self, @selector(reactTag), reactTag, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(nullable NSSet<NSString *> *)propKeys

--- a/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -154,12 +154,12 @@ using namespace facebook::react;
   // Default implementation does nothing.
 }
 
-- (NSNumber *)reactTag // [macOS]
+- (NSNumber *)reactTag
 {
   return objc_getAssociatedObject(self, _cmd);
 }
 
-- (void)setReactTag:(NSNumber *)reactTag // [macOS]
+- (void)setReactTag:(NSNumber *)reactTag
 {
   objc_setAssociatedObject(self, @selector(reactTag), reactTag, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }

--- a/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -7,7 +7,6 @@
 
 #import "RCTSurfaceTouchHandler.h"
 
-#import <React/RCTUIKit.h> // [macOS]
 #import <React/RCTUtils.h>
 #import <React/RCTViewComponentView.h>
 
@@ -80,7 +79,7 @@ struct ActiveTouch {
 
 static void UpdateActiveTouchWithUITouch(
     ActiveTouch &activeTouch,
-    RCTUITouch *uiTouch, // [macOS]
+    RCTUITouch *uiTouch,
     RCTUIView *rootComponentView,
     CGPoint rootViewOriginOffset) // [macOS]
 {
@@ -88,6 +87,11 @@ static void UpdateActiveTouchWithUITouch(
   CGPoint offsetPoint = [uiTouch locationInView:activeTouch.componentView];
   CGPoint screenPoint = [uiTouch locationInView:uiTouch.window];
   CGPoint pagePoint = [uiTouch locationInView:rootComponentView];
+#else // [macOS
+  CGPoint offsetPoint = [activeTouch.componentView convertPoint:uiTouch.locationInWindow fromView:nil];
+  CGPoint screenPoint = uiTouch.locationInWindow;
+  CGPoint pagePoint = CGPointMake(screenPoint.x, CGRectGetHeight(rootComponentView.window.frame) - screenPoint.y);
+#endif // macOS]
   pagePoint = CGPointMake(pagePoint.x + rootViewOriginOffset.x, pagePoint.y + rootViewOriginOffset.y);
 
   activeTouch.touch.offsetPoint = RCTPointFromCGPoint(offsetPoint);
@@ -96,24 +100,59 @@ static void UpdateActiveTouchWithUITouch(
 
   activeTouch.touch.timestamp = uiTouch.timestamp;
 
+#if !TARGET_OS_OSX // [macOS]
   if (RCTForceTouchAvailable()) {
     activeTouch.touch.force = RCTZeroIfNaN(uiTouch.force / uiTouch.maximumPossibleForce);
   }
-#endif // [macOS]
+#else // [macOS
+  NSEventType type = uiTouch.type;
+  if (type == NSEventTypeLeftMouseDown || type == NSEventTypeLeftMouseUp || type == NSEventTypeLeftMouseDragged) {
+    activeTouch.touch.button = 0;
+  } else if (type == NSEventTypeRightMouseDown || type == NSEventTypeRightMouseUp || type == NSEventTypeRightMouseDragged) {
+    activeTouch.touch.button = 2;
+  }
+
+  NSEventModifierFlags modifierFlags = uiTouch.modifierFlags;
+  if (modifierFlags & NSEventModifierFlagOption) {
+    activeTouch.touch.altKey = true;
+  }
+  if (modifierFlags & NSEventModifierFlagCommand) {
+    activeTouch.touch.ctrlKey = true;
+  }
+  if (modifierFlags & NSEventModifierFlagShift) {
+    activeTouch.touch.shiftKey = true;
+  }
+  if (modifierFlags & NSEventModifierFlagCommand) {
+    activeTouch.touch.metaKey = true;
+  }
+#endif // macOS]
 }
 
 static ActiveTouch CreateTouchWithUITouch(RCTUITouch *uiTouch, RCTUIView *rootComponentView, CGPoint rootViewOriginOffset) // [macOS]
 {
   ActiveTouch activeTouch = {};
 
-#if !TARGET_OS_OSX // [macOS]
   // Find closest Fabric-managed touchable view
+#if !TARGET_OS_OSX // [macOS]
   RCTUIView *componentView = uiTouch.view; // [macOS]
+#else // [macOS
+  CGPoint touchLocation = [rootComponentView.superview convertPoint:uiTouch.locationInWindow fromView:nil];
+  RCTUIView *componentView = (RCTUIView *) [rootComponentView hitTest:touchLocation];
+#endif // macOS]
   while (componentView) {
+#if !TARGET_OS_OSX // [macOS]
+    CGPoint offsetPoint = [uiTouch locationInView:componentView];
+#else // [macOS
+    CGPoint offsetPoint = [componentView convertPoint:uiTouch.locationInWindow fromView:nil];
+#endif // macOS]
     if ([componentView respondsToSelector:@selector(touchEventEmitterAtPoint:)]) {
       activeTouch.eventEmitter = [(id<RCTTouchableComponentViewProtocol>)componentView
-          touchEventEmitterAtPoint:[uiTouch locationInView:componentView]];
+          touchEventEmitterAtPoint:offsetPoint];
+#if !TARGET_OS_OSX // [macOS]
       activeTouch.touch.target = (Tag)componentView.tag;
+#else // [macOS
+      activeTouch.touch.target = (Tag)(componentView.reactTag.intValue);
+#endif // macOS]
       activeTouch.componentView = componentView;
       break;
     }
@@ -121,33 +160,32 @@ static ActiveTouch CreateTouchWithUITouch(RCTUITouch *uiTouch, RCTUIView *rootCo
   }
 
   UpdateActiveTouchWithUITouch(activeTouch, uiTouch, rootComponentView, rootViewOriginOffset);
-#endif // [macOS]
   return activeTouch;
 }
 
-static BOOL AllTouchesAreCancelledOrEnded(NSSet<RCTUITouch *> *touches) // [macOS]
+#if !TARGET_OS_OSX // [macOS
+
+static BOOL AllTouchesAreCancelledOrEnded(NSSet<RCTUITouch *> *touches)
 {
-  for (RCTUITouch *touch in touches) { // [macOS]
-#if !TARGET_OS_OSX // [macOS]
+  for (RCTUITouch *touch in touches) {
     if (touch.phase == UITouchPhaseBegan || touch.phase == UITouchPhaseMoved || touch.phase == UITouchPhaseStationary) {
       return NO;
     }
-#endif // [macOS]
   }
   return YES;
 }
 
-static BOOL AnyTouchesChanged(NSSet<RCTUITouch *> *touches) // [macOS]
+static BOOL AnyTouchesChanged(NSSet<RCTUITouch *> *touches)
 {
-  for (RCTUITouch *touch in touches) { // [macOS]
-#if !TARGET_OS_OSX // [macOS]
+  for (RCTUITouch *touch in touches) {
     if (touch.phase == UITouchPhaseBegan || touch.phase == UITouchPhaseMoved) {
       return YES;
     }
-#endif // [macOS]
   }
   return NO;
 }
+
+#endif // macOS]
 
 /**
  * Surprisingly, `__unsafe_unretained id` pointers are not regular pointers
@@ -167,8 +205,12 @@ struct PointerHasher {
 @end
 
 @implementation RCTSurfaceTouchHandler {
+#if !TARGET_OS_OSX // [macOS]
   std::unordered_map<__unsafe_unretained RCTUITouch *, ActiveTouch, PointerHasher<__unsafe_unretained RCTUITouch *>>
-      _activeTouches; // [macOS]
+      _activeTouches;
+#else // [macOS
+  std::unordered_map<NSInteger, ActiveTouch> _activeTouches;
+#endif // macOS]
 
   /*
    * We hold the view weakly to prevent a retain cycle.
@@ -215,19 +257,27 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   _rootComponentView = nil;
 }
 
-- (void)_registerTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
+- (void)_registerTouches:(NSSet<RCTUITouch *> *)touches
 {
-  for (RCTUITouch *touch in touches) { // [macOS]
+  for (RCTUITouch *touch in touches) {
     auto activeTouch = CreateTouchWithUITouch(touch, _rootComponentView, _viewOriginOffset);
     activeTouch.touch.identifier = _identifierPool.dequeue();
+#if !TARGET_OS_OSX // [macOS]
     _activeTouches.emplace(touch, activeTouch);
+#else // [macOS
+    _activeTouches.emplace(touch.eventNumber, activeTouch);
+#endif // macOS]
   }
 }
 
-- (void)_updateTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
+- (void)_updateTouches:(NSSet<RCTUITouch *> *)touches
 {
-  for (RCTUITouch *touch in touches) { // [macOS]
+  for (RCTUITouch *touch in touches) {
+#if !TARGET_OS_OSX // [macOS]
     auto iterator = _activeTouches.find(touch);
+#else // [macOS
+    auto iterator = _activeTouches.find(touch.eventNumber);
+#endif // macOS]
     assert(iterator != _activeTouches.end() && "Inconsistency between local and UIKit touch registries");
     if (iterator == _activeTouches.end()) {
       continue;
@@ -237,27 +287,39 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   }
 }
 
-- (void)_unregisterTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
+- (void)_unregisterTouches:(NSSet<RCTUITouch *> *)touches
 {
-  for (RCTUITouch *touch in touches) { // [macOS]
+  for (RCTUITouch *touch in touches) {
+#if !TARGET_OS_OSX // [macOS]
     auto iterator = _activeTouches.find(touch);
+#else // [macOS
+    auto iterator = _activeTouches.find(touch.eventNumber);
+#endif // macOS]
     assert(iterator != _activeTouches.end() && "Inconsistency between local and UIKit touch registries");
     if (iterator == _activeTouches.end()) {
       continue;
     }
     auto &activeTouch = iterator->second;
     _identifierPool.enqueue(activeTouch.touch.identifier);
+#if !TARGET_OS_OSX // [macOS]
     _activeTouches.erase(touch);
+#else // [macOS
+    _activeTouches.erase(touch.eventNumber);
+#endif // macOS]
   }
 }
 
-- (std::vector<ActiveTouch>)_activeTouchesFromTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
+- (std::vector<ActiveTouch>)_activeTouchesFromTouches:(NSSet<RCTUITouch *> *)touches
 {
   std::vector<ActiveTouch> activeTouches;
   activeTouches.reserve(touches.count);
 
-  for (RCTUITouch *touch in touches) { // [macOS]
+  for (RCTUITouch *touch in touches) {
+#if !TARGET_OS_OSX // [macOS]
     auto iterator = _activeTouches.find(touch);
+#else // [macOS
+    auto iterator = _activeTouches.find(touch.eventNumber);
+#endif // macOS]
     assert(iterator != _activeTouches.end() && "Inconsistency between local and UIKit touch registries");
     if (iterator == _activeTouches.end()) {
       continue;
@@ -325,9 +387,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 
 #pragma mark - `UIResponder`-ish touch-delivery methods
 
-- (void)touchesBegan:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event // [macOS]
-{
 #if !TARGET_OS_OSX // [macOS]
+
+- (void)touchesBegan:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event
+{
   [super touchesBegan:touches withEvent:event];
 
   [self _registerTouches:touches];
@@ -338,24 +401,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   } else if (self.state == UIGestureRecognizerStateBegan) {
     self.state = UIGestureRecognizerStateChanged;
   }
-#endif // [macOS]
 }
 
-- (void)touchesMoved:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event // [macOS]
+- (void)touchesMoved:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event
 {
-#if !TARGET_OS_OSX // [macOS]
   [super touchesMoved:touches withEvent:event];
 
   [self _updateTouches:touches];
   [self _dispatchActiveTouches:[self _activeTouchesFromTouches:touches] eventType:RCTTouchEventTypeTouchMove];
 
   self.state = UIGestureRecognizerStateChanged;
-#endif // [macOS]
 }
 
-- (void)touchesEnded:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event // [macOS]
+- (void)touchesEnded:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event
 {
-#if !TARGET_OS_OSX // [macOS]
   [super touchesEnded:touches withEvent:event];
 
   [self _updateTouches:touches];
@@ -367,12 +426,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   } else if (AnyTouchesChanged(event.allTouches)) {
     self.state = UIGestureRecognizerStateChanged;
   }
-#endif // [macOS]
 }
 
-- (void)touchesCancelled:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event // [macOS]
+- (void)touchesCancelled:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event
 {
-#if !TARGET_OS_OSX // [macOS]
   [super touchesCancelled:touches withEvent:event];
 
   [self _updateTouches:touches];
@@ -384,8 +441,98 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   } else if (AnyTouchesChanged(event.allTouches)) {
     self.state = UIGestureRecognizerStateChanged;
   }
-#endif // [macOS]
 }
+
+#else // [macOS
+
+- (BOOL)acceptsFirstMouse:(NSEvent *)event
+{
+  // This will only be called if the hit-tested view returns YES for acceptsFirstMouse,
+  // therefore asking it again would be redundant.
+  return YES;
+}
+
+- (void)mouseDown:(NSEvent *)event
+{
+  [super mouseDown:event];
+
+  {
+    NSSet* touches = [NSSet setWithObject:event];
+    [self _registerTouches:touches];
+    [self _dispatchActiveTouches:[self _activeTouchesFromTouches:touches] eventType:RCTTouchEventTypeTouchStart];
+
+    if (self.state == NSGestureRecognizerStatePossible) {
+      self.state = NSGestureRecognizerStateBegan;
+    } else if (self.state == NSGestureRecognizerStateBegan) {
+      self.state = NSGestureRecognizerStateChanged;
+    }
+  }
+}
+
+- (void)rightMouseDown:(NSEvent *)event
+{
+  [super rightMouseDown:event];
+
+  {
+    NSSet* touches = [NSSet setWithObject:event];
+    [self _registerTouches:touches];
+    [self _dispatchActiveTouches:[self _activeTouchesFromTouches:touches] eventType:RCTTouchEventTypeTouchStart];
+
+    if (self.state == NSGestureRecognizerStatePossible) {
+      self.state = NSGestureRecognizerStateBegan;
+    } else if (self.state == NSGestureRecognizerStateBegan) {
+      self.state = NSGestureRecognizerStateChanged;
+    }
+  }
+}
+
+- (void)mouseDragged:(NSEvent *)event
+{
+  [super mouseDragged:event];
+
+  NSSet* touches = [NSSet setWithObject:event];
+  [self _updateTouches:touches];
+  [self _dispatchActiveTouches:[self _activeTouchesFromTouches:touches] eventType:RCTTouchEventTypeTouchMove];
+
+  self.state = NSGestureRecognizerStateChanged;
+}
+
+- (void)rightMouseDragged:(NSEvent *)event
+{
+  [super rightMouseDragged:event];
+
+  NSSet* touches = [NSSet setWithObject:event];
+  [self _updateTouches:touches];
+  [self _dispatchActiveTouches:[self _activeTouchesFromTouches:touches] eventType:RCTTouchEventTypeTouchMove];
+
+  self.state = NSGestureRecognizerStateChanged;
+}
+
+- (void)mouseUp:(NSEvent *)event
+{
+  [super mouseUp:event];
+
+  NSSet* touches = [NSSet setWithObject:event];
+  [self _updateTouches:touches];
+  [self _dispatchActiveTouches:[self _activeTouchesFromTouches:touches] eventType:RCTTouchEventTypeTouchEnd];
+  [self _unregisterTouches:touches];
+
+  self.state = NSGestureRecognizerStateEnded;
+}
+
+- (void)rightMouseUp:(NSEvent *)event
+{
+  [super rightMouseUp:event];
+
+  NSSet* touches = [NSSet setWithObject:event];
+  [self _updateTouches:touches];
+  [self _dispatchActiveTouches:[self _activeTouchesFromTouches:touches] eventType:RCTTouchEventTypeTouchEnd];
+  [self _unregisterTouches:touches];
+
+  self.state = NSGestureRecognizerStateEnded;
+}
+
+#endif // macOS]
 
 - (void)reset
 {

--- a/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -137,7 +137,7 @@ static ActiveTouch CreateTouchWithUITouch(RCTUITouch *uiTouch, RCTUIView *rootCo
   RCTUIView *componentView = uiTouch.view; // [macOS]
 #else // [macOS
   CGPoint touchLocation = [rootComponentView.superview convertPoint:uiTouch.locationInWindow fromView:nil];
-  RCTUIView *componentView = (RCTUIView *) [rootComponentView hitTest:touchLocation];
+  RCTUIView *componentView = (RCTUIView *) [rootComponentView hitTest:touchLocation]; // [macOS]
 #endif // macOS]
   while (componentView) {
 #if !TARGET_OS_OSX // [macOS]
@@ -163,11 +163,10 @@ static ActiveTouch CreateTouchWithUITouch(RCTUITouch *uiTouch, RCTUIView *rootCo
   return activeTouch;
 }
 
-#if !TARGET_OS_OSX // [macOS
-
-static BOOL AllTouchesAreCancelledOrEnded(NSSet<RCTUITouch *> *touches)
+#if !TARGET_OS_OSX // [macOS]
+static BOOL AllTouchesAreCancelledOrEnded(NSSet<RCTUITouch *> *touches) // [macOS]
 {
-  for (RCTUITouch *touch in touches) {
+  for (RCTUITouch *touch in touches) { // [macOS]
     if (touch.phase == UITouchPhaseBegan || touch.phase == UITouchPhaseMoved || touch.phase == UITouchPhaseStationary) {
       return NO;
     }
@@ -175,17 +174,16 @@ static BOOL AllTouchesAreCancelledOrEnded(NSSet<RCTUITouch *> *touches)
   return YES;
 }
 
-static BOOL AnyTouchesChanged(NSSet<RCTUITouch *> *touches)
+static BOOL AnyTouchesChanged(NSSet<RCTUITouch *> *touches) // [macOS]
 {
-  for (RCTUITouch *touch in touches) {
+  for (RCTUITouch *touch in touches) { // [macOS]
     if (touch.phase == UITouchPhaseBegan || touch.phase == UITouchPhaseMoved) {
       return YES;
     }
   }
   return NO;
 }
-
-#endif // macOS]
+#endif // [macOS]
 
 /**
  * Surprisingly, `__unsafe_unretained id` pointers are not regular pointers
@@ -257,9 +255,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   _rootComponentView = nil;
 }
 
-- (void)_registerTouches:(NSSet<RCTUITouch *> *)touches
+- (void)_registerTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
 {
-  for (RCTUITouch *touch in touches) {
+  for (RCTUITouch *touch in touches) { // [macOS]
     auto activeTouch = CreateTouchWithUITouch(touch, _rootComponentView, _viewOriginOffset);
     activeTouch.touch.identifier = _identifierPool.dequeue();
 #if !TARGET_OS_OSX // [macOS]
@@ -270,9 +268,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   }
 }
 
-- (void)_updateTouches:(NSSet<RCTUITouch *> *)touches
+- (void)_updateTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
 {
-  for (RCTUITouch *touch in touches) {
+  for (RCTUITouch *touch in touches) { // [macOS]
 #if !TARGET_OS_OSX // [macOS]
     auto iterator = _activeTouches.find(touch);
 #else // [macOS
@@ -287,9 +285,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   }
 }
 
-- (void)_unregisterTouches:(NSSet<RCTUITouch *> *)touches
+- (void)_unregisterTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
 {
-  for (RCTUITouch *touch in touches) {
+  for (RCTUITouch *touch in touches) { // [macOS]
 #if !TARGET_OS_OSX // [macOS]
     auto iterator = _activeTouches.find(touch);
 #else // [macOS
@@ -309,7 +307,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   }
 }
 
-- (std::vector<ActiveTouch>)_activeTouchesFromTouches:(NSSet<RCTUITouch *> *)touches
+- (std::vector<ActiveTouch>)_activeTouchesFromTouches:(NSSet<RCTUITouch *> *)touches // [macOS]
 {
   std::vector<ActiveTouch> activeTouches;
   activeTouches.reserve(touches.count);
@@ -389,7 +387,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 
 #if !TARGET_OS_OSX // [macOS]
 
-- (void)touchesBegan:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event
+- (void)touchesBegan:(NSSet<RCTUITouch *> *)touches withEvent:(UIEvent *)event // [macOS]
 {
   [super touchesBegan:touches withEvent:event];
 

--- a/ReactCommon/react/renderer/components/view/Touch.cpp
+++ b/ReactCommon/react/renderer/components/view/Touch.cpp
@@ -27,11 +27,11 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
       {"target", getDebugDescription(touch.target, options)},
       {"force", getDebugDescription(touch.force, options)},
       {"timestamp", getDebugDescription(touch.timestamp, options)},
-      {"button", getDebugDescription(touch.button, options)},
-      {"altKey", getDebugDescription(touch.altKey, options)},
-      {"ctrlKey", getDebugDescription(touch.ctrlKey, options)},
-      {"shiftKey", getDebugDescription(touch.shiftKey, options)},
-      {"metaKey", getDebugDescription(touch.metaKey, options)},
+      {"button", getDebugDescription(touch.button, options)}, // [macOS]
+      {"altKey", getDebugDescription(touch.altKey, options)}, // [macOS]
+      {"ctrlKey", getDebugDescription(touch.ctrlKey, options)}, // [macOS]
+      {"shiftKey", getDebugDescription(touch.shiftKey, options)}, // [macOS]
+      {"metaKey", getDebugDescription(touch.metaKey, options)}, // [macOS]
   };
 }
 

--- a/ReactCommon/react/renderer/components/view/Touch.cpp
+++ b/ReactCommon/react/renderer/components/view/Touch.cpp
@@ -27,6 +27,11 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
       {"target", getDebugDescription(touch.target, options)},
       {"force", getDebugDescription(touch.force, options)},
       {"timestamp", getDebugDescription(touch.timestamp, options)},
+      {"button", getDebugDescription(touch.button, options)},
+      {"altKey", getDebugDescription(touch.altKey, options)},
+      {"ctrlKey", getDebugDescription(touch.ctrlKey, options)},
+      {"shiftKey", getDebugDescription(touch.shiftKey, options)},
+      {"metaKey", getDebugDescription(touch.metaKey, options)},
   };
 }
 

--- a/ReactCommon/react/renderer/components/view/Touch.h
+++ b/ReactCommon/react/renderer/components/view/Touch.h
@@ -57,6 +57,31 @@ struct Touch {
   Float timestamp;
 
   /*
+   * The button indicating which pointer is used.
+   */
+  int button;
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  bool altKey;
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  bool ctrlKey;
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool shiftKey;
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  bool metaKey;
+
+  /*
    * The particular implementation of `Hasher` and (especially) `Comparator`
    * make sense only when `Touch` object is used as a *key* in indexed
    * collections. Because of that they are expressed as separate classes.

--- a/ReactCommon/react/renderer/components/view/Touch.h
+++ b/ReactCommon/react/renderer/components/view/Touch.h
@@ -56,6 +56,7 @@ struct Touch {
    */
   Float timestamp;
 
+  // [macOS
   /*
    * The button indicating which pointer is used.
    */
@@ -80,7 +81,8 @@ struct Touch {
    * A flag indicating if the meta key is pressed.
    */
   bool metaKey;
-
+  // macOS]
+  
   /*
    * The particular implementation of `Hasher` and (especially) `Comparator`
    * make sense only when `Touch` object is used as a *key* in indexed

--- a/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -26,11 +26,11 @@ static void setTouchPayloadOnObject(
   object.setProperty(runtime, "target", touch.target);
   object.setProperty(runtime, "timestamp", touch.timestamp * 1000);
   object.setProperty(runtime, "force", touch.force);
-  object.setProperty(runtime, "button", touch.button);
-  object.setProperty(runtime, "altKey", touch.altKey);
-  object.setProperty(runtime, "ctrlKey", touch.ctrlKey);
-  object.setProperty(runtime, "shiftKey", touch.shiftKey);
-  object.setProperty(runtime, "metaKey", touch.metaKey);
+  object.setProperty(runtime, "button", touch.button); // [macOS]
+  object.setProperty(runtime, "altKey", touch.altKey); // [macOS]
+  object.setProperty(runtime, "ctrlKey", touch.ctrlKey); // [macOS]
+  object.setProperty(runtime, "shiftKey", touch.shiftKey); // [macOS]
+  object.setProperty(runtime, "metaKey", touch.metaKey); // [macOS]
 }
 
 static jsi::Value touchesPayload(

--- a/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -26,6 +26,11 @@ static void setTouchPayloadOnObject(
   object.setProperty(runtime, "target", touch.target);
   object.setProperty(runtime, "timestamp", touch.timestamp * 1000);
   object.setProperty(runtime, "force", touch.force);
+  object.setProperty(runtime, "button", touch.button);
+  object.setProperty(runtime, "altKey", touch.altKey);
+  object.setProperty(runtime, "ctrlKey", touch.ctrlKey);
+  object.setProperty(runtime, "shiftKey", touch.shiftKey);
+  object.setProperty(runtime, "metaKey", touch.metaKey);
 }
 
 static jsi::Value touchesPayload(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Update the RCTSurfaceTouchHandler to support mouse events on macOS Fabric and convert them to touch events.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->
[macOS] [Added] - Touch events for Fabric

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
[x] Build RNTester-macOS w/ Fabric
<img width="752" alt="macos-fabric" src="https://user-images.githubusercontent.com/151054/214643304-79aee6fe-e88b-425c-8195-f3d458b4f34f.png">

[x] Click around RNTester-macOS w/ Fabric
https://user-images.githubusercontent.com/151054/214643298-c550a516-2710-40a1-8025-d4f5f9431bdb.mov

[x] Build RNTester - iOS w/ Fabric
<img width="565" alt="ios-fabric" src="https://user-images.githubusercontent.com/151054/214643280-8d0a6e5b-28e2-4cc8-a18c-aecd01ef8813.png">

[x] Build RNTester-macOS w/ Paper
<img width="752" alt="macos-paper" src="https://user-images.githubusercontent.com/151054/214643311-fb2e73b6-c62d-44e5-81e9-699601305ad9.png">

[x] Build RNTester - iOS w/ Paper
<img width="565" alt="ios-paper" src="https://user-images.githubusercontent.com/151054/214643295-cfc93e33-6508-4727-85af-beab2e98f32b.png">
