### PR TITLE
[Fabric] Add mandatory color space conversion for macOS.

### DIFF
--- a/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
+++ b/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
@@ -179,6 +179,9 @@ static inline NSString *_NSStringFromCString(
 static inline facebook::react::ColorComponents _ColorComponentsFromUIColor(RCTUIColor *color) // [macOS]
 {
   CGFloat rgba[4];
+#if TARGET_OS_OSX // [macOS
+  color = [color colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+#endif // macOS]
   [color getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
   return {(float)rgba[0], (float)rgba[1], (float)rgba[2], (float)rgba[3]};
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Extracting color components from a color in fabric was throwing an exception because some colors need to manually be converted to a color space supporting the RGBA components. This adds the necessary color space conversion for macOS.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[macOS] [FIXED] - Color RGBA component extraction throwing exception in fabric
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Tested by running RNTester on macOS with fabric (`RCT_NEW_ARCH_ENABLED=1`) and launching the API Border example.

Without the fix the app crashes with the following exception:

```
libc++abi: terminating due to uncaught exception of type NSException
terminating due to uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -getRed:green:blue:alpha: not valid for the NSColor Catalog color: System separatorColor; need to first convert colorspace.'
```
<img width="1136" alt="Screenshot 2023-05-04 at 16 12 29" src="https://user-images.githubusercontent.com/151054/236234596-6c09ce52-7df2-4872-8e0e-c9f2c3e8d2f1.png">

With the fix:

<img width="1136" alt="Screenshot 2023-05-04 at 16 14 57" src="https://user-images.githubusercontent.com/151054/236234642-f132e90f-6977-4680-9b27-60d523350f16.png">
