### PR TITLE
[0.71] Make sure the Native RuntimeScheduler is initialized on Old Arch 

### DIFF
--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -6,27 +6,39 @@
  */
 
 #import "RCTAppDelegate.h"
-#import "RCTAppSetupUtils.h"
+#import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTRootView.h>
+#import <React/RCTRuntimeExecutorFromBridge.h>
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
+
+#import "RCTAppSetupUtils.h"
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/CoreModulesPlugins.h>
-#import <React/RCTCxxBridgeDelegate.h>
+#import <React/RCTComponentViewFactory.h>
+#import <React/RCTComponentViewProtocol.h>
 #import <React/RCTFabricSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <react/config/ReactNativeConfig.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+#import "RCTLegacyInteropComponents.h"
 
 static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
-@interface RCTAppDelegate () <RCTTurboModuleManagerDelegate, RCTCxxBridgeDelegate> {
+@interface RCTAppDelegate () <RCTTurboModuleManagerDelegate, RCTComponentViewFactoryComponentProvider> {
   std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
   facebook::react::ContextContainer::Shared _contextContainer;
 }
 @end
 
 #endif
+
+@interface RCTAppDelegate () <RCTCxxBridgeDelegate> {
+  std::shared_ptr<facebook::react::RuntimeScheduler> _runtimeScheduler;
+}
+@end
 
 @implementation RCTAppDelegate
 
@@ -140,18 +152,28 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 }
 #endif // macOS]
 
-#if RCT_NEW_ARCH_ENABLED
 #pragma mark - RCTCxxBridgeDelegate
 
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
-  self.turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
-                                                                 delegate:self
-                                                                jsInvoker:bridge.jsCallInvoker];
-  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+  _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
+#if RCT_NEW_ARCH_ENABLED
+  std::shared_ptr<facebook::react::CallInvoker> callInvoker =
+      std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
+  RCTTurboModuleManager *turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                                                   delegate:self
+                                                                                  jsInvoker:callInvoker];
+  _contextContainer->erase("RuntimeScheduler");
+  _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, turboModuleManager, _runtimeScheduler);
+#else
+  return RCTAppSetupJsExecutorFactoryForOldArch(bridge, _runtimeScheduler);
+#endif
 }
 
-#pragma mark RCTTurboModuleManagerDelegate
+#if RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTTurboModuleManagerDelegate
 
 - (Class)getModuleClassFromName:(const char *)name
 {

--- a/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -11,7 +11,7 @@
 
 #ifdef __cplusplus
 
-#if RCT_NEW_ARCH_ENABLED
+#import <memory>
 
 #ifndef RCT_USE_HERMES
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
@@ -27,15 +27,27 @@
 #import <React/JSCExecutorFactory.h>
 #endif
 
+#if RCT_NEW_ARCH_ENABLED
 #import <ReactCommon/RCTTurboModuleManager.h>
 #endif
+
+// Forward declaration to decrease compilation coupling
+namespace facebook::react {
+class RuntimeScheduler;
+}
 
 #if RCT_NEW_ARCH_ENABLED
 RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass);
 
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,
-    RCTTurboModuleManager *turboModuleManager);
+    RCTTurboModuleManager *turboModuleManager,
+    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler);
+
+#else
+std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
+    RCTBridge *bridge,
+    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler);
 #endif
 
 #endif // __cplusplus

--- a/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -7,6 +7,10 @@
 
 #import "RCTAppSetupUtils.h"
 
+#import <React/RCTJSIExecutorRuntimeInstaller.h>
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+
 #if RCT_NEW_ARCH_ENABLED
 // Turbo Module
 #import <React/CoreModulesPlugins.h>
@@ -15,7 +19,6 @@
 #import <React/RCTGIFImageDecoder.h>
 #import <React/RCTHTTPRequestHandler.h>
 #import <React/RCTImageLoader.h>
-#import <React/RCTJSIExecutorRuntimeInstaller.h>
 #import <React/RCTLocalAssetImageLoader.h>
 #import <React/RCTNetworking.h>
 
