### PR TITLE
Fix text input not correctly submitting events

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -142,6 +142,8 @@
 
 - (void)textInputDidChange
 {
+  [super textInputDidChange];
+
   [_scrollView setHasVerticalScroller:[self shouldShowVerticalScrollbar]];
 }
 

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -198,7 +198,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   // enter/return
   if (commandSelector == @selector(insertNewline:) || commandSelector == @selector(insertNewlineIgnoringFieldEditor:)) {
     [self textFieldDidEndEditingOnExit];
-    if ([textInputDelegate textInputShouldReturn]) {
+    if ([textInputDelegate textInputShouldSubmitOnReturn]) {
       [[_backedTextInputView window] makeFirstResponder:nil];
     }
     commandHandled = YES;
@@ -434,7 +434,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   id<RCTBackedTextInputDelegate> textInputDelegate = [_backedTextInputView textInputDelegate];
   // enter/return
   if ((commandSelector == @selector(insertNewline:) || commandSelector == @selector(insertNewlineIgnoringFieldEditor:))) {
-    if (textInputDelegate.textInputShouldReturn) {
+    if ([textInputDelegate textInputShouldSubmitOnReturn]) {
       [_backedTextInputView.window makeFirstResponder:nil];
       commandHandled = YES;
     }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

- The delegate method for submitting text input changes to JS changed in https://github.com/facebook/react-native/pull/33653 

- The new api is `textInputShouldSubmitOnReturn`

https://github.com/facebook/react-native/blob/43bd29fb22b2b9993f68dc545bd1f84612e879ba/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h#L28

- I also noticed that `onChange` was not being called correctly for MutliLine TextInput.
- The reason was this change: https://github.com/microsoft/react-native-macos/commit/277129c7e270026e58923e63cd44535c25e1e8dd
- We overrode `textInputDidChange` but forgot to call `[super textInputDidChange]`

closes #1788 

## Changelog

[MACOS] [FIXED] - Fix TextInput to submit value to onChange & onSubmitEditing

## Test Plan

### SingleLine TextInput
https://user-images.githubusercontent.com/96719/236112608-f262c3a9-4d23-4ff0-9b36-ed630d224bdf.mp4

### MultiLine TextInput
https://user-images.githubusercontent.com/96719/236112637-7897757f-9c49-4b7e-a5bc-f2c651df54f1.mp4

NOTE: The double submit has been fixed here: https://github.com/facebook/react-native/commit/a804c0f22b4b11b3d9632dc59a6da14f6c4325e3
