### PR TITLE
[Fabric] Clean up hit testing now that RCTUIView extends RCTPlatformView

### DIFF
--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -391,7 +391,6 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 - (void)layoutIfNeeded;
 
 - (void)layoutSubviews;
-- (NSArray<RCTUIView *> *)reactZIndexSortedSubviews; // [macOS]
 
 - (void)setNeedsDisplay;
 
@@ -414,10 +413,6 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
  * Specifies whether focus ring should be drawn when the view has the first responder status.
  */
 @property (nonatomic, assign) BOOL enableFocusRing;
-/**
- * The z-index of the view.
- */
-@property (nonatomic, assign) NSInteger reactZIndex;
 
 @end
 

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -406,27 +406,6 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
   [super layout];
 }
 
-- (NSArray<RCTUIView *> *)reactZIndexSortedSubviews
-{
-  // Check if sorting is required - in most cases it won't be.
-  BOOL sortingRequired = NO;
-  for (RCTUIView *subview in self.subviews) {
-    if (subview.reactZIndex != 0) {
-      sortingRequired = YES;
-      break;
-    }
-  }
-  return sortingRequired ? [self.subviews sortedArrayUsingComparator:^NSComparisonResult(RCTUIView *a, RCTUIView *b) {
-    if (a.reactZIndex > b.reactZIndex) {
-      return NSOrderedDescending;
-    } else {
-      // Ensure sorting is stable by treating equal zIndex as ascending so
-      // that original order is preserved.
-      return NSOrderedAscending;
-    }
-  }] : self.subviews;
-}
-
 - (void)setNeedsDisplay
 {
   self.needsDisplay = YES;

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -458,7 +458,6 @@ using namespace facebook::react;
   return _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 }
 
-#if !TARGET_OS_OSX // [macOS]
 - (RCTUIView *)betterHitTest:(CGPoint)point withEvent:(UIEvent *)event // [macOS]
 {
   // This is a classic textbook implementation of `hitTest:` with a couple of improvements:
@@ -509,60 +508,6 @@ using namespace facebook::react;
       return view != self ? view : nil;
   }
 }
-#else // [macOS
-
-- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event // [macOS]
-{
-  BOOL canReceiveTouchEvents = ([self isUserInteractionEnabled] && ![self isHidden]);
-  if (!canReceiveTouchEvents) {
-    return nil;
-  }
-
-  // `hitSubview` is the topmost subview which was hit. The hit point can
-  // be outside the bounds of `view` (e.g., if -clipsToBounds is NO).
-  RCTUIView *hitSubview = nil; // [macOS]
-  BOOL isPointInside = [self pointInside:point withEvent:event];
-  BOOL needsHitSubview = !(_props->pointerEvents == PointerEventsMode::None || _props->pointerEvents == PointerEventsMode::BoxOnly);
-  if (needsHitSubview && (![self clipsToBounds] || isPointInside)) {
-    // Take z-index into account when calculating the touch target.
-    NSArray<RCTUIView *> *sortedSubviews = [self reactZIndexSortedSubviews]; // [macOS]
-
-    // The default behaviour of UIKit is that if a view does not contain a point,
-    // then no subviews will be returned from hit testing, even if they contain
-    // the hit point. By doing hit testing directly on the subviews, we bypass
-    // the strict containment policy (i.e., UIKit guarantees that every ancestor
-    // of the hit view will return YES from -pointInside:withEvent:). See:
-    //  - https://developer.apple.com/library/ios/qa/qa2013/qa1812.html
-    for (RCTUIView *subview in [sortedSubviews reverseObjectEnumerator]) { // [macOS]
-      CGPoint pointForHitTest = CGPointZero;
-      if ([subview isKindOfClass:[RCTUIView class]]) { // [macOS]
-        pointForHitTest = [subview convertPoint:point fromView:self];
-      } else {
-        pointForHitTest = point;
-      }
-      hitSubview = (RCTUIView *)[subview hitTest:pointForHitTest]; // [macOS]
-      if (hitSubview != nil) {
-        break;
-      }
-    }
-  }
-
-  RCTUIView *hitView = (isPointInside ? self : nil); // [macOS]
-
-  switch (_props->pointerEvents) {
-    case PointerEventsMode::None:
-      return nil;
-    case PointerEventsMode::Auto:
-      return hitSubview ?: hitView;
-    case PointerEventsMode::BoxOnly:
-      return hitView;
-    case PointerEventsMode::BoxNone:
-      return hitSubview;
-    default:
-      return hitSubview ?: hitView;
-  }
-}
-#endif // macOS]
 
 static RCTCornerRadii RCTCornerRadiiFromBorderRadii(BorderRadii borderRadii)
 {

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -413,6 +413,14 @@ static __weak RCTPlatformView *_pendingFocusView; // [macOS]
       self, @selector(accessibilityValueInternal), accessibilityValue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+// [macOS
+#pragma mark - Hit testing
+  - (RCTPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  return [self hitTest:point];
+}
+// macOS]
+
 #pragma mark - Debug
 - (void)react_addRecursiveDescriptionToString:(NSMutableString *)string atLevel:(NSUInteger)level
 {

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -415,11 +415,12 @@ static __weak RCTPlatformView *_pendingFocusView; // [macOS]
 
 // [macOS
 #pragma mark - Hit testing
-  - (RCTPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+#if TARGET_OS_OSX  
+- (RCTPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
   return [self hitTest:point];
 }
-// macOS]
+#endif // macOS]
 
 #pragma mark - Debug
 - (void)react_addRecursiveDescriptionToString:(NSMutableString *)string atLevel:(NSUInteger)level


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The RCTUIView extends RCTPlatformView now which allows to remove the macOS specific hit testing logic that was added for the implementation of the RCTSurfaceTouchHandler in fabric.

The only macOS specific part that is still required is the implementation of a 
```- (RCTPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event```
 method to support the iOS-style hit test calls coming from the betterHitTest implementation.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[macOS] [REMOVED] - Removed custom hit test implementation used for macOS fabric
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Tested by running RNTester on macOS with fabric (`RCT_NEW_ARCH_ENABLED=1`) and clicking around the app to check that hit testing works as expected.


https://user-images.githubusercontent.com/151054/236241920-36bdae96-6212-42eb-b0c6-7e918fac6bcd.mov


