### PR TITLE
Don't passthru key events that override Pressibilty api's

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -105,8 +105,8 @@ const PASSTHROUGH_PROPS = [
   'onAccessibilityAction',
   'onBlur',
   'onFocus',
-  'onKeyDown',
-  'onKeyUp',
+  // 'onKeyDown', // [macOS]
+  // 'onKeyUp', // [macOS]
   'validKeysDown',
   'validKeysUp',
   'onLayout',


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

#1623 added support for "Enter" and "Space" as default keys to trigger `onKeyDown` on Pressability which will call `onPress`
If the `onKeyDown` or `onKeyUp` was passed as a prop to `TouchableWithoutFeedback`, this would clobber the Pressability callback and the default `onPress` action would never fire.

![CleanShot 2023-02-10 at 15 57 39](https://user-images.githubusercontent.com/96719/218223916-e9d0932b-7d39-48e7-90f5-8f38c434cff5.jpg)

https://user-images.githubusercontent.com/96719/218223974-c26279bb-1354-49cf-8501-8541ac6d20a9.mp4

Pressibility supports calling the `onKeyDown|up` if it's passed as a prop.

https://github.com/microsoft/react-native-macos/blob/b2b61ac9ff5d16ae43fbbbd0b29194f89abda880/Libraries/Pressability/Pressability.js#L627-L630

## Changeling

[macOS] [Fix] - Don't passthru key events that override Pressibilty api's

## Test Plan

https://user-images.githubusercontent.com/96719/218224185-f8b11bbb-e81d-4590-8b97-bc09644c8ba4.mp4