### PR TITLE
Refactor publish pipeline (Take 4) 

### DIFF
--- a/.ado/get-next-semver-version.js
+++ b/.ado/get-next-semver-version.js
@@ -2,22 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const semver = require('semver');
-const {execSync} = require('child_process');
-
-const pkgJsonPath = path.resolve(__dirname, "../package.json");
-let publishBranchName = '';
-try {
-  publishBranchName = process.env.BUILD_SOURCEBRANCH.match(/refs\/heads\/(.*)/)[1];
-} catch (error) {}
-
-function gatherVersionInfo() {
-    let pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
-
-    let releaseVersion = pkgJson.version;
-    const branchVersionSuffix = (publishBranchName.match(/(fb.*merge)|(fabric)/) ? `-${publishBranchName}` : '');
-
-    return {pkgJson, releaseVersion, branchVersionSuffix};
-}
+const {gatherVersionInfo} = require('./versionUtils');
 
 function getNextVersion(patchVersionPrefix) {
 

--- a/.ado/gitTagRelease.js
+++ b/.ado/gitTagRelease.js
@@ -1,0 +1,44 @@
+// @ts-check
+// Used to apply the package updates: the git tag for the published release.
+
+const execSync = require("child_process").execSync;
+const {publishBranchName, gatherVersionInfo} = require('./versionUtils');
+
+function exec(command) {
+  try {
+    console.log(`Running command: ${command}`);
+    return execSync(command, {
+      stdio: "inherit"
+    });
+  } catch (err) {
+    process.exitCode = 1;
+    console.log(`Failure running: ${command}`);
+    throw err;
+  }
+}
+
+function doPublish() {
+  console.log(`Target branch to publish to: ${publishBranchName}`);
+
+  const {releaseVersion} = gatherVersionInfo()
+
+  const tempPublishBranch = `publish-temp-${Date.now()}`;
+  exec(`git checkout -b ${tempPublishBranch}`);
+
+  exec(`git add .`);
+  exec(`git commit -m "Applying package update to ${releaseVersion} ***NO_CI***"`);
+  exec(`git tag v${releaseVersion}`);
+  exec(`git push origin HEAD:${tempPublishBranch} --follow-tags --verbose`);
+  exec(`git push origin tag v${releaseVersion}`);
+
+  exec(`git checkout ${publishBranchName}`);
+  exec(`git pull origin ${publishBranchName}`);
+  exec(`git merge ${tempPublishBranch} --no-edit`);
+  exec(
+    `git push origin HEAD:${publishBranchName} --follow-tags --verbose`
+  );
+  exec(`git branch -d ${tempPublishBranch}`);
+  exec(`git push origin --delete -d ${tempPublishBranch}`);  
+}
+
+doPublish();

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -40,6 +40,11 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      # Setup the repo to be ready for release. This includes:
+      # - Autogenerating the next version number
+      # - Calling the approprate scripts that upstream React Native uses to prepare a release
+      # - Skipping the actual `git tag`, `git push`, and `npm publish steps as we do that here instead
+
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
         - template: templates/apple-job-publish.yml
           parameters:
@@ -56,6 +61,8 @@ jobs:
               echo "Skipping publish for branch $(Build.SourceBranchName)"
               exit 1
 
+      # Generate and publish the SBOM
+  
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 📒 Generate Manifest
         inputs:
@@ -66,6 +73,42 @@ jobs:
         inputs:
           artifactName: SBom-RNGithubNpmJSPublish-$(System.JobAttempt)
           targetPath: $(System.DefaultWorkingDirectory)/_manifest
+
+      # Set the NPM dist-tag and do the actual NPM publish
+  
+      - bash: echo "##vso[task.setvariable variable=npmDistTag]latest"
+        displayName: Set dist-tag to latest
+        condition: eq(variables['Build.SourceBranchName'], variables.latestStableBranch)
+
+      - bash: echo "##vso[task.setvariable variable=npmDistTag]canary"
+        displayName: Set dist-tag to canary
+        condition: eq(variables['Build.SourceBranchName'], 'main')
+
+      - bash: echo "##vso[task.setvariable variable=npmDistTag]v${{variables['Build.SourceBranchName']}}"
+        displayName: Set dist-tag to v0.x-stable
+        condition: and(ne(variables['Build.SourceBranchName'], 'main'), ne(variables['Build.SourceBranchName'], variables.latestStableBranch))
+
+      - task: CmdLine@2
+        displayName: Actual NPM Publish
+        inputs:
+          script: |
+            npm publish --tag $(npmDistTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+
+      # Set the git tag and push the version update back to Github
+
+      - template: templates/configure-git.yml
+
+      - task: CmdLine@2
+        displayName: 'Tag and push to Github'
+        inputs:
+          script: node .ado/gitTagRelease.js
+        env:
+          BUILD_STAGINGDIRECTORY: $(Build.StagingDirectory)
+          BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          githubAuthToken: $(githubAuthToken)
+        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
+      
 
   - job: RNMacOSInitNpmJSPublish
     displayName: NPM Publish react-native-macos-init
@@ -85,7 +128,7 @@ jobs:
 
       - template: templates/apple-install-dependencies.yml
 
-      - template: templates/apple-release-setup.yml
+      - template: templates/configure-git.yml
 
       - task: CmdLine@2
         displayName: Build react-native-macos-init

--- a/.ado/templates/apple-job-publish.yml
+++ b/.ado/templates/apple-job-publish.yml
@@ -6,52 +6,36 @@ steps:
 
   - template: apple-install-dependencies.yml
 
-  # Only set up our release environment if we're not doing a dry run
-  - ${{ if ne( parameters['build_type'], 'dry-run') }}:
-    - template: apple-release-setup.yml  
-
-  - task: CmdLine@2
-    displayName: Set build type to ${{parameters.build_type}}
-    inputs:
-      script: |
-        BUILD_TYPE=${{parameters.build_type}}
-        echo "Set build type: $BUILD_TYPE"
-
   # Extra steps needed for *-stable releases
   - ${{ if eq( parameters['build_type'], 'release') }}:
-    - task: CmdLine@2
-      displayName: Set next version
-      inputs:
-        script: |
-          VERSION=$(node .ado/get-next-semver-version.js)
-          echo "Set version: $VERSION"
-
-    - task: CmdLine@2
-      displayName: Set build type to ${{parameters.build_type}}
-      inputs:
-        script: |
-          BUILD_TYPE=release
-          echo "Set build type: $BUILD_TYPE"
-
     - task: CmdLine@2
       displayName: Set latest tag
       inputs:
         script: |
           LATEST=true
           echo "Set latest to: $LATEST"
+      condition: eq(variables['Build.SourceBranchName'], variables.latestStableBranch)
 
+    # Note, This won't do the actual `git tag` and `git push` as we're doing a dry run.
+    # We do that as a separate step in `.ado/publish.yml`.
     - task: CmdLine@2
-      displayName: Prepare and tag package for release
+      displayName: Prepare package for release
       inputs:
         script: |
+          VERSION=$(node .ado/get-next-semver-version.js)
           if [[ -z "$VERSION" ]]; then
             VERSION=$(grep '"version"' package.json | cut -d '"' -f 4 | head -1)
             echo "Using the version from the package.json: $VERSION"
           fi
-          node ./scripts/prepare-package-for-release.js -v "$VERSION" -l $LATEST
+          node ./scripts/prepare-package-for-release.js -v "$VERSION" --dry-run
+      env:
+        # Map the corresponding variable since `prepare-package-for-release.js` depends on it.
+        CIRCLE_BRANCH: $(Build.SourceBranchName)
 
+  # Note: This won't actually publish to NPM as we've commented that bit out.
+  # We do that as a separate step in `.ado/publish.yml`. 
   - task: CmdLine@2
-    displayName: NPM Publish
+    displayName: Run publish-npm.js
     inputs:
       script: |
         node ./scripts/publish-npm.js --${{ parameters.build_type }}

--- a/.ado/templates/configure-git.yml
+++ b/.ado/templates/configure-git.yml
@@ -6,8 +6,5 @@ steps:
         git config --global user.email "53619745+rnbot@users.noreply.github.com"
         git config --global user.name "React-Native Bot"
 
-  - task: CmdLine@2
-    displayName: Set NPM Auth Token
-    inputs:
-      script: |
-        echo "//registry.npmjs.org/:_authToken=${npmAuthToken}" > ~/.npmrc
+  - script: git remote set-url origin https://rnbot:$(githubAuthToken)@github.com/microsoft/react-native-macos
+    displayName: Set Permissions to push

--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -2,3 +2,4 @@ variables:
   VmImageApple: internal-macos12
   slice_name: 'Xcode_14.2'
   xcode_version: '/Applications/Xcode_14.2.app'
+  latestStableBranch: '0.71-stable'

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -1,0 +1,26 @@
+// @ts-check
+const fs = require("fs");
+const path = require("path");
+const semver = require('semver');
+const {execSync} = require('child_process');
+
+const pkgJsonPath = path.resolve(__dirname, "../package.json");
+let publishBranchName = '';
+try {
+  publishBranchName = process.env.BUILD_SOURCEBRANCH.match(/refs\/heads\/(.*)/)[1];
+} catch (error) {}
+
+function gatherVersionInfo() {
+    let pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+
+    let releaseVersion = pkgJson.version;
+    const branchVersionSuffix = (publishBranchName.match(/(fb.*merge)|(fabric)/) ? `-${publishBranchName}` : '');
+
+    return {pkgJson, releaseVersion, branchVersionSuffix};
+}
+
+module.exports = {
+    gatherVersionInfo,
+    publishBranchName,
+    pkgJsonPath,
+}

--- a/scripts/prepare-package-for-release.js
+++ b/scripts/prepare-package-for-release.js
@@ -22,7 +22,6 @@ const {echo, exec, exit} = require('shelljs');
 const yargs = require('yargs');
 const {isReleaseBranch, parseVersion} = require('./version-utils');
 const {failIfTagExists} = require('./release-utils');
-const {getBranchName} = require('./scm-utils'); // [macOS]
 
 const argv = yargs
   .option('r', {
@@ -45,7 +44,7 @@ const argv = yargs
     default: false,
   }).argv;
 
-const branch = getBranchName(); // [macOS] Don't rely on CircleCI environment variables.
+const branch = process.env.CIRCLE_BRANCH;
 const remote = argv.remote;
 const releaseVersion = argv.toVersion;
 const isLatest = argv.latest;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

We still had NPM publish problems... and after lots of testing, I believe I have found the fix.
The previous refactors attempted to use the nodejs scripts from React Native Core to perform tasks like `git tag`, `git push`, and `npm publish`. However, for whatever reason when those scripts are run in Azure Pipelines, they don't have access our secrets (AKA: `githubAuthToken`, and `npmAuthToken`), and those steps would always fail. This is partially because (as I learned), you must explicitly pass secrets down to each individual step as an environment variable, even if they're already set elsewhere (soemthing about scoping of variables to individual tasks..).

So now, we do the following:
- run `prepare-package-for-release.js` as a dry-run so it skips the `git tag / git push` phase
- Comment out the actual `npm publish` from `publish-npm.js`
- Add extra steps to `.ado/publish.yml` that do the `git tag / git push / npm publish` instead. This involved bringing back some files I had deleted in earlier takes of the refactor 😅.
- Add an extra step to `.ado/configure-git.yml` to give rnbot push permissions as that was missing. This is taken from #1776.
- Add a bunch of comments to `.ado/publish.yml` so hopefully the git history is less confusing 🥲


## Changelog

[INTERNAL] [FIXED] - Refactor publish pipeline (Take 4) 

## Test Plan

I ran these changes (with some modifications to fake the branch name / release type) and successfully published both a nightly and `0.71.0` to NPM. I also tested the `git push` bit by seeing if I I could have rnbot push to a test branch.
