### PR TITLE
[Fabric] Fix text input rendering crashing by using layout metrics pixelScaleFactor

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *text;
 @property (nonatomic, assign) NSTextAlignment textAlignment;
 @property (nonatomic, copy, nullable) NSAttributedString *attributedText;
+@property (nonatomic, assign) CGFloat pointScaleFactor;
 - (NSSize)sizeThatFits:(NSSize)size;
 - (void)setReadablePasteBoardTypes:(NSArray<NSPasteboardType> *)readablePasteboardTypes;
 #endif // macOS]

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -457,7 +457,7 @@ static RCTUIColor *defaultPlaceholderColor() // [macOS]
                                .size;
   placeholderSize = CGSizeMake(RCTCeilPixelValue(placeholderSize.width), RCTCeilPixelValue(placeholderSize.height));
 #else // [macOS
-  CGFloat scale = self.window.backingScaleFactor;
+  CGFloat scale = _pointScaleFactor ?: self.window.backingScaleFactor;
   CGSize placeholderSize = [placeholder sizeWithAttributes:[self _placeholderTextAttributes]];
   placeholderSize = CGSizeMake(RCTCeilPixelValue(placeholderSize.width, scale), RCTCeilPixelValue(placeholderSize.height, scale));
 #endif // macOS]

--- a/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -59,6 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) CGFloat zoomScale;
 @property (nonatomic, assign, readonly) CGPoint contentOffset;
 @property (nonatomic, assign, readonly) UIEdgeInsets contentInset;
+#if TARGET_OS_OSX // [macOS
+@property (nonatomic, assign) CGFloat pointScaleFactor;
+#endif // macOS]
 
 // This protocol disallows direct access to `selectedTextRange` property because
 // unwise usage of it can break the `delegate` behavior. So, we always have to

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL enableFocusRing;
 @property (nonatomic, strong, nullable) RCTUIColor *selectionColor;
 @property (weak, nullable) id<RCTUITextFieldDelegate> delegate;
+@property (nonatomic, assign) CGFloat pointScaleFactor;
 #endif // macOS]
 
 @end

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -605,7 +605,7 @@
   size = CGSizeMake(RCTCeilPixelValue(size.width), RCTCeilPixelValue(size.height));
 #else // [macOS
   CGSize size = [text sizeWithAttributes:@{NSFontAttributeName: self.font}];
-  CGFloat scale = self.window.backingScaleFactor;
+  CGFloat scale = _pointScaleFactor ?: self.window.backingScaleFactor;
   if (scale == 0.0 && RCTRunningInTestEnvironment()) {
     // When running in the test environment the view is not on screen.
     // Use a scaleFactor of 1 so that the test results are machine independent.

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -258,6 +258,9 @@ using namespace facebook::react;
 {
   [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
 
+#if TARGET_OS_OSX // [macOS
+  _backedTextInputView.pointScaleFactor = layoutMetrics.pointScaleFactor;
+#endif // macOS]
   _backedTextInputView.frame =
       UIEdgeInsetsInsetRect(self.bounds, RCTUIEdgeInsetsFromEdgeInsets(layoutMetrics.borderWidth));
   _backedTextInputView.textContainerInset =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The `<TextInput />` component in fabric was querying the pixel scale factor through the window. But since fabric does not guarantee that host views are added to a window when being created and/or inserted, the TextInput views don't have a window and the return scale was 0.0 which caused crashes while loading RNTester.

This changes the behavior for fabric by adding a `pixelScaleFactor` to the `RCTBackedTextInputViewProtocal` so that the component view can provide the layout metrics pixel scale factor to the backing text input view.

The behavior on Paper stays unchanged since the `pixelScaleFactor` won't be set and the scale defaults back to using the window query (`self.window.backingScaleFactor`).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[macOS] [FIXED] - Fix text input rendering crashing on fabric

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested by running RNTester on macOS with paper and fabric (`RCT_NEW_ARCH_ENABLED=1`) and launching the TextInput example.

Without the fix RNTester fabric crashes with the following exception:
```
libc++abi: terminating due to uncaught exception of type NSException
terminating due to uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Layout occurs before the view is in a window?'
```

With the fix in paper:
<img width="1136" alt="Screenshot 2023-05-05 at 19 15 27" src="https://user-images.githubusercontent.com/151054/236525916-41c61839-1013-42c2-a137-2d481a2a56d0.png">


With the fix in fabric:
<img width="1136" alt="Screenshot 2023-05-05 at 19 17 52" src="https://user-images.githubusercontent.com/151054/236525943-dfaa4a22-3b7f-4f57-abc4-dabe1b961a7c.png">

