### PR TITLE
[Fabric] Convert remaining legacy macOS tags

### DIFF
--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -92,7 +92,7 @@
     _textStorage = _textView.textStorage;
     [self addSubview:_textView];
 #endif // macOS]
-    RCTUIViewSetContentModeRedraw(self); // TODO(macOS GH#774) and TODO(macOS ISS#3536887)
+    RCTUIViewSetContentModeRedraw(self); // [macOS]
   }
   return self;
 }

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -381,10 +381,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)decoder)
     if ([self.backedTextInputView respondsToSelector:@selector(selectAll:)]) {
       [self.backedTextInputView selectAll:nil];
     }
-#if TARGET_OS_OSX // [TODO(macOS GH#774)
+#if TARGET_OS_OSX // [macOS
   } else {
     [self.backedTextInputView setSelectedTextRange:NSMakeRange(NSNotFound, 0) notifyDelegate:NO];
-#endif // ]TODO(macOS GH#774)
+#endif // macOS]
   }
 
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -12,7 +12,7 @@
 #import <React/RCTBackedTextInputDelegateAdapter.h>
 #import <React/RCTBackedTextInputDelegate.h> // [macOS]
 #import <React/RCTTextAttributes.h>
-#import <React/RCTTouchHandler.h> // [TODO(macOS GH#774)
+#import <React/RCTTouchHandler.h> // [macOS]
 
 #if TARGET_OS_OSX // [macOS
 

--- a/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -38,14 +38,14 @@ using namespace facebook::react;
   return UIEdgeInsetsZero;
 }
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 - (void)safeAreaInsetsDidChange
 {
   [super safeAreaInsetsDidChange];
 
   [self _updateStateIfNecessary];
 }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
 - (void)_updateStateIfNecessary
 {
@@ -54,18 +54,18 @@ using namespace facebook::react;
   }
 
   UIEdgeInsets insets = [self _safeAreaInsets];
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   insets.left = RCTRoundPixelValue(insets.left);
   insets.top = RCTRoundPixelValue(insets.top);
   insets.right = RCTRoundPixelValue(insets.right);
   insets.bottom = RCTRoundPixelValue(insets.bottom);
-#else // [TODO(macOS GH#774)
+#else // [macOS
   CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];;
   insets.left = RCTRoundPixelValue(insets.left, scale);
   insets.top = RCTRoundPixelValue(insets.top, scale);
   insets.right = RCTRoundPixelValue(insets.right, scale);
   insets.bottom = RCTRoundPixelValue(insets.bottom, scale);
-#endif // ]TODO(macOS GH#774)
+#endif // macOS]
 
   auto newPadding = RCTEdgeInsetsFromUIEdgeInsets(insets);
   auto threshold = 1.0 / RCTScreenScale() + 0.01; // Size of a pixel plus some small threshold.

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.h
@@ -40,9 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
  * resilient to other code as possible: even if something else nil the delegate, other delegates that were subscribed
  * via the splitter will continue working.
  */
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 @property (nonatomic, strong, readonly) RCTGenericDelegateSplitter<id<UIScrollViewDelegate>> *delegateSplitter;
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
 @property (nonatomic, weak) id<RCTEnhancedScrollViewOverridingDelegate> overridingDelegate;
 @property (nonatomic, assign) BOOL pinchGestureEnabled;

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -24,9 +24,9 @@ using namespace facebook::react;
 @end
 
 @implementation RCTPullToRefreshViewComponentView {
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   UIRefreshControl *_refreshControl;
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
   RCTScrollViewComponentView *__weak _scrollViewComponentView;
 }
 
@@ -41,12 +41,12 @@ using namespace facebook::react;
     static auto const defaultProps = std::make_shared<PullToRefreshViewProps const>();
     _props = defaultProps;
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
     _refreshControl = [UIRefreshControl new];
     [_refreshControl addTarget:self
                         action:@selector(handleUIControlEventValueChanged)
               forControlEvents:UIControlEventValueChanged];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
   }
 
   return self;
