### PR TITLE
Don't publish the SBOM back to Github

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -61,19 +61,6 @@ jobs:
               echo "Skipping publish for branch $(Build.SourceBranchName)"
               exit 1
 
-      # Generate and publish the SBOM
-  
-      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        displayName: 📒 Generate Manifest
-        inputs:
-          BuildDropPath: $(System.DefaultWorkingDirectory)
-
-      - task: PublishPipelineArtifact@1
-        displayName: 📒 Publish Manifest
-        inputs:
-          artifactName: SBom-RNGithubNpmJSPublish-$(System.JobAttempt)
-          targetPath: $(System.DefaultWorkingDirectory)/_manifest
-
       # Set the NPM dist-tag and do the actual NPM publish
   
       - bash: echo "##vso[task.setvariable variable=npmDistTag]latest"
@@ -108,6 +95,19 @@ jobs:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           githubAuthToken: $(githubAuthToken)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
+
+      # Generate and publish the SBOM
+  
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 📒 Generate Manifest
+        inputs:
+          BuildDropPath: $(System.DefaultWorkingDirectory)
+
+      - task: PublishPipelineArtifact@1
+        displayName: 📒 Publish Manifest
+        inputs:
+          artifactName: SBom-RNGithubNpmJSPublish-$(System.JobAttempt)
+          targetPath: $(System.DefaultWorkingDirectory)/_manifest
       
 
   - job: RNMacOSInitNpmJSPublish


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Our CI would generate the SBOM, and then commit all files and push back to Github as part of a version update. That meant the SBOM manifest was also picked up. Let's move the "Generate and Publish SBOM" steps to _after_ the "Push back to Github" steps so they aren't picked up. Let's also remove the manifest files.

## Changelog

[INTERNAL] [CHANGED] - Don't publish the SBOM back to Github

## Test Plan

I'll keep an eye on the next publish.
