### PR TITLE
Manual bump to 0.68.67

### DIFF
--- a/Libraries/Core/ReactNativeVersion.js
+++ b/Libraries/Core/ReactNativeVersion.js
@@ -16,6 +16,6 @@
 exports.version = {
   major: 0,
   minor: 68,
-  patch: 66,
+  patch: 67,
   prerelease: null,
 };

--- a/React/Base/RCTVersion.m
+++ b/React/Base/RCTVersion.m
@@ -27,7 +27,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(68),
-                  RCTVersionPatch: @(66),
+                  RCTVersionPatch: @(67),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.68.66
+VERSION_NAME=0.68.67
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -21,6 +21,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 68,
-      "patch", 66,
+      "patch", 67,
       "prerelease", null);
 }

--- a/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -21,7 +21,7 @@ namespace facebook::react {
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 68;
-  int32_t Patch = 66;
+  int32_t Patch = 67;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-macos",
   "private": true,
-  "version": "0.68.66",
+  "version": "0.68.67",
   "bin": "./cli.js",
   "description": "React Native for macOS",
   "license": "MIT",

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.68.66)
-  - FBReactNativeSpec (0.68.66):
+  - FBLazyVector (0.68.67)
+  - FBReactNativeSpec (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.66)
-    - RCTTypeSafety (= 0.68.66)
-    - React-Core (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
+    - RCTRequired (= 0.68.67)
+    - RCTTypeSafety (= 0.68.67)
+    - React-Core (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -86,328 +86,328 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.68.66)
-  - RCTTypeSafety (0.68.66):
-    - FBLazyVector (= 0.68.66)
+  - RCTRequired (0.68.67)
+  - RCTTypeSafety (0.68.67):
+    - FBLazyVector (= 0.68.67)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.66)
-    - React-Core (= 0.68.66)
-  - React (0.68.66):
-    - React-Core (= 0.68.66)
-    - React-Core/DevSupport (= 0.68.66)
-    - React-Core/RCTWebSocket (= 0.68.66)
-    - React-RCTActionSheet (= 0.68.66)
-    - React-RCTAnimation (= 0.68.66)
-    - React-RCTBlob (= 0.68.66)
-    - React-RCTImage (= 0.68.66)
-    - React-RCTLinking (= 0.68.66)
-    - React-RCTNetwork (= 0.68.66)
-    - React-RCTSettings (= 0.68.66)
-    - React-RCTText (= 0.68.66)
-    - React-RCTVibration (= 0.68.66)
-  - React-callinvoker (0.68.66)
-  - React-Codegen (0.68.66):
-    - FBReactNativeSpec (= 0.68.66)
+    - RCTRequired (= 0.68.67)
+    - React-Core (= 0.68.67)
+  - React (0.68.67):
+    - React-Core (= 0.68.67)
+    - React-Core/DevSupport (= 0.68.67)
+    - React-Core/RCTWebSocket (= 0.68.67)
+    - React-RCTActionSheet (= 0.68.67)
+    - React-RCTAnimation (= 0.68.67)
+    - React-RCTBlob (= 0.68.67)
+    - React-RCTImage (= 0.68.67)
+    - React-RCTLinking (= 0.68.67)
+    - React-RCTNetwork (= 0.68.67)
+    - React-RCTSettings (= 0.68.67)
+    - React-RCTText (= 0.68.67)
+    - React-RCTVibration (= 0.68.67)
+  - React-callinvoker (0.68.67)
+  - React-Codegen (0.68.67):
+    - FBReactNativeSpec (= 0.68.67)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.68.66)
-    - RCTTypeSafety (= 0.68.66)
-    - React-Core (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-Core (0.68.66):
+    - RCTRequired (= 0.68.67)
+    - RCTTypeSafety (= 0.68.67)
+    - React-Core (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-Core (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.66)
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-Core/Default (= 0.68.67)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.68.66):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
-    - SocketRocket (= 0.6.0)
-    - Yoga
-  - React-Core/Default (0.68.66):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
-    - SocketRocket (= 0.6.0)
-    - Yoga
-  - React-Core/DevSupport (0.68.66):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.66)
-    - React-Core/RCTWebSocket (= 0.68.66)
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-jsinspector (= 0.68.66)
-    - React-perflogger (= 0.68.66)
-    - SocketRocket (= 0.6.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.68.66):
+  - React-Core/CoreModulesHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.68.66):
+  - React-Core/Default (0.68.67):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
+    - SocketRocket (= 0.6.0)
+    - Yoga
+  - React-Core/DevSupport (0.68.67):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.67)
+    - React-Core/RCTWebSocket (= 0.68.67)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-jsinspector (= 0.68.67)
+    - React-perflogger (= 0.68.67)
+    - SocketRocket (= 0.6.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.68.66):
+  - React-Core/RCTAnimationHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.68.66):
+  - React-Core/RCTBlobHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.68.66):
+  - React-Core/RCTImageHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.68.66):
+  - React-Core/RCTLinkingHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.68.66):
+  - React-Core/RCTNetworkHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.68.66):
+  - React-Core/RCTPushNotificationHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.68.66):
+  - React-Core/RCTSettingsHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.68.66):
+  - React-Core/RCTTextHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.68.66):
+  - React-Core/RCTVibrationHeaders (0.68.67):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.68.66)
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsiexecutor (= 0.68.66)
-    - React-perflogger (= 0.68.66)
+    - React-Core/Default
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
     - Yoga