@@ -65,13 +65,13 @@ using namespace facebook::react;
   auto const &newConcreteProps = *std::static_pointer_cast<PullToRefreshViewProps const>(props);
 
   if (newConcreteProps.refreshing != oldConcreteProps.refreshing) {
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
     if (newConcreteProps.refreshing) {
       [_refreshControl beginRefreshing];
     } else {
       [_refreshControl endRefreshing];
     }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
   }
 
   BOOL needsUpdateTitle = NO;
@@ -103,9 +103,9 @@ using namespace facebook::react;
   auto const &concreteProps = *std::static_pointer_cast<PullToRefreshViewProps const>(_props);
 
   if (concreteProps.title.empty()) {
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
     _refreshControl.attributedTitle = nil;
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
     return;
   }
 
@@ -114,10 +114,10 @@ using namespace facebook::react;
     attributes[NSForegroundColorAttributeName] = RCTUIColorFromSharedColor(concreteProps.titleColor);
   }
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   _refreshControl.attributedTitle =
       [[NSAttributedString alloc] initWithString:RCTNSStringFromString(concreteProps.title) attributes:attributes];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 }
 
 #pragma mark - Attaching & Detaching
@@ -142,11 +142,11 @@ using namespace facebook::react;
     return;
   }
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   if (@available(macOS 13.0, *)) {
     _scrollViewComponentView.scrollView.refreshControl = _refreshControl;
   }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 }
 
 - (void)_detach
@@ -156,13 +156,13 @@ using namespace facebook::react;
   }
 
   // iOS requires to end refreshing before unmounting.
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   [_refreshControl endRefreshing];
 
   if (@available(macOS 13.0, *)) {
     _scrollViewComponentView.scrollView.refreshControl = nil;
   }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
   _scrollViewComponentView = nil;
 }
 
@@ -175,13 +175,13 @@ using namespace facebook::react;
 
 - (void)setNativeRefreshing:(BOOL)refreshing
 {
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   if (refreshing) {
     [_refreshControl beginRefreshing];
   } else {
     [_refreshControl endRefreshing];
   }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 }
 
 #pragma mark - RCTRefreshableProtocol

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
@@ -45,10 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Returns a delegate splitter that can be used to subscribe for UIScrollView delegate.
  */
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 @property (nonatomic, strong, readonly)
     RCTGenericDelegateSplitter<id<UIScrollViewDelegate>> *scrollViewDelegateSplitter;
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
 @end
 

--- a/React/Fabric/Mounting/ComponentViews/Slider/RCTSliderComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Slider/RCTSliderComponentView.mm
@@ -50,12 +50,12 @@ using namespace facebook::react;
 
     _sliderView = [[RCTUISlider alloc] initWithFrame:self.bounds]; // [macOS]
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
     [_sliderView addTarget:self action:@selector(onChange:) forControlEvents:UIControlEventValueChanged];
     [_sliderView addTarget:self
                     action:@selector(sliderTouchEnd:)
           forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchCancel)];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
     _sliderView.value = (float)defaultProps->value;
 
@@ -86,7 +86,7 @@ using namespace facebook::react;
   self.maximumTrackImageCoordinator = nullptr;
   self.thumbImageCoordinator = nullptr;
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   // Tint colors will be taken care of when props are set again - we just
   // need to make sure that image properties are reset here
   [_sliderView setMinimumTrackImage:nil forState:UIControlStateNormal];
@@ -95,7 +95,7 @@ using namespace facebook::react;
   if (_thumbImage) {
     [_sliderView setThumbImage:nil forState:UIControlStateNormal];
   }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
   _trackImage = nil;
   _minimumTrackImage = nil;
@@ -140,12 +140,12 @@ using namespace facebook::react;
     _sliderView.enabled = !newSliderProps.disabled;
   }
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   // `thumbTintColor`
   if (oldSliderProps.thumbTintColor != newSliderProps.thumbTintColor) {
     _sliderView.thumbTintColor = RCTUIColorFromSharedColor(newSliderProps.thumbTintColor);
   }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
   // `minimumTrackTintColor`
   if (oldSliderProps.minimumTrackTintColor != newSliderProps.minimumTrackTintColor) {
@@ -248,7 +248,7 @@ using namespace facebook::react;
   _trackImage = trackImage;
   _minimumTrackImage = nil;
   _maximumTrackImage = nil;
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   CGFloat width = trackImage.size.width / 2;
   UIImage *minimumTrackImage = [trackImage resizableImageWithCapInsets:(UIEdgeInsets){0, width, 0, width}
                                                           resizingMode:UIImageResizingModeStretch];
@@ -256,7 +256,7 @@ using namespace facebook::react;
                                                           resizingMode:UIImageResizingModeStretch];
   [_sliderView setMinimumTrackImage:minimumTrackImage forState:UIControlStateNormal];
   [_sliderView setMaximumTrackImage:maximumTrackImage forState:UIControlStateNormal];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 }
 
 - (void)setMinimumTrackImage:(UIImage *)minimumTrackImage
