### PR TITLE
Remove group: InfoSec-SecurityResults from publish.yml

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -19,7 +19,6 @@ pr: none
 variables:
   - template: variables/vars.yml
   - group: React-native-macos Secrets
-  - group: InfoSec-SecurityResults
   - name: tags
     value: production,externalfacing
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Our pipeline to publish new versions of react-native-macos 0.68.x is broken. The fix is to remove this deprecated group from publish.yml.

## Test Plan

If the CIs pass, we should be good.
