### PR TITLE
Fix Multiline Text Input cursor position being reset to end of line

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -149,7 +149,8 @@
 
 - (void)setAttributedText:(NSAttributedString *)attributedText
 {
-  [_backedTextInputView setAttributedText:attributedText];
+  [super setAttributedText:attributedText];
+  
   [_scrollView setHasVerticalScroller:[self shouldShowVerticalScrollbar]];
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

- #1438 had overrides for MultilineTextView methods w/o calling `[super ...]`
- This broke Multiline text inputs when text was being set from JS via `onChange`
- TextInputDidChange was fixed in #1811 

## Changelog

[MACOS] [FIXED] - Fix Multiline Text Input cursor position being reset to end of line

## Test Plan

### Before

https://github.com/microsoft/react-native-macos/assets/96719/6ff2c2cb-ae2c-4fe8-8260-84cde759cc5e

### After

https://github.com/microsoft/react-native-macos/assets/96719/6175f35b-4fb2-41d9-ba74-9a3e72faf6d3