@@ -125,6 +128,27 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
         facebook::react::RuntimeExecutor syncRuntimeExecutor =
             [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
         [turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
+      }));
+}
+
+#else
+
+std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
+    RCTBridge *bridge,
+    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler)
+{
+#if RCT_USE_HERMES
+  return std::make_unique<facebook::react::HermesExecutorFactory>(
+#else
+  return std::make_unique<facebook::react::JSCExecutorFactory>(
+#endif
+      facebook::react::RCTJSIExecutorRuntimeInstaller([bridge, runtimeScheduler](facebook::jsi::Runtime &runtime) {
+        if (!bridge) {
+          return;
+        }
+        if (runtimeScheduler) {
+          facebook::react::RuntimeSchedulerBinding::createAndInstallIfNeeded(runtime, runtimeScheduler);
+        }
       }));
 }
 

--- a/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -37,16 +37,6 @@ header_search_paths = [
 ].concat(use_hermes ? [
   "$(PODS_ROOT)/Headers/Public/React-hermes",
   "$(PODS_ROOT)/Headers/Public/hermes-engine"
-] : []).concat(use_frameworks ? [
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-Fabric/React_Fabric.framework/Headers/",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-RCTFabric/RCTFabric.framework/Headers/",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers/",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers/",
-  "$(PODS_CONFIGURATION_BUILD_DIR)/React-runtimescheduler/React_runtimescheduler.framework/Headers/",
 ] : []).map{|p| "\"#{p}\""}.join(" ")
 
 Pod::Spec.new do |s|
@@ -77,7 +67,7 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-RCTNetwork"
   s.dependency "React-RCTImage"
-  s.dependency "React-NativeModulesApple"
+  # s.dependency "React-NativeModulesApple"
   s.dependency "React-CoreModules"
   s.dependency "React-runtimescheduler"
 

--- a/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -37,6 +37,16 @@ header_search_paths = [
 ].concat(use_hermes ? [
   "$(PODS_ROOT)/Headers/Public/React-hermes",
   "$(PODS_ROOT)/Headers/Public/hermes-engine"
+] : []).concat(use_frameworks ? [
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-Fabric/React_Fabric.framework/Headers/",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-RCTFabric/RCTFabric.framework/Headers/",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers/",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers/",
+  "$(PODS_CONFIGURATION_BUILD_DIR)/React-runtimescheduler/React_runtimescheduler.framework/Headers/",
 ] : []).map{|p| "\"#{p}\""}.join(" ")
 
 Pod::Spec.new do |s|
@@ -65,9 +75,33 @@ Pod::Spec.new do |s|
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"
+  s.dependency "React-RCTNetwork"
+  s.dependency "React-RCTImage"
+  s.dependency "React-NativeModulesApple"
+  s.dependency "React-CoreModules"
+  s.dependency "React-runtimescheduler"
+
+  if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
+    s.dependency "React-hermes"
+  else
+    s.dependency "React-jsc"
+  end
 
   if is_new_arch_enabled
     s.dependency "React-RCTFabric"
     s.dependency "React-graphics"
+    s.dependency "React-utils"
+    s.dependency "React-debug"
+
+    s.script_phases = {
+      :name => "Generate Legacy Components Interop",
+      :script => "
+. ${PODS_ROOT}/../.xcode.env
+${NODE_BINARY} ${REACT_NATIVE_PATH}/scripts/codegen/generate-legacy-interop-components.js -p #{ENV['APP_PATH']} -o ${REACT_NATIVE_PATH}/Libraries/AppDelegate
+      ",
+      :execution_position => :before_compile,
+      :input_files => ["#{ENV['APP_PATH']}/react-native.config.js"],
+      :output_files => ["${REACT_NATIVE_PATH}/Libraries/AppDelegate/RCTLegacyInteropComponents.mm"],
+    }
   end
 end

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -117,11 +117,13 @@ Pod::Spec.new do |s|
   end
 
   s.dependency "RCT-Folly", folly_version
-  s.dependency "React-cxxreact", version
-  s.dependency "React-perflogger", version
-  s.dependency "React-jsi", version
-  s.dependency "React-jsiexecutor", version
+  s.dependency "React-cxxreact"
+  s.dependency "React-perflogger"
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
+  s.dependency "React-utils"
   s.dependency "SocketRocket", socket_rocket_version
+  s.dependency "React-runtimeexecutor"
   s.dependency "Yoga"
   s.dependency "glog"
 

--- a/React/Base/RCTRuntimeExecutorFromBridge.h
+++ b/React/Base/RCTRuntimeExecutorFromBridge.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#ifdef __cplusplus
+#import <ReactCommon/RuntimeExecutor.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class RCTBridge;
+
+facebook::react::RuntimeExecutor RCTRuntimeExecutorFromBridge(RCTBridge *bridge);
+
+NS_ASSUME_NONNULL_END
+#endif

--- a/React/Base/RCTRuntimeExecutorFromBridge.mm
+++ b/React/Base/RCTRuntimeExecutorFromBridge.mm
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTRuntimeExecutorFromBridge.h"
+#import <React/RCTAssert.h>
+#import <React/RCTBridge+Private.h>
+#import <cxxreact/MessageQueueThread.h>
+#import <react/utils/ManagedObjectWrapper.h>
+
+using namespace facebook::react;
+
+@interface RCTBridge ()
+- (std::shared_ptr<MessageQueueThread>)jsMessageThread;
+- (void)invokeAsync:(std::function<void()> &&)func;
+@end
+
+RuntimeExecutor RCTRuntimeExecutorFromBridge(RCTBridge *bridge)
+{
+  RCTAssert(bridge, @"RCTRuntimeExecutorFromBridge: Bridge must not be nil.");
+
+  auto bridgeWeakWrapper = wrapManagedObjectWeakly([bridge batchedBridge] ?: bridge);
+
+  RuntimeExecutor runtimeExecutor = [bridgeWeakWrapper](
+                                        std::function<void(facebook::jsi::Runtime & runtime)> &&callback) {
+    RCTBridge *bridge = unwrapManagedObjectWeakly(bridgeWeakWrapper);
+
+    RCTAssert(bridge, @"RCTRuntimeExecutorFromBridge: Bridge must not be nil at the moment of scheduling a call.");
+
+    [bridge invokeAsync:[bridgeWeakWrapper, callback = std::move(callback)]() {
+      RCTCxxBridge *batchedBridge = (RCTCxxBridge *)unwrapManagedObjectWeakly(bridgeWeakWrapper);
+
+      RCTAssert(batchedBridge, @"RCTRuntimeExecutorFromBridge: Bridge must not be nil at the moment of invocation.");
+
+      if (!batchedBridge) {
+        return;
+      }
+
+      auto runtime = (facebook::jsi::Runtime *)(batchedBridge.runtime);
+
+      RCTAssert(
+          runtime, @"RCTRuntimeExecutorFromBridge: Bridge must have a valid jsi::Runtime at the moment of invocation.");
+
+      if (!runtime) {
+        return;
+      }
+
+      callback(*runtime);
+    }];
+  };
+
+  return runtimeExecutor;
+}

--- a/React/Fabric/RCTSurfacePresenterBridgeAdapter.h
+++ b/React/Fabric/RCTSurfacePresenterBridgeAdapter.h
@@ -6,7 +6,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <ReactCommon/RuntimeExecutor.h>
 #import <React/RCTUIKit.h> // [macOS]
 #import <react/utils/ContextContainer.h>
 
@@ -14,8 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RCTSurfacePresenter;
 @class RCTBridge;
-
-facebook::react::RuntimeExecutor RCTRuntimeExecutorFromBridge(RCTBridge *bridge);
 
 /*
  * Controls a life-cycle of a Surface Presenter based on Bridge's life-cycle.

--- a/React/React-RCTFabric.podspec
+++ b/React/React-RCTFabric.podspec
@@ -21,14 +21,40 @@ folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2021.07.22.00'
 boost_compiler_flags = '-Wno-documentation'
 
+header_search_paths = [
+  "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
+  "\"$(PODS_ROOT)/boost\"",
+  "\"$(PODS_ROOT)/DoubleConversion\"",
+  "\"$(PODS_ROOT)/RCT-Folly\"",
+  "\"$(PODS_ROOT)/Headers/Private/React-Core\"",
+  "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
+  "\"$(PODS_ROOT)/Headers/Public/React-Codegen\"",
+  "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Codegen/React_Codegen.framework/Headers\"",
+]
+
+if ENV['USE_FRAMEWORKS']
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/textlayoutmanager/platform/ios\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/textinput/iostextinput\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/imagemanager/platform/ios\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-ImageManager/React_ImageManager.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\""
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers\""
+end
+
 Pod::Spec.new do |s|
   s.name                   = "React-RCTFabric"
   s.version                = version
   s.summary                = "RCTFabric for React Native."
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
-  s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = { :ios => min_ios_version_supported, :osx => "10.15" } # [macOS]
   s.source                 = source
   s.source_files           = "Fabric/**/*.{c,h,m,mm,S,cpp}"
   s.exclude_files          = "**/tests/*",
@@ -36,15 +62,33 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.module_name            = "RCTFabric"
-  s.framework              = "JavaScriptCore"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"$(PODS_ROOT)/Headers/Public/React-Codegen\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Codegen/React_Codegen.framework/Headers\"" }
-  s.xcconfig               = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/RCT-Folly\"", "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-                               "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" + " " + folly_flags  }
+  s.framework              = ["JavaScriptCore", "MobileCoreServices"]
+  s.pod_target_xcconfig    = {
+    "HEADER_SEARCH_PATHS" => header_search_paths,
+    "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" + " " + folly_flags,
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+  }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
+    "PUBLIC_HEADERS_FOLDER_PATH" => "$(CONTENTS_FOLDER_PATH)/Headers/React"
+  }: {})
 
   s.dependency "React-Core", version
   s.dependency "React-Fabric", version
   s.dependency "React-RCTImage", version
