### PR TITLE
Use viewDidChangeBackingProperties to remove the use of notifications in RCTImageView

### DIFF
--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -131,11 +131,6 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
 
   RCTUIImageViewAnimated *_imageView;
 
-#if TARGET_OS_OSX // [macOS
-  // Whether observing changes to the window's backing scale
-  BOOL _subscribedToWindowBackingNotifications;
-#endif // macOS]
-  
   RCTImageURLLoaderRequest *_loaderRequest;
 }
 
@@ -616,32 +611,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 #if TARGET_OS_OSX // [macOS
 #define didMoveToWindow viewDidMoveToWindow
 #endif
-#if TARGET_OS_OSX
-- (void)viewWillMoveToWindow:(NSWindow *)newWindow
-{
-  if (_subscribedToWindowBackingNotifications &&
-      self.window != nil &&
-      self.window != newWindow) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                    name:NSWindowDidChangeBackingPropertiesNotification
-                                                  object:self.window];
-    _subscribedToWindowBackingNotifications = NO;
-  }
-}
-#endif // macOS]
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
 
-#if TARGET_OS_OSX // [macOS
-  if (!_subscribedToWindowBackingNotifications && self.window != nil) {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(windowDidChangeBackingProperties:)
-                                                 name:NSWindowDidChangeBackingPropertiesNotification
-                                               object:self.window];
-    _subscribedToWindowBackingNotifications = YES;
-  }
-#endif // macOS]
   if (!self.window) {
     // Cancel loading the image if we've moved offscreen. In addition to helping
     // prioritise image requests that are actually on-screen, this removes
@@ -655,7 +628,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 }
     
 #if TARGET_OS_OSX // [macOS
-- (void)windowDidChangeBackingProperties:(NSNotification *)notification
+- (void)viewDidChangeBackingProperties
 {
   [self reloadImage];
 }


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

In some rare cases a react native app on macOS would crash with the following message:
```
-[RCTImageView windowDidChangeBackingProperties:]: unrecognized selector sent to instance 0x10b0c2c00
```

The notification center is supposed to check if the object subscribed to the notification still exists before calling the registered selector for the notification. This is supposed to relieve us from having to remove the observer when deallocating the observing object.

In these rare crashes I assume another NSObject got allocated at the same address as what was previously an observing RCTImageView and the notification center may have considered the observer still active and sent the registered selector to it.

To fix the potential bug and also remove a couple differences with React Native this PR removes the need for notification subscriptions by using the NSView `viewDidChangeBackingProperties` instead.

## Changelog

[macOS] [CHANGED] - Use viewDidChangeBackingProperties for image reloads on backing properties change

## Test Plan

Tested by running RNTester on macOS with paper and dragging the window from a 1.0 backing scale factor display to a 2.0 backing scale factor display and checking that the image reload happens in the debugger.


https://github.com/microsoft/react-native-macos/assets/151054/a6f41a2d-c604-4683-8cda-736003f71c7a

