### PR TITLE
[Fabric] Use RCT_NEW_ARCH_ENABLED flag for enabling new arch

### DIFF
--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -38,8 +38,8 @@ jobs:
           xcode_configuration: 'Debug'
           xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
           xcode_actions: 'build test'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-          use_fabric: '0'
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+          new_arch_enabled: '0'
           use_hermes: '0'
         'iOS Paper Release JSC':
           packager_platform: 'ios'
@@ -48,8 +48,8 @@ jobs:
           xcode_configuration: 'Release'
           xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
           xcode_actions: 'build'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
-          use_fabric: '0'
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
+          new_arch_enabled: '0'
           use_hermes: '0'
         'macOS Paper Debug JSC':
           packager_platform: 'macos'
@@ -58,8 +58,8 @@ jobs:
           xcode_configuration: 'Debug'
           xcode_destination: 'platform=macOS,arch=x86_64'
           xcode_actions: 'build test'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-          use_fabric: '0'
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+          new_arch_enabled: '0'
           use_hermes: '0'
         'macOS Paper Release JSC':
           packager_platform: 'macos'
@@ -68,8 +68,8 @@ jobs:
           xcode_configuration: 'Release'
           xcode_destination: 'platform=macOS,arch=x86_64'
           xcode_actions: 'build'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
-          use_fabric: '0'
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
+          new_arch_enabled: '0'
           use_hermes: '0'
         'iOS Fabric Debug JSC':
           packager_platform: 'ios'
@@ -78,8 +78,8 @@ jobs:
           xcode_configuration: 'Debug'
           xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
           xcode_actions: 'build test'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-          use_fabric: '1'
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+          new_arch_enabled: '1'
           use_hermes: '0'
         'iOS Fabric Release JSC':
           packager_platform: 'ios'
@@ -88,8 +88,8 @@ jobs:
           xcode_configuration: 'Release'
           xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
           xcode_actions: 'build'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
-          use_fabric: '1' 
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
+          new_arch_enabled: '1'
           use_hermes: '0'
         'macOS Fabric Debug JSC':
           packager_platform: 'macos'
@@ -98,8 +98,8 @@ jobs:
           xcode_configuration: 'Debug'
           xcode_destination: 'platform=macOS,arch=x86_64'
           xcode_actions: 'build test'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-          use_fabric: '1'
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+          new_arch_enabled: '1'
           use_hermes: '0'
         'macOS Fabric Release JSC':
           packager_platform: 'macos'
@@ -108,8 +108,8 @@ jobs:
           xcode_configuration: 'Release'
           xcode_destination: 'platform=macOS,arch=x86_64'
           xcode_actions: 'build'
-          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
-          use_fabric: '1'
+          xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
+          new_arch_enabled: '1'
           use_hermes: '0'
         # Disable Hermes Jobs for now
         # 'iOS Paper Debug Hermes':
@@ -119,8 +119,8 @@ jobs:
         #   xcode_configuration: 'Debug'
         #   xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
         #   xcode_actions: 'build test'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-        #   use_fabric: '0'
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+        #   new_arch_enabled: '0'
         #   use_hermes: '1'
         # 'iOS Paper Release Hermes':
         #   packager_platform: 'ios'
@@ -128,9 +128,9 @@ jobs:
         #   xcode_scheme: 'RNTester'
         #   xcode_configuration: 'Release'
         #   xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
         #   xcode_actions: 'build'
-        #   use_fabric: '0'
+        #   new_arch_enabled: '0'
         #   use_hermes: '1'
         # 'macOS Paper Debug Hermes':
         #   packager_platform: 'macos'
@@ -139,8 +139,8 @@ jobs:
         #   xcode_configuration: 'Debug'
         #   xcode_destination: 'platform=macOS,arch=x86_64'
         #   xcode_actions: 'build test'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-        #   use_fabric: '0'
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+        #   new_arch_enabled: '0'
         #   use_hermes: '1'
         # 'macOS Paper Release Hermes':
         #   packager_platform: 'macos'
@@ -149,28 +149,28 @@ jobs:
         #   xcode_configuration: 'Release'
         #   xcode_destination: 'platform=macOS,arch=x86_64'
         #   xcode_actions: 'build'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
