### PR TITLE
[Test] Fix publish.yml

### DIFF
--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -10,7 +10,7 @@ pr:
   branches:
     include:
       - main
-      - '*-stable'
+      - 0.71-stable
   paths:
     exclude:
       - '*.md'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,6 +1,3 @@
-# It is expected that a `latestStableBranch` variable is set in the pipeline's settings:
-# https://dev.azure.com/office/ISS/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=18541
-
 # This file defines the build steps to publish a release
 name: $(Date:yyyyMMdd).$(Rev:.r)
 
@@ -9,8 +6,7 @@ trigger:
   branches:
     include:
       - main
-      - 0.68-stable
-      - 0.71-stable
+      - '*-stable'
   paths:
     exclude:
       - package.json


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Our publish pipeline seems to have been broken since this commit: https://github.com/microsoft/react-native-macos/commit/b50758fe0d6b8778f9acb9cf5d84170d1999517d/

My guess is Azure pipelines doesn't like "0.68-stable" as a branch name. So let's revert back to the string with wildcard. 

## Changelog

[GENERAL] [FIXED] - Fix publish.yml

## Test Plan

CI should pass
