### PR TITLE
Remove apple specific steps from `react-native-macos-init` publish

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -128,11 +128,14 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - template: templates/apple-tools-setup.yml
-
-      - template: templates/apple-install-dependencies.yml
-
       - template: templates/configure-git.yml
+
+      - task: CmdLine@2
+        displayName: yarn install
+        inputs:
+          script: |
+            cd packages/react-native-macos-init
+            yarn install
 
       - task: CmdLine@2
         displayName: Build react-native-macos-init


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

As it turns out, this job runs on Ubuntu. So we shouldn't do anything related to home-brew. We also shouldn't need to, since it's a JS package. Revert the setup steps to what they were like in [0.68-stable](https://github.com/microsoft/react-native-macos/blob/4696d347c9cf9110a7ded81a9db7b1b3f35b3b52/.ado/publish.yml#L152-L159)

## Changelog

[INTERNAL] [FIXED] - Remove apple specific steps from `react-native-macos-init` publish

## Test Plan

I'll run the web validator again.