+  s.dependency "React-ImageManager"
+  s.dependency "React-graphics"
   s.dependency "RCT-Folly/Fabric", folly_version
+  s.dependency "glog"
+  s.dependency "Yoga"
+  s.dependency "React-RCTText"
+  s.dependency "React-FabricImage"
+  s.dependency "React-utils"
+  s.dependency "React-runtimescheduler"
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsi"
+  end
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = "Tests/**/*.{mm}"

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -42,6 +42,19 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-logger"
+  s.dependency "glog"
+  s.dependency "DoubleConversion"
+  s.dependency "React-Core"
+  s.dependency "React-debug"
+  s.dependency "React-utils"
+  s.dependency "React-runtimescheduler"
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsi"
+  end
 
   s.subspec "animations" do |ss|
     ss.dependency             folly_dep_name, folly_version
@@ -222,15 +235,6 @@ Pod::Spec.new do |s|
     end
   end
 
-  s.subspec "debug_core" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/debug/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/debug/tests"
-    ss.header_dir           = "react/debug"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
   s.subspec "debug_renderer" do |ss|
     ss.dependency             folly_dep_name, folly_version
     ss.compiler_flags       = folly_compiler_flags
@@ -327,21 +331,4 @@ Pod::Spec.new do |s|
     ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
                                 "GCC_WARN_PEDANTIC" => "YES" }
   end
-
-  s.subspec "runtimescheduler" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/runtimescheduler/**/*.{cpp,h}"
-    ss.exclude_files        = "react/renderer/runtimescheduler/tests"
-    ss.header_dir           = "react/renderer/runtimescheduler"
-    ss.pod_target_xcconfig  = {"HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
-                               "GCC_WARN_PEDANTIC" => "YES" }
-  end
-
-  s.subspec "utils" do |ss|
-    ss.source_files         = "react/utils/*.{m,mm,cpp,h}"
-    ss.header_dir           = "react/utils"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\""}
-  end
-
 end

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -33,7 +33,8 @@ Pod::Spec.new do |s|
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\"",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
   s.header_dir             = "cxxreact"
 
   s.dependency "boost", "1.76.0"

