### PR TITLE
Update accessibilityValue to include radio button state attribute

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -448,7 +448,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     for (NSString *state in [self accessibilityState]) {
       id val = [self accessibilityState][state];
       if (val != nil) {
-        if ([state isEqualToString:@"checked"]) {
+        if ([state isEqualToString:@"checked"] || [state isEqualToString:@"selected"]) {
           if ([val isKindOfClass:[NSNumber class]]) {
             accessibilityValue = @([val boolValue]);
           } else if ([val isKindOfClass:[NSString class]] && [val isEqualToString:@"mixed"]) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

NSAccessibilityRadioButtonRole has a separate enum for accessibility state, let's add it so that VoiceOver announces accessibility states for radio button and checkbox.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[macOS] [FIXED] - Update accessibilityValue

## Test Plan
Tested the accessibility scenario in an external app
