### PR TITLE
[Fabric] Use the layout metrics to get the scale factor in component views.

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -59,16 +59,19 @@ using namespace facebook::react;
   insets.top = RCTRoundPixelValue(insets.top);
   insets.right = RCTRoundPixelValue(insets.right);
   insets.bottom = RCTRoundPixelValue(insets.bottom);
+
+  auto newPadding = RCTEdgeInsetsFromUIEdgeInsets(insets);
+  auto threshold = 1.0 / RCTScreenScale() + 0.01; // Size of a pixel plus some small threshold.
 #else // [macOS
-  CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];;
+  CGFloat scale = _layoutMetrics.pointScaleFactor;
   insets.left = RCTRoundPixelValue(insets.left, scale);
   insets.top = RCTRoundPixelValue(insets.top, scale);
   insets.right = RCTRoundPixelValue(insets.right, scale);
   insets.bottom = RCTRoundPixelValue(insets.bottom, scale);
-#endif // macOS]
 
   auto newPadding = RCTEdgeInsetsFromUIEdgeInsets(insets);
-  auto threshold = 1.0 / RCTScreenScale() + 0.01; // Size of a pixel plus some small threshold.
+  auto threshold = 1.0 / scale + 0.01; // Size of a pixel plus some small threshold.
+#endif // macOS]
 
   _state->updateState(
       [=](SafeAreaViewShadowNode::ConcreteState::Data const &oldData)

--- a/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/SafeAreaView/RCTSafeAreaViewComponentView.mm
@@ -54,25 +54,22 @@ using namespace facebook::react;
   }
 
   UIEdgeInsets insets = [self _safeAreaInsets];
+  CGFloat scale = _layoutMetrics.pointScaleFactor; // [macOS]
 #if !TARGET_OS_OSX // [macOS]
   insets.left = RCTRoundPixelValue(insets.left);
   insets.top = RCTRoundPixelValue(insets.top);
   insets.right = RCTRoundPixelValue(insets.right);
   insets.bottom = RCTRoundPixelValue(insets.bottom);
-
-  auto newPadding = RCTEdgeInsetsFromUIEdgeInsets(insets);
-  auto threshold = 1.0 / RCTScreenScale() + 0.01; // Size of a pixel plus some small threshold.
 #else // [macOS
-  CGFloat scale = _layoutMetrics.pointScaleFactor;
   insets.left = RCTRoundPixelValue(insets.left, scale);
   insets.top = RCTRoundPixelValue(insets.top, scale);
   insets.right = RCTRoundPixelValue(insets.right, scale);
   insets.bottom = RCTRoundPixelValue(insets.bottom, scale);
-
-  auto newPadding = RCTEdgeInsetsFromUIEdgeInsets(insets);
-  auto threshold = 1.0 / scale + 0.01; // Size of a pixel plus some small threshold.
 #endif // macOS]
 
+  auto newPadding = RCTEdgeInsetsFromUIEdgeInsets(insets);
+  auto threshold = 1.0 / scale + 0.01; // Size of a pixel plus some small threshold. [macOS]
+  
   _state->updateState(
       [=](SafeAreaViewShadowNode::ConcreteState::Data const &oldData)
           -> SafeAreaViewShadowNode::ConcreteState::SharedData {

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -632,7 +632,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     RCTBorderColors borderColors = RCTCreateRCTBorderColorsFromBorderColors(borderMetrics.borderColors);
 
 #if TARGET_OS_OSX // [macOS
-  CGFloat scaleFactor = self.window.backingScaleFactor;
+  CGFloat scaleFactor = _layoutMetrics.pointScaleFactor;
 #else
   // On iOS setting the scaleFactor to 0.0 will default to the device's native scale factor.
   CGFloat scaleFactor = 0.0;
@@ -657,13 +657,13 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       CGRect contentsCenter = CGRect{
           CGPoint{imageCapInsets.left / imageSize.width, imageCapInsets.top / imageSize.height},
           CGSize{(CGFloat)1.0 / imageSize.width, (CGFloat)1.0 / imageSize.height}};
-        
+
 #if !TARGET_OS_OSX // [macOS]
         _borderLayer.contents = (id)image.CGImage;
         _borderLayer.contentsScale = image.scale;
 #else // [macOS
         _borderLayer.contents = [image layerContentsForContentsScale:scaleFactor];
-        _borderLayer.contentsScale = RCTScreenScale();
+        _borderLayer.contentsScale = scaleFactor;
 #endif // macOS]
 
       BOOL isResizable = !UIEdgeInsetsEqualToEdgeInsets(image.capInsets, UIEdgeInsetsZero);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fabric does not provide guarantees for the order of creation of host views, which means a view could be created before being added to a window. This causes issues when reading the `backingScaleFactor` within a view because it returns a nil window and the returned value is 0.

This caused border rendering issues in the `<View />` component since the border was generated before the view hierarchy was added to a window.

The layout metrics of the shadow node provides the current scale factor through the `pointScaleFactor` property. This is set when initializing the layout context, which guarantees that the value will be available when a view is being created and inserted.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[macOS] [FIXED] - Use the layout metrics scale factor in view components to fix scale dependent rendering

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested by running RNTester on macOS with fabric (RCT_NEW_ARCH_ENABLED=1) and launching the API Border example.

Without the fix:
<img width="1136" alt="Screenshot 2023-05-05 at 13 03 38" src="https://user-images.githubusercontent.com/151054/236446049-37335f6a-14a0-4349-b40a-282c67e3b601.png">

With the fix:
<img width="1136" alt="Screenshot 2023-05-05 at 13 02 10" src="https://user-images.githubusercontent.com/151054/236446114-3ec776d2-1b19-4f46-854d-138ea61dbd7b.png">

