### PR TITLE
[RCTTouchHandler] Invert Y coordinate when sending touch events to JS

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -232,6 +232,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
   CGPoint rootViewLocation = [_cachedRootView.window.contentView convertPoint:location toView:_cachedRootView];
   NSView *touchView = _touchViews[touchIndex];
   CGPoint touchViewLocation = [touchView convertPoint:location fromView:nil];
+  // JavaScript expects coordinates to have (0,0) at top left, unlike the macOS coordinate system
+  rootViewLocation.y = NSHeight([[_cachedRootView window] frame]) - rootViewLocation.y; 
 #endif // macOS]
 
   NSMutableDictionary *reactTouch = _reactTouches[touchIndex];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

macOS has an inverted Y coordinate for its screen coordinate system compared to other OS'es. This led to a bug where pressIn/pressOut on Pressables was calculated with the wrong rect, and click hold->move mouse out of button rect was doing weird stuff. Also some animation code was off. It's easier to explain with a video:

https://github.com/microsoft/react-native-macos/assets/6722175/ac08339e-91ca-4080-8a6a-a3255b335a74

The solution is to flip the Y coordinate in RCTTouchHandler when sending the touch (aka click) event to JS.

## Changelog

[MACOS] [FIXED] - nvert Y coordinate when sending to JS in RCTTouchHandler

## Test Plan

Tested the same two demos and they work now :)

https://github.com/microsoft/react-native-macos/assets/6722175/53cf893e-8f75-4971-8cde-a6f3601eb0a5
