### PR TITLE
[Fabric] Point scale factor update support

### DIFF
--- a/React/Base/Surface/RCTSurfaceProtocol.h
+++ b/React/Base/Surface/RCTSurfaceProtocol.h
@@ -75,6 +75,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)start;
 - (void)stop;
 
+- (void)updateLayoutContextWithPointScaleFactor:(CGFloat)pointScaleFactor;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -248,6 +248,11 @@ RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
   [self _updateViews];
 }
 
+- (void)viewDidChangeBackingProperties
+{
+  [_surface updateLayoutContextWithPointScaleFactor:self.window.backingScaleFactor];
+}
+
 #pragma mark - RCTSurfaceDelegate
 
 - (void)surface:(__unused RCTSurface *)surface didChangeStage:(RCTSurfaceStage)stage

--- a/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/React/Fabric/Surface/RCTFabricSurface.mm
@@ -170,19 +170,24 @@ using namespace facebook::react;
   }
 }
 
-- (void)_updateLayoutContext
+- (void)updateLayoutContextWithPointScaleFactor:(CGFloat)pointScaleFactor
 {
   auto layoutConstraints = _surfaceHandler->getLayoutConstraints();
   layoutConstraints.layoutDirection = RCTLayoutDirection([[RCTI18nUtil sharedInstance] isRTL]);
 
   auto layoutContext = _surfaceHandler->getLayoutContext();
 
-  layoutContext.pointScaleFactor = RCTScreenScale();
+  layoutContext.pointScaleFactor = pointScaleFactor;
   layoutContext.swapLeftAndRightInRTL =
       [[RCTI18nUtil sharedInstance] isRTL] && [[RCTI18nUtil sharedInstance] doLeftAndRightSwapInRTL];
   layoutContext.fontSizeMultiplier = RCTFontSizeMultiplier();
 
   _surfaceHandler->constraintLayout(layoutConstraints, layoutContext);
+}
+
+- (void)_updateLayoutContext
+{
+  [self updateLayoutContextWithPointScaleFactor:RCTScreenScale()];
 }
 
 #pragma mark - Properties Management

--- a/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -141,6 +141,10 @@ void YogaLayoutableShadowNode::dirtyLayout() {
   yogaNode_.setDirty(true);
 }
 
+void YogaLayoutableShadowNode::dirtyLayoutAndPropagateDownwards() {
+  yogaNode_.markDirtyAndPropogateDownwards();
+}
+
 bool YogaLayoutableShadowNode::getIsLayoutClean() const {
   return !yogaNode_.isDirty();
 }

--- a/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -73,6 +73,7 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
 
   void cleanLayout() override;
   void dirtyLayout() override;
+  void dirtyLayoutAndPropagateDownwards() override;
   bool getIsLayoutClean() const override;
 
   /*

--- a/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -142,6 +142,7 @@ class LayoutableShadowNode : public ShadowNode {
    */
   virtual void cleanLayout() = 0;
   virtual void dirtyLayout() = 0;
+  virtual void dirtyLayoutAndPropagateDownwards() = 0;
   virtual bool getIsLayoutClean() const = 0;
 
   /*

--- a/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -144,6 +144,17 @@ ShadowNode::Unshared ShadowNode::clone(
   }
 }
 
+ShadowNode::Unshared ShadowNode::cloneRecursive() const {
+  auto clonedChildren = std::make_shared<ShadowNode::ListOfShared>(*children_);
+  auto nonConstChildren =
+      std::const_pointer_cast<ShadowNode::ListOfShared>(clonedChildren);
+  for (auto iter = nonConstChildren->begin(); iter != nonConstChildren->end(); iter++) {
+    auto sharedChild = *iter;
+    *iter = sharedChild->cloneRecursive();
+  }
+  return clone({.children = nonConstChildren});
+}
+
 ContextContainer::Shared ShadowNode::getContextContainer() const {
   return family_->componentDescriptor_.getContextContainer();
 }

--- a/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/ReactCommon/react/renderer/core/ShadowNode.h
@@ -95,6 +95,12 @@ class ShadowNode : public Sealable, public DebugStringConvertible {
    * Clones the shadow node using stored `cloneFunction`.
    */
   Unshared clone(const ShadowNodeFragment &fragment) const;
+  
+  /*
+   * Clones the shadow node recursively.
+   */
+  Unshared cloneRecursive() const;
+
 
   /*
    * Clones the node (and partially the tree starting from the node) by

--- a/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -240,8 +240,8 @@ void SurfaceHandler::constraintLayout(
     react_native_assert(
         link_.shadowTree && "`link_.shadowTree` must not be null.");
     link_.shadowTree->commit([&](RootShadowNode const &oldRootShadowNode) {
-      return oldRootShadowNode.clone(
-          propsParserContext, layoutConstraints, layoutContext);
+      return std::static_pointer_cast<RootShadowNode>(oldRootShadowNode.clone(
+          propsParserContext, layoutConstraints, layoutContext)->cloneRecursive());
     });
   }
 }

--- a/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -240,8 +240,10 @@ void SurfaceHandler::constraintLayout(
     react_native_assert(
         link_.shadowTree && "`link_.shadowTree` must not be null.");
     link_.shadowTree->commit([&](RootShadowNode const &oldRootShadowNode) {
-      return std::static_pointer_cast<RootShadowNode>(oldRootShadowNode.clone(
+      auto newRootShadowNode = std::static_pointer_cast<RootShadowNode>(oldRootShadowNode.clone(
           propsParserContext, layoutConstraints, layoutContext)->cloneRecursive());
+      newRootShadowNode->dirtyLayoutAndPropagateDownwards();
+      return newRootShadowNode;
     });
   }
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Update the layout context to the right point scale factor when moving the window to a display with a different backing scale factor.

This is achieved by committing a cloned shadow tree and forcing yoga to re-evaluate the layout on all nodes so that the updated layout context would be assigned to all layoutable nodes through the updated layout metrics holding the point scale factor.

## Changelog

[macOS] [ADDED] - Add support for point scale factor updates.

## Test Plan

Tested by running RNTester on macOS with fabric (`RCT_NEW_ARCH_ENABLED=1`) and launching the API Border example.

Setup one screen with a 1x scale factor and another screen with a 2x scale factor. Drag the window from one screen to the other and observe the re-render of the borders to the right resolution of the screen.
