### PR TITLE
[Fabric] Add support for image content mode and tint features

### DIFF
--- a/Libraries/Image/RCTUIImageViewAnimated.h
+++ b/Libraries/Image/RCTUIImageViewAnimated.h
@@ -8,5 +8,5 @@
 #import <React/RCTAnimatedImage.h>
 #import <React/RCTDefines.h>
 
-@interface RCTUIImageViewAnimated : RCTUIImageView
+@interface RCTUIImageViewAnimated : RCTUIImageView // [macOS]
 @end

--- a/Libraries/Image/RCTUIImageViewAnimated.h
+++ b/Libraries/Image/RCTUIImageViewAnimated.h
@@ -8,10 +8,5 @@
 #import <React/RCTAnimatedImage.h>
 #import <React/RCTDefines.h>
 
-#if !TARGET_OS_OSX // [macOS]
-@interface RCTUIImageViewAnimated : UIImageView
-#else // [macOS
-@interface RCTUIImageViewAnimated : NSImageView
-#endif  // macOS]
-
+@interface RCTUIImageViewAnimated : RCTUIImageView
 @end

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -578,3 +578,17 @@ typedef UITouch RCTUITouch;
 @interface RCTUITouch : NSEvent
 @end
 #endif
+
+// RCTUIImageView
+
+#if !TARGET_OS_OSX
+typedef UIImageView RCTUIImageView;
+#else
+@interface RCTUIImageView : NSImageView
+NS_ASSUME_NONNULL_BEGIN
+@property (nonatomic, assign) BOOL clipsToBounds;
+@property (nonatomic, strong) RCTUIColor *tintColor;
+@property (nonatomic, assign) UIViewContentMode contentMode;
+NS_ASSUME_NONNULL_END
+@end
+#endif

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -770,8 +770,6 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 - (BOOL)clipsToBounds
 {
-  NSLog(@"%s", __PRETTY_FUNCTION__);
-
   return self.layer.masksToBounds;
 }
 

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -755,14 +755,11 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 @implementation RCTUIImageView
 
-@synthesize tintColor = _tintColor;
-@synthesize contentMode = _contentMode;
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    self.layer = [[CALayer alloc] init];
-    self.wantsLayer = YES;
+    [self setLayer:[[CALayer alloc] init]];
+    [self setWantsLayer:YES];
   }
   
   return self;
