### PR TITLE
-[RCTAccessibilityManager announceForAccessibility:] calls into AppKit from background thread

### DIFF
--- a/React/Modules/MacOS/RCTAccessibilityManager.m
+++ b/React/Modules/MacOS/RCTAccessibilityManager.m
@@ -60,6 +60,7 @@ static void *AccessibilityVoiceOverChangeContext = &AccessibilityVoiceOverChange
 
 RCT_EXPORT_METHOD(announceForAccessibility:(NSString *)announcement)
 {
+  dispatch_async(dispatch_get_main_queue(), ^{
     NSAccessibilityPostNotificationWithUserInfo(
                                                     NSApp,
                                                     NSAccessibilityAnnouncementRequestedNotification,
@@ -67,6 +68,7 @@ RCT_EXPORT_METHOD(announceForAccessibility:(NSString *)announcement)
                                                       NSAccessibilityPriorityKey : @(NSAccessibilityPriorityHigh)
                                                     }
                                                 );
+  });
 }
 
 RCT_EXPORT_METHOD(getCurrentHighContrastState:(RCTResponseSenderBlock)callback


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Specifically, NSAccessibilityPostNotificationWithUserInfo. Other methods such as `getCurrentHighContrastState` provide cached state (cached on main thread via `observeValueForKeyPath` et al). Some other methods such as `setAccessibilityFocus` dispatch to the main thread.

Not doing so could lead to AppKit further firing selectors on UI logic in app code and lead to downstream issues.

## Test Plan

I've verified that original badness I observed in Office that led to discovering this no longer reproduces. Announcement posts in Accessibility Inspector.