@@ -267,12 +267,12 @@ using namespace facebook::react;
 
   _trackImage = nil;
   _minimumTrackImage = minimumTrackImage;
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   _minimumTrackImage =
       [_minimumTrackImage resizableImageWithCapInsets:(UIEdgeInsets){0, _minimumTrackImage.size.width, 0, 0}
                                          resizingMode:UIImageResizingModeStretch];
   [_sliderView setMinimumTrackImage:_minimumTrackImage forState:UIControlStateNormal];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 }
 
 - (void)setMaximumTrackImage:(UIImage *)maximumTrackImage
@@ -283,12 +283,12 @@ using namespace facebook::react;
 
   _trackImage = nil;
   _maximumTrackImage = maximumTrackImage;
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   _maximumTrackImage =
       [_maximumTrackImage resizableImageWithCapInsets:(UIEdgeInsets){0, 0, 0, _maximumTrackImage.size.width}
                                          resizingMode:UIImageResizingModeStretch];
   [_sliderView setMaximumTrackImage:_maximumTrackImage forState:UIControlStateNormal];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 }
 
 - (void)setThumbImage:(UIImage *)thumbImage
@@ -298,9 +298,9 @@ using namespace facebook::react;
   }
 
   _thumbImage = thumbImage;
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   [_sliderView setThumbImage:thumbImage forState:UIControlStateNormal];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 }
 
 - (void)onChange:(RCTUISlider *)sender // [macOS]

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.h
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.h
@@ -9,11 +9,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 @interface RCTAccessibilityElement : UIAccessibilityElement
-#else // [TODO(macOS GH#774)
+#else // [macOS
 @interface RCTAccessibilityElement : NSAccessibilityElement
