### PR TITLE
[Fabric] Return active touch identifiers in surface touch handler on mouse up.

### DIFF
--- a/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -660,6 +660,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
     }
     _activeTouches.erase(touch);
 #else // [macOS
+    _identifierPool.enqueue(activeTouch.touch.identifier);
     _activeTouches.erase(touch.eventNumber);
 #endif // macOS]
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
There are 11 active touch identifiers available in the surface touch handler. We were not returning identifiers when completing a touch on mouse up which led to the app hanging looking for a free touch identifier when all 11 slots were used up.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[macOS] [FIXED] - App hanging after multiple clicks in fabric
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Tested by running RNTester on macOS with fabric (`RCT_NEW_ARCH_ENABLED=1`) and clicking around the app to check that the app doesn't hang anymore after a couple of click.

Without the fix RNTester becomes unresponsive (the beachball at the end is not captured by the screen recording):

https://user-images.githubusercontent.com/151054/236255098-50c78ecc-5333-4d91-b2c4-ba7fd7ea6e3d.mov

With the fix RNTester keeps working no matter how many times you click around:

https://user-images.githubusercontent.com/151054/236255482-5f3df5d4-3abb-4e8d-9419-8e4ff43cb301.mov