@@ -770,37 +767,34 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 - (BOOL)clipsToBounds
 {
-  return self.layer.masksToBounds;
+  return [[self layer] masksToBounds];
 }
 
 - (void)setClipsToBounds:(BOOL)clipsToBounds
 {
-  self.layer.masksToBounds = clipsToBounds;
-}
-
-- (UIViewContentMode)contentMode
-{
-  return _contentMode;
+  [[self layer] setMasksToBounds:clipsToBounds];
 }
 
 - (void)setContentMode:(UIViewContentMode)contentMode
 {
   _contentMode = contentMode;
+  
+  CALayer *layer = [self layer];
   switch (contentMode) {
     case UIViewContentModeScaleAspectFill:
-      self.layer.contentsGravity = kCAGravityResizeAspectFill;
+      [layer setContentsGravity:kCAGravityResizeAspectFill];
       break;
       
     case UIViewContentModeScaleAspectFit:
-      self.layer.contentsGravity = kCAGravityResizeAspect;
+      [layer setContentsGravity:kCAGravityResizeAspect];
       break;
       
     case UIViewContentModeScaleToFill:
-      self.layer.contentsGravity = kCAGravityResize;
+      [layer setContentsGravity:kCAGravityResize];
       break;
       
     case UIViewContentModeCenter:
-      self.layer.contentsGravity = kCAGravityCenter;
+      [layer setContentsGravity:kCAGravityCenter];
       break;
     
     default:
@@ -810,32 +804,31 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 - (UIImage *)image
 {
-  return self.layer.contents;
+  return [[self layer] contents];
 }
 
 - (void)setImage:(UIImage *)image
 {
-  if (self.layer.contents == image) {
-    return;
-  }
+  CALayer *layer = [self layer];
   
-  if (self.tintColor) {
-    image = [image copy];
-    [image lockFocus];
-    [self.tintColor set];
-    NSRect imageRect = { NSZeroPoint, image.size };
-    NSRectFillUsingOperation(imageRect, NSCompositingOperationSourceIn);
-    [image unlockFocus];
+  if ([layer contents] != image || [layer backgroundColor] != nil) {
+    if (_tintColor != nil) {
+      image = [image copy];
+      [image lockFocus];
+      [_tintColor set];
+      NSRect imageRect = { NSZeroPoint, image.size };
+      NSRectFillUsingOperation(imageRect, NSCompositingOperationSourceIn);
+      [image unlockFocus];
+    }
+    
+    if (image != nil && [image resizingMode] == NSImageResizingModeTile) {
+      [layer setContents:nil];
+      [layer setBackgroundColor:[NSColor colorWithPatternImage:image].CGColor];
+    } else {
+      [layer setContents:image];
+      [layer setBackgroundColor:nil];
+    }
   }
-  
-  if (image != nil && image.resizingMode == NSImageResizingModeTile) {
-    self.layer.contents = nil;
-    self.layer.backgroundColor = [NSColor colorWithPatternImage:image].CGColor;
-  } else {
-    self.layer.contents = image;
-    self.layer.backgroundColor = nil;
-  }
-  
 }
 
 @end

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -751,4 +751,95 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 @end
 
+// RCTUIImageView
+
+@implementation RCTUIImageView
+
+@synthesize tintColor = _tintColor;
+@synthesize contentMode = _contentMode;
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    self.layer = [[CALayer alloc] init];
+    self.wantsLayer = YES;
+  }
+  
+  return self;
+}
+
+- (BOOL)clipsToBounds
+{
+  NSLog(@"%s", __PRETTY_FUNCTION__);
+
+  return self.layer.masksToBounds;
+}
+
+- (void)setClipsToBounds:(BOOL)clipsToBounds
+{
+  self.layer.masksToBounds = clipsToBounds;
+}
+
+- (UIViewContentMode)contentMode
+{
+  return _contentMode;
+}
+
+- (void)setContentMode:(UIViewContentMode)contentMode
+{
+  _contentMode = contentMode;
+  switch (contentMode) {
+    case UIViewContentModeScaleAspectFill:
+      self.layer.contentsGravity = kCAGravityResizeAspectFill;
+      break;
+      
+    case UIViewContentModeScaleAspectFit:
+      self.layer.contentsGravity = kCAGravityResizeAspect;
+      break;
+      
+    case UIViewContentModeScaleToFill:
+      self.layer.contentsGravity = kCAGravityResize;
+      break;
+      
+    case UIViewContentModeCenter:
+      self.layer.contentsGravity = kCAGravityCenter;
+      break;
+    
+    default:
+      break;
+  }
+}
+
+- (UIImage *)image
+{
+  return self.layer.contents;
+}
+
+- (void)setImage:(UIImage *)image
+{
+  if (self.layer.contents == image) {
+    return;
+  }
+  
+  if (self.tintColor) {
+    image = [image copy];
+    [image lockFocus];
+    [self.tintColor set];
+    NSRect imageRect = { NSZeroPoint, image.size };
+    NSRectFillUsingOperation(imageRect, NSCompositingOperationSourceIn);
+    [image unlockFocus];
+  }
+  
+  if (image != nil && image.resizingMode == NSImageResizingModeTile) {
+    self.layer.contents = nil;
+    self.layer.backgroundColor = [NSColor colorWithPatternImage:image].CGColor;
+  } else {
+    self.layer.contents = image;
+    self.layer.backgroundColor = nil;
+  }
+  
+}
+
+@end
+
 #endif

--- a/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -31,10 +31,8 @@ using namespace facebook::react;
     _props = defaultProps;
 
     _imageView = [RCTUIImageViewAnimated new];
-#if !TARGET_OS_OSX // [macOS]
     _imageView.clipsToBounds = YES;
     _imageView.contentMode = RCTContentModeFromImageResizeMode(defaultProps->resizeMode);
-#endif // [macOS]
     _imageView.layer.minificationFilter = kCAFilterTrilinear;
     _imageView.layer.magnificationFilter = kCAFilterTrilinear;
 
@@ -58,7 +56,6 @@ using namespace facebook::react;
   auto const &oldImageProps = *std::static_pointer_cast<ImageProps const>(_props);
   auto const &newImageProps = *std::static_pointer_cast<ImageProps const>(props);
 
-#if !TARGET_OS_OSX // [macOS]
   // `resizeMode`
   if (oldImageProps.resizeMode != newImageProps.resizeMode) {
     _imageView.contentMode = RCTContentModeFromImageResizeMode(newImageProps.resizeMode);
@@ -68,7 +65,6 @@ using namespace facebook::react;
   if (oldImageProps.tintColor != newImageProps.tintColor) {
     _imageView.tintColor = RCTUIColorFromSharedColor(newImageProps.tintColor);
   }
-#endif // [macOS]
 
   [super updateProps:props oldProps:oldProps];
 }
@@ -148,6 +144,11 @@ using namespace facebook::react;
     // Applying capInsets of 0 will switch the "resizingMode" of the image to "tile" which is undesired.
     image = [image resizableImageWithCapInsets:RCTUIEdgeInsetsFromEdgeInsets(imageProps.capInsets)
                                   resizingMode:UIImageResizingModeStretch];
+  }
+#else
+  if (imageProps.resizeMode == ImageResizeMode::Repeat) {
+    image.capInsets = RCTUIEdgeInsetsFromEdgeInsets(imageProps.capInsets);
+    image.resizingMode = NSImageResizingModeTile;
   }
 #endif // [macOS]
 


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This PR adds the `RCTUIImageView` class to RCTUIKit offering the same API as the UIImageView on iOS for setting the content mode and the tint color. The implementation uses CALayer and NSImage for scale settings which matches the iOS scaling methods.

Using this image view implementation on fabric removes most of the macOS specific code changes that the `RCTImageComponentView` required previously.

## Changelog

[macOS] [FIXED] - Image content mode and tinting in Fabric

## Test Plan

Tested by running RNTester on macOS with fabric (`RCT_NEW_ARCH_ENABLED=1`) and launching the Image example.

With the fix:
<img width="688" alt="Screenshot 2023-05-15 at 17 44 16" src="https://github.com/microsoft/react-native-macos/assets/151054/74a3229d-424b-4444-85cf-169de5f1988a">
<img width="688" alt="Screenshot 2023-05-15 at 17 44 24" src="https://github.com/microsoft/react-native-macos/assets/151054/b0e2e352-8eba-43ff-9783-7e166315b8f6">

Without the fix:
<img width="693" alt="Screenshot 2023-05-15 at 17 46 24" src="https://github.com/microsoft/react-native-macos/assets/151054/2cc71860-5bc0-4ff4-bea4-1233a3cab702">
<img width="693" alt="Screenshot 2023-05-15 at 17 46 34" src="https://github.com/microsoft/react-native-macos/assets/151054/a7c5e36f-2174-4867-b98a-db359868328c">
