### PR TITLE
Fix back ports getting tagged as `latest` on NPM + react-native-macos-init publish

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,5 +1,4 @@
 # It is expected that a `latestStableBranch` variable is set in the pipeline's settings:
-# https://dev.azure.com/office/ISS/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=18541
 
 # This file defines the build steps to publish a release
 name: $(Date:yyyyMMdd).$(Rev:.r)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -126,6 +126,8 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      - template: apple-tools-setup.yml
+
       - template: templates/apple-install-dependencies.yml
 
       - template: templates/configure-git.yml

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,3 +1,6 @@
+# It is expected that a `latestStableBranch` variable is set in the pipeline's settings:
+# https://dev.azure.com/office/ISS/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=18541
+
 # This file defines the build steps to publish a release
 name: $(Date:yyyyMMdd).$(Rev:.r)
 

--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -2,4 +2,3 @@ variables:
   VmImageApple: internal-macos12
   slice_name: 'Xcode_14.2'
   xcode_version: '/Applications/Xcode_14.2.app'
-  latestStableBranch: '0.71-stable'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This PR fixes two changes:

1) The `react-native-macos-init` publish job was missing a step to set up some tools, like node and ruby. This caused the pipeline to fail. This should be a relatively simple fix. 

2) Backports to `0.68-stable` were getting tagged as "latest" on NPM. This is because our Publish pipeline has a variable `latestStableBranch` defined in its build settings, set to `0.68-stable`. I thought I could override that locally in `vars.yml`, but that change didn't carry down to the `068-stable` branch. Therefore, when a new change was published to `0.68-stable`, it still thought that was the latest released and tagged it on NPM as such. To fix this, we can remove the variable from our yml, add back the note it's expected to be defined in the pipelines' build settings, and update the build settings. I don't have pipeline edit auth, so I'm asking @dannyvv to do so 🙂.

## Changelog

[INTERNAL] [FIXED] - Fix back ports getting tagged as `latest` on NPM

## Test Plan

CI should pass. 