--- a/ReactCommon/react/debug/React-debug.podspec
+++ b/ReactCommon/react/debug/React-debug.podspec
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-debug"
+  s.version                = version
+  s.summary                = "-"  # TODO
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = { :ios => min_ios_version_supported }
+  s.source                 = source
+  s.source_files           = "**/*.{cpp,h}"
+  s.header_dir             = "react/debug"
+  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
+
+  if ENV['USE_FRAMEWORKS']
+    s.module_name            = "React_debug"
+    s.header_mappings_dir  = "../.."
+  end
+end

--- a/ReactCommon/react/debug/React-debug.podspec
+++ b/ReactCommon/react/debug/React-debug.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => min_ios_version_supported }
+  s.platforms              = { :ios => min_ios_version_supported, :osx => "10.15" } # [macOS]
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "react/debug"

--- a/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+folly_version = '2021.07.22.00'
+
+header_search_paths = [
+    "\"$(PODS_ROOT)/RCT-Folly\"",
+]
+
+if ENV['USE_FRAMEWORKS']
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" #this is needed to allow the RuntimeScheduler access its own files
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\""
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-runtimescheduler"
+  s.version                = version
+  s.summary                = "-"  # TODO
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = { :ios => min_ios_version_supported }
+  s.source                 = source
+  s.source_files           = "**/*.{cpp,h}"
+  s.compiler_flags         = folly_compiler_flags
+  s.header_dir             = "react/renderer/runtimescheduler"
+  s.exclude_files          = "tests"
+  s.pod_target_xcconfig    = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
+
+  if ENV['USE_FRAMEWORKS']
+    s.module_name            = "React_runtimescheduler"
+    s.header_mappings_dir  = "../../.."
+  end
+
+  s.dependency "React-jsi"
+  s.dependency "React-runtimeexecutor"
+  s.dependency "React-callinvoker"
+  s.dependency "React-debug"
+  s.dependency "glog"
+  s.dependency "RCT-Folly", folly_version
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsi"
+  end
+
+end

--- a/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => min_ios_version_supported }
+  s.platforms              = { :ios => min_ios_version_supported, :osx => "10.15" } # [macOS]
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "RuntimeSchedulerBinding.h"
-#include "SchedulerPriority.h"
+#include <ReactCommon/SchedulerPriority.h>
+#include "RuntimeScheduler.h"
+#include "SchedulerPriorityUtils.h"
 #include "primitives.h"
 
 #include <react/debug/react_native_assert.h>

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
@@ -6,9 +6,9 @@
  */
 
 #include "RuntimeSchedulerBinding.h"
-#include <ReactCommon/SchedulerPriority.h>
+#include "SchedulerPriority.h"
 #include "RuntimeScheduler.h"
