### PR TITLE
[0.71] Fix TextInput to submit value to onChange & onSubmitEdit

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -142,6 +142,8 @@
 
 - (void)textInputDidChange
 {
+  [super textInputDidChange];
+
   [_scrollView setHasVerticalScroller:[self shouldShowVerticalScrollbar]];
 }
 

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -198,7 +198,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   // enter/return
   if (commandSelector == @selector(insertNewline:) || commandSelector == @selector(insertNewlineIgnoringFieldEditor:)) {
     [self textFieldDidEndEditingOnExit];
-    if ([textInputDelegate textInputShouldReturn]) {
+    if ([textInputDelegate textInputShouldSubmitOnReturn]) {
       [[_backedTextInputView window] makeFirstResponder:nil];
     }
     commandHandled = YES;
@@ -434,7 +434,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   id<RCTBackedTextInputDelegate> textInputDelegate = [_backedTextInputView textInputDelegate];
   // enter/return
   if ((commandSelector == @selector(insertNewline:) || commandSelector == @selector(insertNewlineIgnoringFieldEditor:))) {
-    if (textInputDelegate.textInputShouldReturn) {
+    if ([textInputDelegate textInputShouldSubmitOnReturn]) {
       [_backedTextInputView.window makeFirstResponder:nil];
       commandHandled = YES;
     }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Picking #1811 to 0.71.1

## Changelog

[MACOS][FIX] Pick to 0.71 - Fix TextInput to submit value to onChange & onSubmitEditing (#1811)

## Test Plan

See testplan in #1811 