### PR TITLE
Fix ColorWithSystemEffect not returning the correct base color

### DIFF
--- a/Libraries/StyleSheet/PlatformColorValueTypes.macos.js
+++ b/Libraries/StyleSheet/PlatformColorValueTypes.macos.js
@@ -97,12 +97,12 @@ export const normalizeColorObject = (
     'colorWithSystemEffect' in color &&
     color.colorWithSystemEffect != null
   ) {
-    const processColor = require('./processColor').default;
+    const normalizeColor = require('./normalizeColor');
     const colorWithSystemEffect = color.colorWithSystemEffect;
     const colorObject: NativeColorValue = {
       colorWithSystemEffect: {
         // $FlowFixMe[incompatible-use]
-        baseColor: processColor(colorWithSystemEffect.baseColor),
+        baseColor: normalizeColor(colorWithSystemEffect.baseColor),
         // $FlowFixMe[incompatible-use]
         systemEffect: colorWithSystemEffect.systemEffect,
       },


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When the colorWithSystemEffect object gets normalized, we should be calling @react-native/normalize-colors not processColor. This is a regression from 68 because in 68 we return the unprocessed color, not the noralized color object https://github.com/microsoft/react-native-macos/blob/0.68-stable/Libraries/StyleSheet/normalizeColor.js#L25
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[macOS] [FIXED] - Fix ColorWithSystemEffect not returning the correct base color

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

Before:
![image](https://github.com/microsoft/react-native-macos/assets/67026167/043b5850-d748-462f-9662-32c35398a0c8)

After:

![image](https://github.com/microsoft/react-native-macos/assets/67026167/94be769c-ca1d-42d2-836a-6a7e97048473)