-#include "SchedulerPriorityUtils.h"
+//#include "SchedulerPriorityUtils.h"
 #include "primitives.h"
 
 #include <react/debug/react_native_assert.h>

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 namespace facebook {
 namespace react {
+
+class RuntimeScheduler;
 
 /*
  * Exposes RuntimeScheduler to JavaScript realm.

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
@@ -8,6 +8,7 @@
 #include "RuntimeSchedulerCallInvoker.h"
 
 #include <utility>
+#include "RuntimeScheduler.h"
 
 namespace facebook::react {
 

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 namespace facebook {
 namespace react {
+
+class RuntimeScheduler;
 
 /*
  * Exposes RuntimeScheduler to native modules. All calls invonked on JavaScript

--- a/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -7,24 +7,18 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/runtimescheduler/Task.h>
 
 namespace facebook {
 namespace react {
 
-struct TaskWrapper : public jsi::HostObject {
-  TaskWrapper(std::shared_ptr<Task> const &task) : task(task) {}
-
-  std::shared_ptr<Task> task;
-};
-
 inline static jsi::Value valueFromTask(
     jsi::Runtime &runtime,
-    std::shared_ptr<Task> const &task) {
-  return jsi::Object::createFromHostObject(
-      runtime, std::make_shared<TaskWrapper>(task));
+    std::shared_ptr<Task> task) {
+  jsi::Object obj(runtime);
+  obj.setNativeState(runtime, std::move(task));
+  return obj;
 }
 
 inline static std::shared_ptr<Task> taskFromValue(
@@ -34,7 +28,7 @@ inline static std::shared_ptr<Task> taskFromValue(
     return nullptr;
   }
 
-  return value.getObject(runtime).getHostObject<TaskWrapper>(runtime)->task;
+  return value.getObject(runtime).getNativeState<Task>(runtime);
 }
 
 } // namespace react

--- a/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -13,12 +13,17 @@
 namespace facebook {
 namespace react {
 
+struct TaskWrapper : public jsi::HostObject {
+  TaskWrapper(std::shared_ptr<Task> const &task) : task(task) {}
+
+  std::shared_ptr<Task> task;
+};
+
 inline static jsi::Value valueFromTask(
     jsi::Runtime &runtime,
     std::shared_ptr<Task> task) {
-  jsi::Object obj(runtime);
-  obj.setNativeState(runtime, std::move(task));
-  return obj;
+      return jsi::Object::createFromHostObject(
+          runtime, std::make_shared<TaskWrapper>(task));
 }
 
 inline static std::shared_ptr<Task> taskFromValue(
@@ -28,7 +33,7 @@ inline static std::shared_ptr<Task> taskFromValue(
     return nullptr;
   }
 
-  return value.getObject(runtime).getNativeState<Task>(runtime);
+  return value.getObject(runtime).getHostObject<TaskWrapper>(runtime)->task;
 }
 
 } // namespace react

--- a/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -13,7 +13,7 @@
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/EventBeat.h>
 #include <react/renderer/leakchecker/LeakChecker.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/renderer/uimanager/primitives.h>
 #include <react/utils/ContextContainer.h>

--- a/ReactCommon/react/utils/ManagedObjectWrapper.h
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.h
@@ -14,7 +14,7 @@
 #endif
 
 #if defined(__OBJC__) && defined(__cplusplus)
-#if TARGET_OS_MAC
+#if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
 
 #include <memory>
 

--- a/ReactCommon/react/utils/ManagedObjectWrapper.h
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.h
@@ -14,7 +14,7 @@
 #endif
 
 #if defined(__OBJC__) && defined(__cplusplus)
-#if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
+// #if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
 
 #include <memory>
 
@@ -78,5 +78,5 @@ inline id unwrapManagedObjectWeakly(std::shared_ptr<void> const &object) noexcep
 } // namespace react
 } // namespace facebook
 
-#endif
+// #endif
 #endif

--- a/ReactCommon/react/utils/ManagedObjectWrapper.mm
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.mm
@@ -7,7 +7,7 @@
 
 #include "ManagedObjectWrapper.h"
 
-#if TARGET_OS_MAC
+#if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
 
 namespace facebook {
 namespace react {
@@ -33,4 +33,4 @@ void wrappedManagedObjectDeleter(void *cfPointer) noexcept
 @implementation RCTInternalGenericWeakWrapper
 @end
 
-#endif
+// #endif

--- a/ReactCommon/react/utils/ManagedObjectWrapper.mm
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.mm
@@ -7,7 +7,7 @@
 
 #include "ManagedObjectWrapper.h"
 
-#if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
+// #if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
 
 namespace facebook {
 namespace react {

--- a/ReactCommon/react/utils/React-utils.podspec
+++ b/ReactCommon/react/utils/React-utils.podspec
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+folly_version = '2021.07.22.00'
+
+header_search_paths = [
+    "\"$(PODS_ROOT)/RCT-Folly\"",
+    "\"$(PODS_TARGET_SRCROOT)\"",
+    "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
+]
+
+if ENV["USE_FRAMEWORKS"]
+  header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\""
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-utils"
+  s.version                = version
+  s.summary                = "-"  # TODO
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = { :ios => min_ios_version_supported }
+  s.source                 = source
+  s.source_files           = "**/*.{cpp,h,mm}"
+  s.compiler_flags         = folly_compiler_flags
+  s.header_dir             = "react/utils"
+  s.exclude_files          = "tests"
+  s.pod_target_xcconfig    = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
+
+  if ENV['USE_FRAMEWORKS']
+    s.module_name            = "React_utils"
+    s.header_mappings_dir  = "../.."
+  end
+
+  s.dependency "RCT-Folly", folly_version
+  s.dependency "React-debug"
+  s.dependency "glog"
+end

--- a/ReactCommon/react/utils/React-utils.podspec
+++ b/ReactCommon/react/utils/React-utils.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => min_ios_version_supported }
+  s.platforms              = { :ios => min_ios_version_supported, :osx => "10.15" } # [macOS]
   s.source                 = source
   s.source_files           = "**/*.{cpp,h,mm}"
   s.compiler_flags         = folly_compiler_flags

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "shouldPublish": false
   },
   "resolutions": {
+    "@babel/runtime": "7.21.0",
     "async": "^3.2.2",
     "debug": ">=3.1.0",
     "es5-ext": "0.10.53",

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -43,7 +43,9 @@ PODS:
     - React-RCTVibration (= 0.71.9)
   - React-callinvoker (0.71.9)
   - React-Codegen (0.71.9):
+    - DoubleConversion
     - FBReactNativeSpec
+    - glog
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -57,32 +59,38 @@ PODS:
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 0.71.9)
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/CoreModulesHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/Default (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/DevSupport (0.71.9):
@@ -90,133 +98,157 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 0.71.9)
     - React-Core/RCTWebSocket (= 0.71.9)
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
     - React-jsinspector (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTActionSheetHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTAnimationHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTBlobHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTImageHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTLinkingHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTNetworkHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTPushNotificationHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTSettingsHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTTextHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTVibrationHeaders (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-Core/RCTWebSocket (0.71.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 0.71.9)
-    - React-cxxreact (= 0.71.9)
+    - React-cxxreact
     - React-jsc
-    - React-jsi (= 0.71.9)
-    - React-jsiexecutor (= 0.71.9)
-    - React-perflogger (= 0.71.9)
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
     - SocketRocket (= 0.6.0)
     - Yoga
   - React-CoreModules (0.71.9):
@@ -240,6 +272,7 @@ PODS:
     - React-logger (= 0.71.9)
     - React-perflogger (= 0.71.9)
     - React-runtimeexecutor (= 0.71.9)
+  - React-debug (0.71.9)
   - React-jsc (0.71.9):
     - React-jsc/Fabric (= 0.71.9)
     - React-jsi (= 0.71.9)
@@ -276,10 +309,10 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - React-CoreModules
-    - React-hermes
-    - React-NativeModulesApple
+    - React-jsc
     - React-RCTImage
     - React-RCTNetwork
+    - React-runtimescheduler
     - ReactCommon/turbomodule/core
   - React-RCTBlob (0.71.9):
     - RCT-Folly (= 2021.07.22.00)
@@ -338,6 +371,17 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.71.9)
   - React-runtimeexecutor (0.71.9):
     - React-jsi (= 0.71.9)
+  - React-runtimescheduler (0.71.9):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-callinvoker
+    - React-debug
+    - React-jsi
+    - React-runtimeexecutor
+  - React-utils (0.71.9):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-debug
   - ReactCommon/turbomodule/bridging (0.71.9):
     - DoubleConversion
     - glog
@@ -370,7 +414,6 @@ PODS:
     - React-perflogger (= 0.71.9)
     - ReactCommon/turbomodule/core (= 0.71.9)
   - ScreenshotManager (0.0.1):
-    - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - SocketRocket (0.6.0)
@@ -393,6 +436,7 @@ DEPENDENCIES:
   - React-Core/RCTWebSocket (from `../../`)
   - React-CoreModules (from `../../React/CoreModules`)
   - React-cxxreact (from `../../ReactCommon/cxxreact`)
+  - React-debug (from `../../ReactCommon/react/debug`)
   - React-jsc (from `../../ReactCommon/jsc`)
   - React-jsi (from `../../ReactCommon/jsi`)
   - React-jsiexecutor (from `../../ReactCommon/jsiexecutor`)
@@ -412,6 +456,8 @@ DEPENDENCIES:
   - React-RCTText (from `../../Libraries/Text`)
   - React-RCTVibration (from `../../Libraries/Vibration`)
   - React-runtimeexecutor (from `../../ReactCommon/runtimeexecutor`)
+  - React-runtimescheduler (from `../../ReactCommon/react/renderer/runtimescheduler`)
+  - React-utils (from `../../ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../../ReactCommon`)
   - ReactCommon/turbomodule/samples (from `../../ReactCommon`)
   - ScreenshotManager (from `NativeModuleExample`)
@@ -452,6 +498,8 @@ EXTERNAL SOURCES:
     :path: "../../React/CoreModules"
   React-cxxreact:
     :path: "../../ReactCommon/cxxreact"
+  React-debug:
+    :path: "../../ReactCommon/react/debug"
   React-jsc:
     :path: "../../ReactCommon/jsc"
   React-jsi:
@@ -490,6 +538,10 @@ EXTERNAL SOURCES:
     :path: "../../Libraries/Vibration"
   React-runtimeexecutor:
     :path: "../../ReactCommon/runtimeexecutor"
+  React-runtimescheduler:
+    :path: "../../ReactCommon/react/renderer/runtimescheduler"
+  React-utils:
+    :path: "../../ReactCommon/react/utils"
   ReactCommon:
     :path: "../../ReactCommon"
   ScreenshotManager:
@@ -510,10 +562,11 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 181fe186459a5d0bb58b4a9598ed49e696075a0f
   React: 45aa27aa368b664472f4c7417a95c92d1becd3ba
   React-callinvoker: 141ab2c8eaf432dd1fe904c8645da883d780f8a1
-  React-Codegen: 55b9cf16d7aee7f13f535822fd7782c213ff4d64
-  React-Core: 4c6388c919b8834b38c80698da94ca2e304e209d
+  React-Codegen: 6ee96fba241942a237493f88e96f8125c0224db4
+  React-Core: c3960fa40d5574b8572b42b63935a4a97bf3245a
   React-CoreModules: 3a79aac89e612cbc27d5afb4f1050e3de6ff755d
-  React-cxxreact: 642aeef37306c95317afe17072034c0b27203f57
+  React-cxxreact: 22030cf18291852acdf4036758e4941e06f673a1
+  React-debug: 6063d5aa2222cbe91691da3bb7f400d9812f5a3e
   React-jsc: 20c9378136666b09f2340ee6c0e3a7e7fd184ba4
   React-jsi: 4529e3bdae4f54aff6a985a28ec7a735b4937e09
   React-jsiexecutor: d1917e283b18ea4a8c1ae15183390eb153422047
@@ -522,7 +575,7 @@ SPEC CHECKSUMS:
   React-perflogger: ad12d16b6909321cf0a243c533a5563fda359c8f
   React-RCTActionSheet: d6e2fa6593bc218feb667db89d5c494e82a7dc03
   React-RCTAnimation: b9a0fbc96b8418d7015b77a14abe4796209bd2c0
-  React-RCTAppDelegate: 33aca1ace4605d527c74e894800951722001e942
+  React-RCTAppDelegate: e4bf9b6b06af3b371d788e54734d4598b5a577bc
   React-RCTBlob: 2249dc79d1d5c21aef9a73af3d2ec8048ad42e01
   React-RCTImage: 0ed16720bee34ab6a0d86ce81f87ae43936ed61f
   React-RCTLinking: f52ef6a373db2e524e46b734573ec0386cb3abc4
@@ -533,6 +586,8 @@ SPEC CHECKSUMS:
   React-RCTText: 4f2e960be025fabdb786ee723fa2b9d42e393163
   React-RCTVibration: e4dcf84e762dd211abd7cdde3927582030fb1b80
   React-runtimeexecutor: 4dd1aaa5446bbfbd87000eea67c61a7467172984
+  React-runtimescheduler: 8b9f903b174f86379f6d96bb726b5362bc58b077
+  React-utils: 93d649cac943085463227f44343f36daf1b63bce
   ReactCommon: f2b2050e72d839e4442ab0bdaa0d9ef3eac9b374
   ScreenshotManager: 2fac62be553326d7d32ef3019c9fa4fd7b59918d
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -275,6 +275,11 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
+    - React-CoreModules
+    - React-hermes
+    - React-NativeModulesApple
+    - React-RCTImage
+    - React-RCTNetwork
     - ReactCommon/turbomodule/core
   - React-RCTBlob (0.71.9):
     - RCT-Folly (= 2021.07.22.00)
@@ -365,6 +370,7 @@ PODS:
     - React-perflogger (= 0.71.9)
     - ReactCommon/turbomodule/core (= 0.71.9)
   - ScreenshotManager (0.0.1):
+    - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - SocketRocket (0.6.0)

--- a/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -540,9 +540,28 @@ class CodegenUtilsTests < Test::Unit::TestCase
         specs[:dependencies].merge!({
             'React-graphics': [],
             'React-rncore':  [],
+            'React-Fabric': [],
+            'React-utils': [],
+            'React-debug': [],
         })
 
         specs[:'script_phases'] = script_phases
+
+        return specs
+    end
+
+    def get_podspec_when_use_frameworks
+        specs = get_podspec_no_fabric_no_script()
+
+        specs["pod_target_xcconfig"]["FRAMEWORK_SEARCH_PATHS"].concat([])
+        specs["pod_target_xcconfig"]["HEADER_SEARCH_PATHS"].concat(" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-Fabric/React_Fabric.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-FabricImage/React_FabricImage.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-RCTFabric/RCTFabric.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers\"")
+
+        specs[:dependencies].merge!({
+            'React-graphics': [],
+            'React-Fabric': [],
+            'React-utils': [],
+            'React-debug': [],
+        })
 
         return specs
     end

--- a/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -137,7 +137,7 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "RCTTypeSafety" },
                 { :dependency_name => "ReactCommon/turbomodule/bridging" },
                 { :dependency_name => "ReactCommon/turbomodule/core" },