-  - React-CoreModules (0.68.66):
+  - React-Core/RCTWebSocket (0.68.67):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.66)
-    - React-Codegen (= 0.68.66)
-    - React-Core/CoreModulesHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-RCTImage (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
+    - React-Core/Default (= 0.68.67)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsiexecutor (= 0.68.67)
+    - React-perflogger (= 0.68.67)
     - SocketRocket (= 0.6.0)
-  - React-cxxreact (0.68.66):
+    - Yoga
+  - React-CoreModules (0.68.67):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.68.67)
+    - React-Codegen (= 0.68.67)
+    - React-Core/CoreModulesHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-RCTImage (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+    - SocketRocket (= 0.6.0)
+  - React-cxxreact (0.68.67):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-jsinspector (= 0.68.66)
-    - React-logger (= 0.68.66)
-    - React-perflogger (= 0.68.66)
-    - React-runtimeexecutor (= 0.68.66)
-  - React-jsi (0.68.66):
+    - React-callinvoker (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-jsinspector (= 0.68.67)
+    - React-logger (= 0.68.67)
+    - React-perflogger (= 0.68.67)
+    - React-runtimeexecutor (= 0.68.67)
+  - React-jsi (0.68.67):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.68.66)
-  - React-jsi/Default (0.68.66):
+    - React-jsi/Default (= 0.68.67)
+  - React-jsi/Default (0.68.67):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.68.66):
+  - React-jsiexecutor (0.68.67):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-perflogger (= 0.68.66)
-  - React-jsinspector (0.68.66)
-  - React-logger (0.68.66):
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-perflogger (= 0.68.67)
+  - React-jsinspector (0.68.67)
+  - React-logger (0.68.67):
     - glog
