### PR TITLE
[Fabric] Fix RNTester content not resizing with window.

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -135,6 +135,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   self.window.autorecalculatesKeyViewLoop = YES;
   NSViewController *rootViewController = [NSViewController new];
   rootViewController.view = rootView;
+  rootView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
   rootView.frame = frame;
   self.window.contentViewController = rootViewController;
   [self.window makeKeyAndOrderFront:self];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This fix sets the auto-resizing masks on the `SurfaceHostingProxyRootView` of the RNTester app so that when using fabric, resizing the window would also resize the `SurfaceHostingProxyRootView` to fit the new frame size of the window.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[macOS] [FIXED] - Fix RNTester window content not resizing

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested by running RNTester on macOS with fabric (RCT_NEW_ARCH_ENABLED=1) and paper and resizing the window.

Without the fix in Fabric:
<img width="1377" alt="Screenshot 2023-05-07 at 18 52 54" src="https://user-images.githubusercontent.com/151054/236696172-8461b1ff-4fd6-404c-9d28-44faeba98ae0.png">

With the fix in Fabric:
<img width="1339" alt="Screenshot 2023-05-07 at 18 53 16" src="https://user-images.githubusercontent.com/151054/236696180-d3270d2e-6ddd-43d1-9ed2-98a30b0c7588.png">

With the fix in Paper:
<img width="1299" alt="Screenshot 2023-05-07 at 20 51 29" src="https://user-images.githubusercontent.com/151054/236697008-babe9c7c-aa9b-4794-bc21-6e7316274dfa.png">