-                { :dependency_name => "React-NativeModulesApple" },
+                # { :dependency_name => "React-NativeModulesApple" },
                 { :dependency_name => "Yoga" },
                 { :dependency_name => "React-Fabric" },
                 { :dependency_name => "React-graphics" },

--- a/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -123,7 +123,7 @@ class NewArchitectureTests < Test::Unit::TestCase
 
         # Assert
         assert_equal(spec.compiler_flags, NewArchitectureHelper.folly_compiler_flags)
-        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\"")
+        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\" \"$(PODS_ROOT)/DoubleConversion\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\"")
         assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++17")
         assert_equal(spec.pod_target_xcconfig["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1")
         assert_equal(
@@ -136,7 +136,14 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "RCTRequired" },
                 { :dependency_name => "RCTTypeSafety" },
                 { :dependency_name => "ReactCommon/turbomodule/bridging" },
-                { :dependency_name => "ReactCommon/turbomodule/core" }
+                { :dependency_name => "ReactCommon/turbomodule/core" },
+                { :dependency_name => "React-NativeModulesApple" },
+                { :dependency_name => "Yoga" },
+                { :dependency_name => "React-Fabric" },
+                { :dependency_name => "React-graphics" },
+                { :dependency_name => "React-utils" },
+                { :dependency_name => "React-debug" },
+                { :dependency_name => "hermes-engine" }
         ])
     end
 
