### PR TITLE
[Fabric] Fix wrong text offset when a line height is set.

### DIFF
--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
@@ -416,9 +416,8 @@ static void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
                             if (!font) {
                               return;
                             }
-#if !TARGET_OS_OSX // [macOS]
-                            maximumFontLineHeight = MAX(font.lineHeight, maximumFontLineHeight);
-#endif // [macOS]
+    
+                            maximumFontLineHeight = MAX(UIFontLineHeight(font), maximumFontLineHeight); // [macOS]
                           }];
 
   if (maximumLineHeight < maximumFontLineHeight) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This change adds back a working maximum font line height calculation method for macOS on fabric by using the common `UIFontLineHeight` method that works for UIKit and AppKit. This is required for the correct calculation of the baseline offset for text having a line height greater than the text's font height.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[macOS] [FIXED] - Fixed the vertical text position in Fabric when setting a line height

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested by running RNTester on macOS with paper and fabric (RCT_NEW_ARCH_ENABLED=1) and launching the TextInput example. As a regression test for iOS, the RNTester app was tested on iOS with fabric.

Without the fix on Fabric (text is too high and clipped by the view):
<img width="1136" alt="Screenshot 2023-05-08 at 01 32 40" src="https://user-images.githubusercontent.com/151054/236708362-dbfdc2a0-3087-4d6a-9986-54e5bc63be88.png">

With the fix on Fabric:
<img width="1136" alt="Screenshot 2023-05-08 at 01 27 57" src="https://user-images.githubusercontent.com/151054/236708377-351a9f86-3318-4d85-b4a9-fda6c0df9fec.png">

With the fix on Paper:
<img width="1136" alt="Screenshot 2023-05-08 at 01 30 42" src="https://user-images.githubusercontent.com/151054/236708391-330ccae1-2dae-4a58-bc6a-1ccca78efe7a.png">

With the fix on Fabric iOS:
<img width="564" alt="Screenshot 2023-05-08 at 01 29 17" src="https://user-images.githubusercontent.com/151054/236708395-a0ac0265-ea2e-4728-964f-0b2a914449ec.png">
