### PR TITLE
[Fabric] Tint images using CIFilter fixing wrong tinted image size

### DIFF
--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -753,7 +753,9 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 // RCTUIImageView
 
-@implementation RCTUIImageView
+@implementation RCTUIImageView {
+  CALayer *_tintingLayer;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -812,13 +814,19 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
   CALayer *layer = [self layer];
   
   if ([layer contents] != image || [layer backgroundColor] != nil) {
-    if (_tintColor != nil) {
-      image = [image copy];
-      [image lockFocus];
-      [_tintColor set];
-      NSRect imageRect = { NSZeroPoint, image.size };
-      NSRectFillUsingOperation(imageRect, NSCompositingOperationSourceIn);
-      [image unlockFocus];
+    if (_tintColor) {
+      if (!_tintingLayer) {
+        _tintingLayer = [CALayer new];
+        [_tintingLayer setFrame:self.bounds];
+        [_tintingLayer setAutoresizingMask:kCALayerWidthSizable | kCALayerHeightSizable];
+        [_tintingLayer setZPosition:1.0];
+        [_tintingLayer setCompositingFilter:[CIFilter filterWithName:@"CISourceInCompositing"]];
+        [layer addSublayer:_tintingLayer];
+      }
+      [_tintingLayer setBackgroundColor:_tintColor.CGColor];
+    } else {
+      [_tintingLayer removeFromSuperlayer];
+      _tintingLayer = nil;
     }
     
     if (image != nil && [image resizingMode] == NSImageResizingModeTile) {

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -820,7 +820,9 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
         [_tintingLayer setFrame:self.bounds];
         [_tintingLayer setAutoresizingMask:kCALayerWidthSizable | kCALayerHeightSizable];
         [_tintingLayer setZPosition:1.0];
-        [_tintingLayer setCompositingFilter:[CIFilter filterWithName:@"CISourceInCompositing"]];
+        CIFilter *sourceInCompositingFilter = [CIFilter filterWithName:@"CISourceInCompositing"];
+        [sourceInCompositingFilter setDefaults];
+        [_tintingLayer setCompositingFilter:sourceInCompositingFilter];
         [layer addSublayer:_tintingLayer];
       }
       [_tintingLayer setBackgroundColor:_tintColor.CGColor];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary
Implement image tinting using a CALayer with a compositing CIFilter instead of generating a tinted image. This fixes the wrong image aspect ratio of the generated tint image and removes the need to change the source image.

## Changelog

[macOS] [FIXED] - Image tint renders the images with the correct size on fabric.

## Test Plan

Tested by running RNTester on macOS with fabric (RCT_NEW_ARCH_ENABLED=1) and launching the Image example.

With the fix:
<img width="1136" alt="Screenshot 2023-06-07 at 03 37 26" src="https://github.com/microsoft/react-native-macos/assets/151054/6c6e4189-b2a3-4051-9d3a-23a9f2669667">

Without the fix:
<img width="1136" alt="Screenshot 2023-06-07 at 03 37 58" src="https://github.com/microsoft/react-native-macos/assets/151054/370a470b-579d-47a1-9fff-4184872fff0b">