@@ -154,7 +161,7 @@ class NewArchitectureTests < Test::Unit::TestCase
 
         # Assert
         assert_equal(spec.compiler_flags, "-Wno-nullability-completeness #{NewArchitectureHelper.folly_compiler_flags}")
-        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "#{other_flags} \"$(PODS_ROOT)/boost\"")
+        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "#{other_flags} \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\" \"$(PODS_ROOT)/DoubleConversion\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\"")
         assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++17")
         assert_equal(
             spec.dependencies,

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -74,6 +74,34 @@ class CodegenUtils
         folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
         boost_compiler_flags = '-Wno-documentation'
 
+        header_search_paths = [
+          "\"$(PODS_ROOT)/boost\"",
+          "\"$(PODS_ROOT)/RCT-Folly\"",
+          "\"$(PODS_ROOT)/DoubleConversion\"",
+          "\"${PODS_ROOT}/Headers/Public/React-Codegen/react/renderer/components\"",
+          "\"$(PODS_ROOT)/Headers/Private/React-Fabric\"",
+          "\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\"",
+          "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
+        ]
+        framework_search_paths = []
+
+        if use_frameworks
+          header_search_paths.concat([
+            "\"$(PODS_ROOT)/DoubleConversion\"",
+            "\"$(PODS_TARGET_SRCROOT)\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-Fabric/React_Fabric.framework/Headers\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-FabricImage/React_FabricImage.framework/Headers\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-RCTFabric/RCTFabric.framework/Headers\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\"",
+            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers\"",
+          ])
+        end
+
         spec = {
           'name' => "React-Codegen",
           'version' => version,
@@ -107,14 +135,19 @@ class CodegenUtils
             "React-Core": [],
             "React-jsi": [],
             "ReactCommon/turbomodule/bridging": [],
-            "ReactCommon/turbomodule/core": []
+            "ReactCommon/turbomodule/core": [],
+            "React-NativeModulesApple": [],
+            "glog": [],
+            "DoubleConversion": [],
           }
         }
 
         if fabric_enabled
           spec[:'dependencies'].merge!({
             'React-graphics': [],
-            'React-rncore':  [],
+            'React-Fabric': [],
+            'React-debug': [],
+            'React-utils': [],
           });
         end
 

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -85,22 +85,22 @@ class CodegenUtils
         ]
         framework_search_paths = []
 
