### PR TITLE
[0.71] Re-enable direct debugging with JSC on latest OS versions

### DIFF
--- a/ReactCommon/jsc/JSCRuntime.cpp
+++ b/ReactCommon/jsc/JSCRuntime.cpp
@@ -396,6 +396,13 @@ JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
       stringCounter_(0)
 #endif
 {
+// [macOS
+#ifndef NDEBUG
+  if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+    JSGlobalContextSetInspectable(ctx_, true);
+  }
+// macOS]
+#endif
 }
 
 JSCRuntime::~JSCRuntime() {


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/react-native-macos/pull/1848 to 0.71-stable