-  - React-perflogger (0.68.66)
-  - React-RCTActionSheet (0.68.66):
-    - React-Core/RCTActionSheetHeaders (= 0.68.66)
-  - React-RCTAnimation (0.68.66):
+  - React-perflogger (0.68.67)
+  - React-RCTActionSheet (0.68.67):
+    - React-Core/RCTActionSheetHeaders (= 0.68.67)
+  - React-RCTAnimation (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.66)
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTAnimationHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTBlob (0.68.66):
+    - RCTTypeSafety (= 0.68.67)
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTAnimationHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTBlob (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTBlobHeaders (= 0.68.66)
-    - React-Core/RCTWebSocket (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-RCTNetwork (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTImage (0.68.66):
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTBlobHeaders (= 0.68.67)
+    - React-Core/RCTWebSocket (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-RCTNetwork (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTImage (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.66)
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTImageHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-RCTNetwork (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTLinking (0.68.66):
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTLinkingHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTNetwork (0.68.66):
+    - RCTTypeSafety (= 0.68.67)
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTImageHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-RCTNetwork (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTLinking (0.68.67):
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTLinkingHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTNetwork (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.66)
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTNetworkHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTPushNotification (0.68.66):
-    - RCTTypeSafety (= 0.68.66)
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTPushNotificationHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTSettings (0.68.66):
+    - RCTTypeSafety (= 0.68.67)
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTNetworkHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTPushNotification (0.68.67):
+    - RCTTypeSafety (= 0.68.67)
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTPushNotificationHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTSettings (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.68.66)
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTSettingsHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTTest (0.68.66):
+    - RCTTypeSafety (= 0.68.67)
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTSettingsHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTTest (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core (= 0.68.66)
-    - React-CoreModules (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-RCTText (0.68.66):
-    - React-Core/RCTTextHeaders (= 0.68.66)
-  - React-RCTVibration (0.68.66):
+    - React-Core (= 0.68.67)
+    - React-CoreModules (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-RCTText (0.68.67):
+    - React-Core/RCTTextHeaders (= 0.68.67)
+  - React-RCTVibration (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.68.66)
-    - React-Core/RCTVibrationHeaders (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-runtimeexecutor (0.68.66):
-    - React-jsi (= 0.68.66)
-  - React-TurboModuleCxx-RNW (0.68.66):
+    - React-Codegen (= 0.68.67)
+    - React-Core/RCTVibrationHeaders (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-runtimeexecutor (0.68.67):
+    - React-jsi (= 0.68.67)
+  - React-TurboModuleCxx-RNW (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.66)
-    - React-TurboModuleCxx-WinRTPort (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
-  - React-TurboModuleCxx-WinRTPort (0.68.66):
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.66)
-    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.68.66)
-  - React-TurboModuleCxx-WinRTPort/Shared (0.68.66)
-  - React-TurboModuleCxx-WinRTPort/WinRT (0.68.66):
+    - React-callinvoker (= 0.68.67)
+    - React-TurboModuleCxx-WinRTPort (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
+  - React-TurboModuleCxx-WinRTPort (0.68.67):
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.67)
+    - React-TurboModuleCxx-WinRTPort/WinRT (= 0.68.67)
+  - React-TurboModuleCxx-WinRTPort/Shared (0.68.67)
+  - React-TurboModuleCxx-WinRTPort/WinRT (0.68.67):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.66)
-    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.66)
-  - ReactCommon/turbomodule/core (0.68.66):
+    - React-callinvoker (= 0.68.67)
+    - React-TurboModuleCxx-WinRTPort/Shared (= 0.68.67)
+  - ReactCommon/turbomodule/core (0.68.67):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.66)
-    - React-Core (= 0.68.66)
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-logger (= 0.68.66)
-    - React-perflogger (= 0.68.66)
-  - ReactCommon/turbomodule/samples (0.68.66):
+    - React-callinvoker (= 0.68.67)
+    - React-Core (= 0.68.67)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-logger (= 0.68.67)
+    - React-perflogger (= 0.68.67)
+  - ReactCommon/turbomodule/samples (0.68.67):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.68.66)
-    - React-Core (= 0.68.66)
-    - React-cxxreact (= 0.68.66)
-    - React-jsi (= 0.68.66)
-    - React-logger (= 0.68.66)
-    - React-perflogger (= 0.68.66)
-    - ReactCommon/turbomodule/core (= 0.68.66)
+    - React-callinvoker (= 0.68.67)
+    - React-Core (= 0.68.67)
+    - React-cxxreact (= 0.68.67)
+    - React-jsi (= 0.68.67)
+    - React-logger (= 0.68.67)
+    - React-perflogger (= 0.68.67)
+    - ReactCommon/turbomodule/core (= 0.68.67)
   - ScreenshotManager (0.0.1):
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core
@@ -576,8 +576,8 @@ SPEC CHECKSUMS:
   boost: 613e39eac4239cc72b15421247b5ab05361266a2
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: ed15e075aa758ac0e4c1f8b830bd4e4d40d669e8
-  FBLazyVector: 55c06d35bd70b5a578cba8c9f88de19bdfb264f5
-  FBReactNativeSpec: 9f50614e581878710ed6b6d17f93c7c332ac4832
+  FBLazyVector: 7bfebcced895c01d73f476917c33ddfc49f5b291
+  FBReactNativeSpec: 009793a4bdc05a7e4247e9869a609cbd9d70df27
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 3d3d04a078d4f3a1b6c6916587f159dc11f232c4
@@ -592,37 +592,37 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 5544a3ff21f4406e70e92a8711598e97fc81517c
-  RCTRequired: 310b4cc8ca8ef3ed38cdb70d2c4ba91360837a95
-  RCTTypeSafety: 1d97a4a995aa16fc17a4ba4b5a2d41438b8155c5
-  React: d7b4979fb798eb256b1731de746654b988bd26d1
-  React-callinvoker: df042fbe7a272b3da48953143b9d3f47af539a3c
-  React-Codegen: 6c9e0915b99ec945658119545646f807d6f29039
-  React-Core: 581b1b7a5d85a8f647a618877dc22732c9635c0b
-  React-CoreModules: 92cc8b624d34a6b3dc6bd58b29553ca5fa713b6b
-  React-cxxreact: 88c6440f2ae6b7098cb754d94b891ad8ebc6b7e0
-  React-jsi: 5f8c4cc6913b1d8a7099551d6dc184d375bd922a
-  React-jsiexecutor: 77985718d9a89c6b7f547372420c5608d7f7ccab
-  React-jsinspector: 43175faeaad04f7f76a8a159d4fe8953f714bfc6
-  React-logger: f88282cd40a0845743753e1c4a2fce29519963be
-  React-perflogger: cf930b397ec692fa56958e38932d386c219a7d94
-  React-RCTActionSheet: 4c6e6b19b4a6536c7e42e335a388373168f62ac4
-  React-RCTAnimation: f8fa75b8f430e1d1e3b36fd78d1f5ec882f56e5d
-  React-RCTBlob: a5c98b78b93be45391e2697c6a2d2fdf725916cb
-  React-RCTImage: d8291ea3f1b36894521186b7423206f8bbeb7b5d
-  React-RCTLinking: 753f2d8f7d2d1fd1c39b9eb91a03cd5da7e9e119
-  React-RCTNetwork: b1639b623b255b3b5821743dc37887e69e6dc6d7
-  React-RCTPushNotification: 5c8abfdc4a9facf5acbc9f8bee0cbeb7d39c584d
-  React-RCTSettings: 4db3c44fd41de75f405d1ed3423d6d3ace1b699f
-  React-RCTTest: 4cf6bf0544cdce5208a8fded7f4e22b085e27c3a
-  React-RCTText: 11699c87ac515d7bde9173ae8e95afc8c6e42e6b
-  React-RCTVibration: 5e01780eb45effeb1e538fc3c64ffa186423eb2a
-  React-runtimeexecutor: 17ad66d482998fbe0a92253cced17a5cbc06a125
-  React-TurboModuleCxx-RNW: cb0c6f987cfa63529626df7f7d49047cc8f09905
-  React-TurboModuleCxx-WinRTPort: 5f6af2b7fc9e2d075bef12dc514f917a8008a764
-  ReactCommon: d4e6d01d12414c52ec5d0de14d9ad8cd5d09ad61
+  RCTRequired: fece3c0808a220769464ebdd3dc5f0713057a929
+  RCTTypeSafety: f57e5bb0a9cdbaf405a62c187a2e1b69cbe99f0b
+  React: 5b483df697a9577058b1aa14dd717705c0041222
+  React-callinvoker: ffbadf125e12579c598f0feede343f59933af3c3
+  React-Codegen: 9f80bb770d49bf368be6fa540764852736df21c1
+  React-Core: 3395048e88a200bdb480cdf79f1838cea755975a
+  React-CoreModules: 7dedac3257653b7f63eb4985bf3da43ac4fd23c9
+  React-cxxreact: e2c8d0c662c5ac528a49908074d7ca525f1fb062
+  React-jsi: 77d8f35d7f1e835e58d3cbaefd05c2ec250f83e2
+  React-jsiexecutor: 74ce2ca671847e950f3749da830695f351b88c0a
+  React-jsinspector: 2517685f2fb5d0f497b0a9a2711da98abd7245e8
+  React-logger: 6b87b4f0a0690b24ed114f94ec83342ac9b29b8c
+  React-perflogger: 65dbd44844aed1fe2fb05b7fc7718a3189ed14de
+  React-RCTActionSheet: 191f7048ac87b76c272aef02b805229381583baa
+  React-RCTAnimation: dad08278d2c87c07d04aa87fd05c3030110009d4
+  React-RCTBlob: fea96a6b93d58c59a51a8439e1b988d2cc7ae3ed
+  React-RCTImage: 3c46544253a628c37bec1a335b280d97140ad46f
+  React-RCTLinking: ffdfab3a668cdd0fda7cd121575dd5fac3fffa95
+  React-RCTNetwork: 1c9c1ce93db4ccc90bc7059b26b08fb2880bc5b0
+  React-RCTPushNotification: 0ef5d6f346cb6d1505c0b5e64ed9e1fbb2ecd73d
+  React-RCTSettings: e19db96fb3b391580dbc0595ad58cef2c297ea97
+  React-RCTTest: 7945f2e807d16f45cf513b792ec8b53d061c24a0
+  React-RCTText: 2d3d6134ac85da5c95f4f929f8569761d58d6e91
+  React-RCTVibration: 9a3fdb15269193dac4961838d6410ec8cff4429d
+  React-runtimeexecutor: 03ce535d2bf2cc72d490d492eef859181e3c04d8
+  React-TurboModuleCxx-RNW: be7ecfc56f2b71547ce6998522af07c67ab64ef7
+  React-TurboModuleCxx-WinRTPort: dc743f9431f680a8d3b3fdc2083a5e120c2269e0
+  ReactCommon: 91519dda8c5e923a43a44faf5f9ece69dcfffea6
   ScreenshotManager: a2479ac2273d34c8c2c1e4b8e33fe46fb2f0fb60
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: bb01caf02105a5b0cd8ea3b3d79d9884d503575c
+  Yoga: c9f2c0cd62c812f9f4840a52af8cd23652940580
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: f75714fcec17ede364b8166fcfded0d9bc9ea275

--- a/template/package.json
+++ b/template/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "17.0.2",
-    "react-native-macos": "0.68.66"
+    "react-native-macos": "0.68.67"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
Manual bump to 0.68.67 to unblock publishing pipelines.

Script run: `node scripts/set-rn-version.js -v 0.68.67 -n -S`