-        if use_frameworks
-          header_search_paths.concat([
-            "\"$(PODS_ROOT)/DoubleConversion\"",
-            "\"$(PODS_TARGET_SRCROOT)\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-Fabric/React_Fabric.framework/Headers\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-FabricImage/React_FabricImage.framework/Headers\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-RCTFabric/RCTFabric.framework/Headers\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\"",
-            "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers\"",
-          ])
-        end
+        # if use_frameworks
+        #   header_search_paths.concat([
+        #     "\"$(PODS_ROOT)/DoubleConversion\"",
+        #     "\"$(PODS_TARGET_SRCROOT)\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-Fabric/React_Fabric.framework/Headers\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-FabricImage/React_FabricImage.framework/Headers\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-RCTFabric/RCTFabric.framework/Headers\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\"",
+        #     "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers\"",
+        #   ])
+        # end
 
         spec = {
           'name' => "React-Codegen",
@@ -136,7 +136,7 @@ class CodegenUtils
             "React-jsi": [],
             "ReactCommon/turbomodule/bridging": [],
             "ReactCommon/turbomodule/core": [],
-            "React-NativeModulesApple": [],
+            # "React-NativeModulesApple": [],
             "glog": [],
             "DoubleConversion": [],
           }

--- a/scripts/cocoapods/new_architecture.rb
+++ b/scripts/cocoapods/new_architecture.rb
@@ -84,6 +84,9 @@ class NewArchitectureHelper
             header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\""
             header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\""
         end
+
+        boost_search_path = "\"$(PODS_ROOT)/boost\""
+
         header_search_paths_string = header_search_paths.join(" ")
         spec.compiler_flags = compiler_flags.empty? ? @@folly_compiler_flags : "#{compiler_flags} #{@@folly_compiler_flags}"
         current_config["HEADER_SEARCH_PATHS"] = current_headers.empty? ? boost_search_path : "#{current_headers} #{boost_search_path}"
@@ -102,7 +105,7 @@ class NewArchitectureHelper
             spec.dependency "RCTTypeSafety"
             spec.dependency "ReactCommon/turbomodule/bridging"
             spec.dependency "ReactCommon/turbomodule/core"
-            spec.dependency "React-NativeModulesApple"
+            # spec.dependency "React-NativeModulesApple"
             spec.dependency "Yoga"
             spec.dependency "React-Fabric"
             spec.dependency "React-graphics"

--- a/scripts/cocoapods/new_architecture.rb
+++ b/scripts/cocoapods/new_architecture.rb
@@ -71,8 +71,20 @@ class NewArchitectureHelper
         current_config = hash["pod_target_xcconfig"] != nil ? hash["pod_target_xcconfig"] : {}
         current_headers = current_config["HEADER_SEARCH_PATHS"] != nil ? current_config["HEADER_SEARCH_PATHS"] : ""
 
-        boost_search_path = "\"$(PODS_ROOT)/boost\""
-
+        header_search_paths = ["\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\""]
+        if ENV['USE_FRAMEWORKS']
+            header_search_paths << "\"$(PODS_ROOT)/DoubleConversion\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\""
+            header_search_paths << "\"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\""
+        end
+        header_search_paths_string = header_search_paths.join(" ")
         spec.compiler_flags = compiler_flags.empty? ? @@folly_compiler_flags : "#{compiler_flags} #{@@folly_compiler_flags}"
         current_config["HEADER_SEARCH_PATHS"] = current_headers.empty? ? boost_search_path : "#{current_headers} #{boost_search_path}"
         current_config["CLANG_CXX_LANGUAGE_STANDARD"] = @@cplusplus_version
@@ -90,6 +102,18 @@ class NewArchitectureHelper
             spec.dependency "RCTTypeSafety"
             spec.dependency "ReactCommon/turbomodule/bridging"
             spec.dependency "ReactCommon/turbomodule/core"
+            spec.dependency "React-NativeModulesApple"
+            spec.dependency "Yoga"
+            spec.dependency "React-Fabric"
+            spec.dependency "React-graphics"
+            spec.dependency "React-utils"
+            spec.dependency "React-debug"
+
+            if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+                spec.dependency "hermes-engine"
+            else
+                spec.dependency "React-jsi"
+            end
         end
 
         spec.pod_target_xcconfig = current_config

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -101,6 +101,8 @@ def use_react_native! (
   pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
 
   pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
+  pod 'React-debug', :path => "#{prefix}/ReactCommon/react/debug"
+  pod 'React-utils', :path => "#{prefix}/ReactCommon/react/utils"
 
   if hermes_enabled
     setup_hermes!(:react_native_path => prefix, :fabric_enabled => fabric_enabled)
@@ -113,6 +115,7 @@ def use_react_native! (
 
   pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
   pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
+  pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
   pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
   pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
   pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,17 +947,10 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.18.3":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
-  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.8.4":
-  version "7.20.13"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
-  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
+"@babel/runtime@7.21.0", "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.8.4":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -6331,7 +6324,7 @@ regenerator-runtime@^0.13.11:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
-regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.2:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
This is a working branch to test changes of this change back ported to 0.71:

https://github.com/facebook/react-native/pull/37523/