### PR TITLE
Add back macOS tintColor implementation

### DIFF
--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -653,6 +653,28 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
     [self reloadImage];
   }
 }
+    
+#if TARGET_OS_OSX // [macOS
+- (void)windowDidChangeBackingProperties:(NSNotification *)notification
+{
+  [self reloadImage];
+}
+  
+- (RCTPlatformView *)reactAccessibilityElement
+{
+  return _imageView;
+}
+
+- (NSColor *)tintColor
+{
+  return _imageView.contentTintColor;
+}
+
+- (void)setTintColor:(NSColor *)tintColor
+{
+  _imageView.contentTintColor = tintColor;
+}
+#endif // macOS]
 
 - (void)dealloc
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

During the 71 merge, I accidentally removed a macOS ifdef block that implemented tintColor for macOS. Thanks @ospfranco for catching! Let's add it back by copying it from the `0.68-stable` branch :)

## Changelog

[MACOS] [FIXED] - Add back macOS tintColor implementation

## Test Plan

TintColor went from not working to working:
![Screenshot 2023-04-25 at 10 50 59 PM](https://user-images.githubusercontent.com/6722175/234483507-fb20fe46-7a4f-4a9a-93a0-eaf3cd7fa276.png)
![Screenshot 2023-04-25 at 10 55 38 PM](https://user-images.githubusercontent.com/6722175/234483542-a73722ef-0e39-4a24-87ab-170699926f48.png)



