### PR TITLE
Include timestamp in nightly versions

### DIFF
--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -62,7 +62,8 @@ if (!version) {
     const currentCommit = exec('git rev-parse HEAD', {
       silent: true,
     }).stdout.trim();
-    version = `0.0.0-${currentCommit.slice(0, 9)}`;
+    const calvar = exec(`git show -s --format=%cd --date=format:%Y%m%d ${currentCommit}`, { silent: true }).stdout.trim();
+    version = `0.0.0-${calvar}-${currentCommit.slice(0, 9)}`;
     // macOS]
   } else {
     echo('You must specify a version using -v');

--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -62,7 +62,10 @@ if (!version) {
     const currentCommit = exec('git rev-parse HEAD', {
       silent: true,
     }).stdout.trim();
-    const calvar = exec(`git show -s --format=%cd --date=format:%Y%m%d ${currentCommit}`, { silent: true }).stdout.trim();
+    const calvar = exec(
+      `git show -s --format=%cd --date=format:%Y%m%d ${currentCommit}`,
+      {silent: true},
+    ).stdout.trim();
     version = `0.0.0-${calvar}-${currentCommit.slice(0, 9)}`;
     // macOS]
   } else {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Resolved #1630. Edits our nightly versions to include a better timestamp so that cocoa pods is less confused

## Changelog

[Internal] [Fixed ] - react-native-macos@canary randomly fails installing

## Test Plan

CI should pass. 
