### PR TITLE
[Xcode 15] Silence warning with mismatched NSView.clipsToBounds property

### DIFF
--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -394,7 +394,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 - (void)setNeedsDisplay;
 
-// FUTURE: When building with Xcode 15, we can remove this override since it's now declared on NSView
+// FUTURE: When Xcode 14 is no longer supported (CI is building with Xcode 15), we can remove this override since it's now declared on NSView
 @property BOOL clipsToBounds;
 @property (nonatomic, copy) NSColor *backgroundColor;
 @property (nonatomic) CGAffineTransform transform;
@@ -589,7 +589,7 @@ typedef UIImageView RCTUIImageView;
 #else
 @interface RCTUIImageView : NSImageView
 NS_ASSUME_NONNULL_BEGIN
-// FUTURE: When building with Xcode 15, we can remove this override since it's now declared on NSView
+// FUTURE: When Xcode 14 is no longer supported (CI is building with Xcode 15), we can remove this override since it's now declared on NSView
 @property (assign) BOOL clipsToBounds;
 @property (nonatomic, strong) RCTUIColor *tintColor;
 @property (nonatomic, assign) UIViewContentMode contentMode;

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -394,8 +394,8 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 - (void)setNeedsDisplay;
 
-// An override of an undocumented API that controls the layer's masksToBounds property
-@property (nonatomic) BOOL clipsToBounds;
+// FUTURE: When building with Xcode 15, we can remove this override since it's now declared on NSView
+@property BOOL clipsToBounds;
 @property (nonatomic, copy) NSColor *backgroundColor;
 @property (nonatomic) CGAffineTransform transform;
 
@@ -589,7 +589,8 @@ typedef UIImageView RCTUIImageView;
 #else
 @interface RCTUIImageView : NSImageView
 NS_ASSUME_NONNULL_BEGIN
-@property (nonatomic, assign) BOOL clipsToBounds;
+// FUTURE: When building with Xcode 15, we can remove this override since it's now declared on NSView
+@property (assign) BOOL clipsToBounds;
 @property (nonatomic, strong) RCTUIColor *tintColor;
 @property (nonatomic, assign) UIViewContentMode contentMode;
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When including react-native-macos public headers with Xcode 15, we get an error that the `clipsToBounds` property declared on RCTUIView doesn't match the one now declared in AppKit as of the macOS 14.0 SDK. AppKit has finally publicized this property, but it is marked as atomic rather than nonatomic.

When we're building exclusively with Xcode 15, we can remove this override. But for now, let's just make the property declarations match.

Note, this isn't actually blocking building react-native-macos because these warnings aren't turned on as errors (they probably should be). But if a consumer has warnings treated as errors, this will fail their builds.

## Changelog

[MACOS] [FIXED] - Silenced warnings with Xcode 15.

## Test Plan

Just counting on CI since this really should be a non-functional change