### PR TITLE
[0.68] Handle edge case for setContentOffset with animation

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -25,6 +25,7 @@
 #import "RCTRefreshControl.h"
 #else
 #import "RCTViewKeyboardEvent.h"
+#import "RCTI18nUtil.h"
 #endif // TODO(macOS GH#774)
 
 /**
@@ -257,6 +258,10 @@
     [NSAnimationContext beginGrouping];
     [[NSAnimationContext currentContext] setDuration:0.3];
     [[self.contentView animator] setBoundsOrigin:contentOffset];
+    if([[RCTI18nUtil sharedInstance] isRTL] && contentOffset.y < 1) {
+        [self.contentView scrollToPoint:contentOffset];
+        [self reflectScrolledClipView:self.contentView];
+    }
     [NSAnimationContext endGrouping];
   } else {
     self.contentOffset = contentOffset;

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -24,8 +24,8 @@
 #if !TARGET_OS_OSX // TODO(macOS GH#774)
 #import "RCTRefreshControl.h"
 #else
-#import "RCTViewKeyboardEvent.h"
 #import "RCTI18nUtil.h"
+#import "RCTViewKeyboardEvent.h"
 #endif // TODO(macOS GH#774)
 
 /**
@@ -258,7 +258,8 @@
     [NSAnimationContext beginGrouping];
     [[NSAnimationContext currentContext] setDuration:0.3];
     [[self.contentView animator] setBoundsOrigin:contentOffset];
-    if([[RCTI18nUtil sharedInstance] isRTL] && contentOffset.y < 1) {
+    // Handling a weird bug where setBoundsOrigin doesn't actually update view bounds
+    if ([[RCTI18nUtil sharedInstance] isRTL] && contentOffset.y < 1) {
         [self.contentView scrollToPoint:contentOffset];
         [self reflectScrolledClipView:self.contentView];
     }


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

A client downstream reported a bug in Flatlist where the clip view does not get scrolled to the offset that's being passed in when in RTL mode. Turns out this issue only repros when animation is enabled, #725 which was added a while back. Since scrollToPoint is not animatable, let's call it alongside setBoundsOrigin so that the animation is still present.


## Test Plan

Verified downstream