### PR TITLE
Scrollview - fix text centered on render when centerContent is true

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -871,7 +871,8 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
 - (void)scrollViewDocumentViewBoundsDidChange:(__unused NSNotification *)notification
 {
   if (_scrollView.centerContent) {
-    _scrollView.contentOffset = _scrollView.contentOffset; // necessary for content centering when _centerContent == YES
+    // contentOffset setter dynamically centers content when _centerContent == YES
+    [_scrollView setContentOffset:_scrollView.contentOffset];
   }
 
   // if scrollView is not ready, don't notify with scroll event
@@ -1176,6 +1177,9 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
   CGSize contentSize = self.contentSize;
   if (!CGSizeEqualToSize(_scrollView.contentSize, contentSize)) {
     _scrollView.contentSize = contentSize;
+#if TARGET_OS_OSX // [macOS
+    [_scrollView setContentOffset:_scrollView.contentOffset];
+#endif // macOS]
   }
 }
 

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -504,6 +504,14 @@ if (Platform.OS === 'macos') {
         return <ScrollIndicatorOverlayExample />;
       },
     },
+    {
+      title: '<ScrollView> (centerContent = true)\n',
+      description:
+        'ScrollView puts its content in the center if the content is smaller than scroll view',
+      render: function (): React.Node {
+        return <CenterContentList />;
+      },
+    },
   );
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

* Text centering with `centerContent` prop only worked after content was first scrolled.
https://reactnative.dev/docs/scrollview#centercontent-ios

* With this change, the content is centered vertically/horizontally when rendered

## Changelog

[MACOS] [FIXED] - Scrollview - fix text centered on render when centerContent is true

## Test Plan

### Before - Must scroll before content is centered
https://github.com/microsoft/react-native-macos/assets/96719/2a6c0827-43c5-4340-9f8c-faa7d25526c3

### After - Vertical
https://github.com/microsoft/react-native-macos/assets/96719/5ea27364-b16f-437a-a325-d8f24269b919
### After - Horizontal
https://github.com/microsoft/react-native-macos/assets/96719/420cc7cd-b945-4b94-9b1b-b97f2fb14f33



