### PR TITLE
Remove TextInput cursor color changes with selectionColor prop changes

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -152,7 +152,6 @@ static RCTUIColor *defaultPlaceholderColor() // [macOS]
   NSMutableDictionary *selectTextAttributes = self.selectedTextAttributes.mutableCopy;
   selectTextAttributes[NSBackgroundColorAttributeName] = selectionColor ?: [NSColor selectedControlColor];
   self.selectedTextAttributes = selectTextAttributes.copy;
-  self.insertionPointColor = self.selectionColor ?: [NSColor textColor];
 }
 
 - (RCTUIColor*)selectionColor

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -454,7 +454,7 @@ function OnPaste(): React.Node {
     </>
   );
 }
-// [macOS]
+// macOS]
 
 exports.displayName = (undefined: ?string);
 exports.title = 'TextInput';
@@ -608,6 +608,10 @@ exports.examples = ([
   },
   {
     title: 'Colored highlight/cursor for text input',
+    // [macOS
+    description:
+      ('Note: On macOS, the selectionColor prop does not change the cursor color.': string),
+    // macOS]
     render: function (): React.Node {
       return (
         <View>
@@ -1109,4 +1113,4 @@ if (Platform.OS === 'macos') {
     },
   );
 }
-// [macOS]
+// macOS]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The caret color on macOS should stay visible at all times. This changes the behavior of the singleline and multiline TextInput to avoid changing the caret color.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[macOS] [CHANGED] - TextInput selectionColor won't change cursorColor


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

In the following recordings, the caret color is set to the system default for a TextInput with a non-default selection color.

Light mode:

https://user-images.githubusercontent.com/151054/231832629-eb4b52b7-3568-4f7a-8484-c79743d930e5.mov


Dark mode:

https://user-images.githubusercontent.com/151054/231832648-ab9c3a7a-baf2-4d33-a5ed-cef958d084c8.mov

