### PR TITLE
[0.71] Use viewDidChangeBackingProperties to remove the use of notifications in RCTImageView

### DIFF
--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -131,11 +131,6 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
 
   RCTUIImageViewAnimated *_imageView;
 
-#if TARGET_OS_OSX // [macOS
-  // Whether observing changes to the window's backing scale
-  BOOL _subscribedToWindowBackingNotifications;
-#endif // macOS]
-  
   RCTImageURLLoaderRequest *_loaderRequest;
 }
 
@@ -616,32 +611,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 #if TARGET_OS_OSX // [macOS
 #define didMoveToWindow viewDidMoveToWindow
 #endif
-#if TARGET_OS_OSX
-- (void)viewWillMoveToWindow:(NSWindow *)newWindow
-{
-  if (_subscribedToWindowBackingNotifications &&
-      self.window != nil &&
-      self.window != newWindow) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                    name:NSWindowDidChangeBackingPropertiesNotification
-                                                  object:self.window];
-    _subscribedToWindowBackingNotifications = NO;
-  }
-}
-#endif // macOS]
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
 
-#if TARGET_OS_OSX // [macOS
-  if (!_subscribedToWindowBackingNotifications && self.window != nil) {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(windowDidChangeBackingProperties:)
-                                                 name:NSWindowDidChangeBackingPropertiesNotification
-                                               object:self.window];
-    _subscribedToWindowBackingNotifications = YES;
-  }
-#endif // macOS]
   if (!self.window) {
     // Cancel loading the image if we've moved offscreen. In addition to helping
     // prioritise image requests that are actually on-screen, this removes
@@ -655,7 +628,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 }
     
 #if TARGET_OS_OSX // [macOS
-- (void)windowDidChangeBackingProperties:(NSNotification *)notification
+- (void)viewDidChangeBackingProperties
 {
   [self reloadImage];
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Cherry pick of https://github.com/microsoft/react-native-macos/pull/1834/ to 0.71-stable

## Changelog

[macOS] [CHANGED] - Use viewDidChangeBackingProperties for image reloads on backing properties change

## Test Plan

Tested by running RNTester on macOS with paper:
<img width="1136" alt="Screenshot 2023-06-01 at 17 49 01" src="https://github.com/microsoft/react-native-macos/assets/151054/31df51fb-b810-471a-9175-970a15956608">

