### PR TITLE
Add cursorColor support to TextInput

### DIFF
--- a/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -163,6 +163,7 @@ const RCTTextInputViewConfig = {
     pastedTypes: true,
     submitKeyEvents: true,
     tooltip: true,
+    cursorColor: {process: require('../../StyleSheet/processColor').default},
     // macOS]
     ...ConditionallyIgnoredEventHandlers({
       onChange: true,

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -612,7 +612,7 @@ type AndroidProps = $ReadOnly<{|
    * When provided it will set the color of the cursor (or "caret") in the component.
    * Unlike the behavior of `selectionColor` the cursor color will be set independently
    * from the color of the text selection box.
-   * @platform android
+   * @platform android macos
    */
   cursorColor?: ?ColorValue,
 

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -612,6 +612,7 @@ type AndroidProps = $ReadOnly<{|
    * When provided it will set the color of the cursor (or "caret") in the component.
    * Unlike the behavior of `selectionColor` the cursor color will be set independently
    * from the color of the text selection box.
+   // [macOS]
    * @platform android macos
    */
   cursorColor?: ?ColorValue,

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_OSX // [macOS
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;
-@property (nonatomic, strong, nullable) RCTUIColor *selectionColor; // TODO(OSS Candidate ISS#2710739)
+@property (nonatomic, strong, nullable) RCTUIColor *selectionColor;
 @property (nonatomic, strong, nullable) RCTUIColor *cursorColor;
 @property (nonatomic, assign) UIEdgeInsets textContainerInsets;
 @property (nonatomic, copy) NSString *text;

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_OSX // [macOS
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor; // TODO(OSS Candidate ISS#2710739)
+@property (nonatomic, strong, nullable) RCTUIColor *cursorColor;
 @property (nonatomic, assign) UIEdgeInsets textContainerInsets;
 @property (nonatomic, copy) NSString *text;
 @property (nonatomic, assign) NSTextAlignment textAlignment;

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -22,6 +22,7 @@
   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
 #if TARGET_OS_OSX // [macOS
   NSArray<NSPasteboardType> *_readablePasteboardTypes;
+  RCTUIColor *_cursorColor;
 #endif // macOS]
 }
 
@@ -152,12 +153,23 @@ static RCTUIColor *defaultPlaceholderColor() // [macOS]
   NSMutableDictionary *selectTextAttributes = self.selectedTextAttributes.mutableCopy;
   selectTextAttributes[NSBackgroundColorAttributeName] = selectionColor ?: [NSColor selectedControlColor];
   self.selectedTextAttributes = selectTextAttributes.copy;
-  self.insertionPointColor = self.selectionColor ?: [NSColor textColor];
+  self.insertionPointColor = _cursorColor ?: self.selectionColor ?: [NSColor textColor];
 }
 
 - (RCTUIColor*)selectionColor
 {
   return (RCTUIColor*)self.selectedTextAttributes[NSBackgroundColorAttributeName];
+}
+
+- (NSColor*)cursorColor
+{
+  return _cursorColor;
+}
+
+- (void)setCursorColor:(NSColor *)cursorColor
+{
+  _cursorColor = cursorColor;
+  self.insertionPointColor = cursorColor;
 }
 
 - (void)setEnabledTextCheckingTypes:(NSTextCheckingTypes)checkingType

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -22,7 +22,6 @@
   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
 #if TARGET_OS_OSX // [macOS
   NSArray<NSPasteboardType> *_readablePasteboardTypes;
-  RCTUIColor *_cursorColor;
 #endif // macOS]
 }
 
@@ -159,11 +158,6 @@ static RCTUIColor *defaultPlaceholderColor() // [macOS]
 - (RCTUIColor*)selectionColor
 {
   return (RCTUIColor*)self.selectedTextAttributes[NSBackgroundColorAttributeName];
-}
-
-- (NSColor*)cursorColor
-{
-  return _cursorColor;
 }
 
 - (void)setCursorColor:(NSColor *)cursorColor

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL clearTextOnSubmit;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onSubmitEditing;
 @property (nonatomic, copy) NSArray<NSDictionary *> *submitKeyEvents;
+@property (nonatomic, strong, nullable) RCTUIColor *cursorColor;
 #endif // macOS]
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, assign, readonly) NSInteger nativeEventCount;

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -47,7 +47,6 @@ RCT_REMAP_VIEW_PROPERTY(placeholderTextColor, backedTextInputView.placeholderCol
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(returnKeyType, backedTextInputView.returnKeyType, UIReturnKeyType) // [macOS]
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(selectionColor, backedTextInputView.tintColor, UIColor) // [macOS]
 RCT_REMAP_OSX_VIEW_PROPERTY(selectionColor, backedTextInputView.selectionColor, UIColor) // [macOS]
-RCT_REMAP_OSX_VIEW_PROPERTY(cursorColor, backedTextInputView.cursorColor, UIColor) // [macOS]
 RCT_REMAP_OSX_VIEW_PROPERTY(grammarCheck, backedTextInputView.grammarCheckingEnabled, BOOL) // [macOS]
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(spellCheck, backedTextInputView.spellCheckingType, UITextSpellCheckingType)// [macOS]
 RCT_REMAP_OSX_VIEW_PROPERTY(spellCheck, backedTextInputView.continuousSpellCheckingEnabled, BOOL) // [macOS]
@@ -75,6 +74,8 @@ RCT_EXPORT_VIEW_PROPERTY(onGrammarCheckChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(clearTextOnSubmit, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onSubmitEditing, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(submitKeyEvents, NSArray<NSDictionary *>);
+
+RCT_REMAP_OSX_VIEW_PROPERTY(cursorColor, backedTextInputView.cursorColor, UIColor)
 #endif // macOS]
 
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -75,7 +75,7 @@ RCT_EXPORT_VIEW_PROPERTY(clearTextOnSubmit, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onSubmitEditing, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(submitKeyEvents, NSArray<NSDictionary *>);
 
-RCT_REMAP_OSX_VIEW_PROPERTY(cursorColor, backedTextInputView.cursorColor, UIColor)
+RCT_REMAP_VIEW_PROPERTY(cursorColor, backedTextInputView.cursorColor, UIColor)
 #endif // macOS]
 
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -47,6 +47,7 @@ RCT_REMAP_VIEW_PROPERTY(placeholderTextColor, backedTextInputView.placeholderCol
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(returnKeyType, backedTextInputView.returnKeyType, UIReturnKeyType) // [macOS]
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(selectionColor, backedTextInputView.tintColor, UIColor) // [macOS]
 RCT_REMAP_OSX_VIEW_PROPERTY(selectionColor, backedTextInputView.selectionColor, UIColor) // [macOS]
+RCT_REMAP_OSX_VIEW_PROPERTY(cursorColor, backedTextInputView.cursorColor, UIColor) // [macOS]
 RCT_REMAP_OSX_VIEW_PROPERTY(grammarCheck, backedTextInputView.grammarCheckingEnabled, BOOL) // [macOS]
 RCT_REMAP_NOT_OSX_VIEW_PROPERTY(spellCheck, backedTextInputView.spellCheckingType, UITextSpellCheckingType)// [macOS]
 RCT_REMAP_OSX_VIEW_PROPERTY(spellCheck, backedTextInputView.continuousSpellCheckingEnabled, BOOL) // [macOS]

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -30,6 +30,7 @@
 @property (nonatomic, getter=isContinuousSpellCheckingEnabled) BOOL continuousSpellCheckingEnabled;
 @property (nonatomic, getter=isGrammarCheckingEnabled) BOOL grammarCheckingEnabled;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor;
+@property (nonatomic, strong, nullable) RCTUIColor *insertionPointColor;
 
 @end
 
@@ -77,7 +78,8 @@
   fieldEditor.grammarCheckingEnabled = self.isGrammarCheckingEnabled;
   NSMutableDictionary *selectTextAttributes = fieldEditor.selectedTextAttributes.mutableCopy;
   selectTextAttributes[NSBackgroundColorAttributeName] = self.selectionColor ?: [NSColor selectedControlColor];
-	fieldEditor.selectedTextAttributes = selectTextAttributes;
+  fieldEditor.selectedTextAttributes = selectTextAttributes;
+  fieldEditor.insertionPointColor = self.insertionPointColor ?: [NSColor textColor];
   return fieldEditor;
 }
 
@@ -261,6 +263,16 @@
 - (RCTUIColor*)selectionColor
 {
   return ((RCTUITextFieldCell*)self.cell).selectionColor;
+}
+    
+- (void)setCursorColor:(NSColor *)cursorColor
+{
+    ((RCTUITextFieldCell*)self.cell).insertionPointColor = cursorColor;
+}
+
+- (RCTUIColor*)cursorColor
+{
+  return ((RCTUITextFieldCell*)self.cell).insertionPointColor;
 }
 
 - (void)setFont:(UIFont *)font

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -1107,6 +1107,55 @@ if (Platform.OS === 'macos') {
         return <OnPaste />;
       },
     },
+    {
+      title: 'Cursor color',
+      render: function (): React.Node {
+        return (
+          <View>
+            <TextInput
+              placeholder="Single line"
+              cursorColor="#00FF00"
+              placeholderTextColor="grey"
+              style={[
+                styles.default,
+                {backgroundColor: 'black', color: 'white', marginBottom: 4},
+              ]}
+            />
+            <TextInput
+              multiline={true}
+              placeholder="Multiline"
+              cursorColor="#00FF00"
+              placeholderTextColor="grey"
+              style={[
+                styles.default,
+                {backgroundColor: 'black', color: 'white', marginBottom: 4},
+              ]}
+            />
+            <TextInput
+              placeholder="Single line with selection color"
+              cursorColor="#00FF00"
+              selectionColor="yellow"
+              placeholderTextColor="grey"
+              style={[
+                styles.default,
+                {backgroundColor: 'black', color: 'white', marginBottom: 4},
+              ]}
+            />
+            <TextInput
+              multiline={true}
+              placeholder="Multiline with selection color"
+              cursorColor="#00FF00"
+              selectionColor="yellow"
+              placeholderTextColor="grey"
+              style={[
+                styles.default,
+                {backgroundColor: 'black', color: 'white'},
+              ]}
+            />
+          </View>
+        );
+      },
+    },
   );
 }
 // [macOS]


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

In the current implementation of TextInput, there is no reliable way to specify cursorColor (caret color). This limitation blocks us from launching one of the features as in our case we have part of the screen in the opposite theme (white/black).

This prop is already supported in Android and documented in the main doc https://reactnative.dev/docs/textinput#cursorcolor-android This pull request adds support to macOS as well. 

To demonstrate, here cursor is actually rendered, but you cannot see it as it is black on black.

https://user-images.githubusercontent.com/963490/231438442-1ab5fb56-7a6e-4f56-bb4e-5af03c1b40a3.mov

TextInput implementation seems to be different between MacOS and iOS, so creating a pull request here.

## Changelog

[MACOS] [ADDED] - Added support for cursorColor prop in TextInput

## Test Plan

Run RNTester-macOS as explained in the guide https://github.com/microsoft/react-native-macos/tree/main/packages/rn-tester#running-on-ios

https://user-images.githubusercontent.com/963490/231439846-3624e5fe-3a55-4d87-8bf9-84a6d45af139.mov
