### PR TITLE
Fix Publish pipeline (take 3)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -40,11 +40,11 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - ${{ if eq(variables['isMain'], true) }}:
+      - ${{ if eq(variables['isMain'], True) }}:
         - template: templates/apple-job-publish.yml
           parameters:
             build_type: nightly
-      - ${{ elseif eq(variables['isReleaseBranch'], true) }}:
+      - ${{ elseif eq(variables['isReleaseBranch'], True) }}:
         - template: templates/apple-job-publish.yml
           parameters:
             build_type: release


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Apparently yml treats booleans as Capital-T-True, not lowercase t  🤷🏾

## Changelog

[MACOS] [FIXED] - Fix publish (take 3)

## Test Plan

🤷🏾