### PR TITLE
Update RCTUITextView to use the systemFontSize for macOS

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -27,7 +27,11 @@
 
 static UIFont *defaultPlaceholderFont()
 {
+#if !TARGET_OS_OSX // [macOS]
   return [UIFont systemFontOfSize:17];
+#else // [macOS
+  return [UIFont systemFontOfSize:[NSFont systemFontSize]];
+#endif // macOS]
 }
 
 static RCTUIColor *defaultPlaceholderColor() // [macOS]

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -25,14 +25,17 @@
 #endif // macOS]
 }
 
+#if !TARGET_OS_OSX // [macOS]
 static UIFont *defaultPlaceholderFont()
 {
-#if !TARGET_OS_OSX // [macOS]
   return [UIFont systemFontOfSize:17];
-#else // [macOS
-  return [UIFont systemFontOfSize:[NSFont systemFontSize]];
-#endif // macOS]
 }
+#else // [macOS
+static NSFont *defaultPlaceholderFont()
+{
+  return [NSFont systemFontOfSize:[NSFont systemFontSize]];
+}
+#endif // macOS]
 
 static RCTUIColor *defaultPlaceholderColor() // [macOS]
 {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We have a component using RCTUITextView, and the placeholder text looks too big on macOS. The placeholder text font size was hardcoded to 17px (which according to [this](https://developer.apple.com/design/human-interface-guidelines/typography#Specifications) is the iOS default font size for body text), but for macOS it should be the system font size, i.e. 13px. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[macOS] [FIXED] - Update RCTUITextView to use the systemFontSize

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

| - | macOS | iOS (no change) |
| - | - | - |
| Before | <img width="600" alt="macOS before" src="https://github.com/microsoft/react-native-macos/assets/78454019/24ff5741-5063-45e7-8c61-3e234274af59"> | <img width="300" alt="iOS before" src="https://github.com/microsoft/react-native-macos/assets/78454019/71db9ed6-e81f-4f66-a458-f43278b35c43"> |
| After | <img width="400" alt="macOS after" src="https://github.com/microsoft/react-native-macos/assets/78454019/cc1bff3f-f10e-4046-bfee-12144dd9c9e1"> | <img width="300" alt="iOS after" src="https://github.com/microsoft/react-native-macos/assets/78454019/5b237ba9-64a6-4170-975b-3a629130e7e5"> |

Also confirmed from debugging that the font size on macOS is indeed 13px