### PR TITLE
Fix contents links in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ You can read more about the macOS implementation in our website - [React Native 
 
 - [Requirements](#-requirements)
 - [Building your first React Native app](#-building-your-first-react-native-app)
-- [Documentation](#-documentation)
-- [Upgrading](#-upgrading)
-- [How to Contribute](#-how-to-contribute)
+- [Documentation](#documentation)
+- [How to Contribute](#contributing)
 - [Code of Conduct](#code-of-conduct)
-- [License](#-license)
+- [License](#license)
 
 
 ## 📋 Requirements


### PR DESCRIPTION
## Summary

Some of the links in the Contents section of the Readme.md are broken. This PR fix those links.

## Changelog

[General] [Fixed] - Fix contents links in Readme.md

## Test Plan

Just click on the links