-        #   use_fabric: '0'
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
+        #   new_arch_enabled: '0'
         #   use_hermes: '1'
-        # 'iOS Fabric Debug Hermes': 
+        # 'iOS Fabric Debug Hermes':
         #   packager_platform: 'ios'
         #   xcode_sdk: iphonesimulator
         #   xcode_scheme: 'RNTester'
         #   xcode_configuration: 'Debug'
         #   xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
         #   xcode_actions: 'build test'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-        #   use_fabric: '1'
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+        #   new_arch_enabled: '1'
         #   use_hermes: '1'
-        # 'iOS Fabric Release Hermes': 
+        # 'iOS Fabric Release Hermes':
         #   packager_platform: 'ios'
         #   xcode_sdk: iphonesimulator
         #   xcode_scheme: 'RNTester'
         #   xcode_configuration: 'Release'
         #   xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
         #   xcode_actions: 'build'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
-        #   use_fabric: '1' 
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
+        #   new_arch_enabled: '1'
         #   use_hermes: '0'
         # 'macOS Fabric Debug Hermes':
         #   packager_platform: 'macos'
@@ -179,8 +179,8 @@ jobs:
         #   xcode_configuration: 'Debug'
         #   xcode_destination: 'platform=macOS,arch=x86_64'
         #   xcode_actions: 'build test'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig' 
-        #   use_fabric: '1'
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/debug_overrides.xcconfig'
+        #   new_arch_enabled: '1'
         #   use_hermes: '1'
         # 'macOS Fabric Release Hermes':
         #   packager_platform: 'macos'
@@ -189,8 +189,8 @@ jobs:
         #   xcode_configuration: 'Release'
         #   xcode_destination: 'platform=macOS,arch=x86_64'
         #   xcode_actions: 'build'
-        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig' 
-        #   use_fabric: '1'
+        #   xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/release_overrides.xcconfig'
+        #   new_arch_enabled: '1'
         #   use_hermes: '1'
     pool:
       vmImage: $(VmImageApple)
@@ -241,4 +241,3 @@ jobs:
       - template: templates/apple-job-publish.yml
         parameters:
           build_type: 'dry-run'
-

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -8,7 +8,7 @@ parameters:
   xcode_extraArgs: ''
   slice_name: ''
   xcode_version: ''
-  use_fabric: ''
+  new_arch_enabled: ''
   use_hermes: ''
 
 steps:
@@ -33,7 +33,7 @@ steps:
         bundle install
         bundle exec pod install
     env:
-      USE_FABRIC: $(use_fabric)
+      RCT_NEW_ARCH_ENABLED: $(new_arch_enabled)
       USE_HERMES: $(use_hermes)
 
   - task: ShellScript@2
@@ -78,4 +78,3 @@ steps:
       disableAutoCwd: true
       cwd: ''
     condition: always()
-

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.podspec
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.description     = "NativeCxxModuleExample"
   s.homepage        = "https://github.com/facebook/react-native.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "12.4" }
+  s.platforms       = { :ios => "12.4", :osx => "10.15" } # [macos]
   s.compiler_flags  = '-Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/react-native.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -19,7 +19,7 @@ def pods(target_name, options = {}, use_flipper: !IN_CI && !USE_FRAMEWORKS)
   project 'RNTesterPods.xcodeproj'
 
   # [macOS Disable Fabric by default till macOS supports it
-  fabric_enabled = ENV['USE_FABRIC'] == '1' || ENV['RCT_NEW_ARCH_ENABLED'] == '1' 
+  fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
   # macOS]
 
   # Hermes is now enabled by default.


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

RCT_NEW_ARCH_ENABLED flag is what RN core uses for enabling the new architecture

## Changelog

[GENERAL] [FIXED] - Use build flag from RN mobile for enabling new architecture

## Test Plan

**Fabric builds**

`RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --verbose`

![CleanShot 2023-04-10 at 13 43 54](https://user-images.githubusercontent.com/96719/230995386-315aceec-c305-4e54-a71b-3a127cdd3cd7.jpg)

