### PR TITLE
Allow blank issues via Github Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
     - name: 📃 Documentation Issue
       url: https://github.com/facebook/react-native-website/issues


### PR DESCRIPTION
We use Github's issue tracker for our Github projects related to Fabric. However, it's not easy for outside collaborators to create issues right now as they need to use one of our pre-filled templates. This change would allow outside collaborators to make blank issues, which will help me sort them into our Fabric Github project.