-#endif // ]TODO(macOS GH#774)
+#endif // macOS]
 
 /*
  * Frame of the accessibility element in parent coordinate system.

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTAccessibilityElement.mm
@@ -9,7 +9,7 @@
 
 @implementation RCTAccessibilityElement
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 - (CGRect)accessibilityFrame
 {
   RCTUIView *container = (RCTUIView *)self.accessibilityContainer; // [macOS]
@@ -19,6 +19,6 @@
     return UIAccessibilityConvertFrameToScreenCoordinates(_frame, container);
   }
 }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
 @end

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.h
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.h
@@ -21,12 +21,12 @@
                          frame:(CGRect)frame
                           view:(RCTUIView *)view; // [macOS]
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 /*
  * Returns an array of `UIAccessibilityElement`s to be used for `UIAccessibilityContainer` implementation.
  */
 - (NSArray<UIAccessibilityElement *> *)accessibilityElements;
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
 /**
  @abstract To make sure the provider is up to date.

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.mm
@@ -21,9 +21,9 @@
 using namespace facebook::react;
 
 @implementation RCTParagraphComponentAccessibilityProvider {
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   NSMutableArray<UIAccessibilityElement *> *_accessibilityElements;
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
   AttributedString _attributedString;
   RCTTextLayoutManager *_layoutManager;
   ParagraphAttributes _paragraphAttributes;
@@ -47,7 +47,7 @@ using namespace facebook::react;
   return self;
 }
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 - (NSArray<UIAccessibilityElement *> *)accessibilityElements
 {
   if (_accessibilityElements) {
@@ -174,7 +174,7 @@ using namespace facebook::react;
   _accessibilityElements = elements;
   return _accessibilityElements;
 }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
 - (BOOL)isUpToDate:(facebook::react::AttributedString)currentAttributedString
 {

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -39,9 +39,9 @@ using namespace facebook::react;
     static auto const defaultProps = std::make_shared<ViewProps const>();
     _props = defaultProps;
     _reactSubviews = [NSMutableArray new];
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
     self.multipleTouchEnabled = YES;
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
   }
   return self;
 }
@@ -249,11 +249,11 @@ using namespace facebook::react;
   // `shouldRasterize`
   if (oldViewProps.shouldRasterize != newViewProps.shouldRasterize) {
     self.layer.shouldRasterize = newViewProps.shouldRasterize;
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
     self.layer.rasterizationScale = newViewProps.shouldRasterize ? [UIScreen mainScreen].scale : 1.0;
-#else // [TODO(macOS GH#774)
+#else // [macOS
     self.layer.rasterizationScale = 1.0;
-#endif // ]TODO(macOS GH#774)
+#endif // macOS]
   }
 
   // `pointerEvents`
@@ -294,7 +294,7 @@ using namespace facebook::react;
     self.nativeId = RCTNSStringFromStringNilIfEmpty(newViewProps.nativeId);
   }
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   // `accessible`
   if (oldViewProps.accessible != newViewProps.accessible) {
     self.accessibilityElement.isAccessibilityElement = newViewProps.accessible;
@@ -359,7 +359,7 @@ using namespace facebook::react;
       self.accessibilityElement.accessibilityValue = nil;
     }
   }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
   // `testId`
   if (oldViewProps.testId != newViewProps.testId) {
@@ -768,7 +768,7 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
   auto const &props = *std::static_pointer_cast<ViewProps const>(_props);
 
   // Handle Switch.
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   if ((self.accessibilityTraits & AccessibilityTraitSwitch) == AccessibilityTraitSwitch) {
     if (props.accessibilityState.checked == AccessibilityState::Checked) {
       return @"1";
@@ -776,7 +776,7 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
       return @"0";
     }
   }
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
   // Handle states which haven't already been handled.
   if (props.accessibilityState.checked == AccessibilityState::Checked) {

--- a/React/Fabric/RCTConversions.h
+++ b/React/Fabric/RCTConversions.h
@@ -83,7 +83,7 @@ inline UIEdgeInsets RCTUIEdgeInsetsFromEdgeInsets(const facebook::react::EdgeIns
   return {edgeInsets.top, edgeInsets.left, edgeInsets.bottom, edgeInsets.right};
 }
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
 UIAccessibilityTraits const AccessibilityTraitSwitch = 0x20000000000001;
 
 inline UIAccessibilityTraits RCTUIAccessibilityTraitsFromAccessibilityTraits(
@@ -147,7 +147,7 @@ inline UIAccessibilityTraits RCTUIAccessibilityTraitsFromAccessibilityTraits(
   }
   return result;
 };
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
 
 inline CATransform3D RCTCATransform3DFromTransformMatrix(const facebook::react::Transform &transformMatrix)
 {

--- a/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/React/Fabric/Surface/RCTFabricSurface.mm
@@ -66,12 +66,12 @@ using namespace facebook::react;
 
     [self _updateLayoutContext];
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleContentSizeCategoryDidChangeNotification:)
                                                  name:UIContentSizeCategoryDidChangeNotification
                                                object:nil];
-#endif // TODO(macOS GH#774)
+#endif // [macOS]
   }
 
   return self;

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
@@ -57,12 +57,12 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 
   CGSize size = [layoutManager usedRectForTextContainer:textContainer].size;
 
-#if !TARGET_OS_OSX // TODO(macOS GH#774)
+#if !TARGET_OS_OSX // [macOS]
   size = (CGSize){RCTCeilPixelValue(size.width), RCTCeilPixelValue(size.height)};
-#else // [TODO(macOS GH#774)
+#else // [macOS
   CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
   size = (CGSize){RCTCeilPixelValue(size.width, scale), RCTCeilPixelValue(size.height, scale)};
-#endif // ]TODO(macOS GH#774)
+#endif // macOS]
 
   __block auto attachments = TextMeasurement::Attachments{};
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

[Fabric] Convert remaining legacy macOS tags

## Changelog

[macOS] [Fixed] - Convert remaining legacy macOS tags

## Test Plan

## Ensure everything builds:
[x] macOS - Fabric
[x] macOS - Paper
[x] iOS - Fabric
[x] iOS - Paper