### PR TITLE
[Key handling] pass through all keys; allow specifying modifiers for validKeys[Down|Up]

### DIFF
--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -188,7 +188,7 @@ type Props = $ReadOnly<{|
   /**
    * When `true`, allows `onKeyDown` and `onKeyUp` to receive events not specified in
    * `validKeysDown` and `validKeysUp`, respectively. Events matching `validKeysDown` and `validKeysUp`
-   * are still removed from the event queue, but the others are not.
+   * still have their native default behavior prevented, but the others do not.
    *
    * @platform macos
    */

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -195,14 +195,14 @@ type Props = $ReadOnly<{|
   passthroughAllKeyEvents?: ?boolean,
 
   /**
-   * Array of keys to receive key down events for. These events are always removed from the system event queue.
+   * Array of keys to receive key down events for. These events have their default native behavior prevented.
    *
    * @platform macos
    */
   validKeysDown?: ?Array<string | HandledKeyboardEvent>,
 
   /**
-   * Array of keys to receive key up events for. These events are always removed from the system event queue.
+   * Array of keys to receive key up events for. These events have their default native behavior prevented.
    *
    * @platform macos
    */

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -12,7 +12,6 @@ import type {
   BlurEvent,
   // [macOS
   FocusEvent,
-  KeyEvent,
   LayoutEvent,
   MouseEvent,
   PressEvent,
@@ -26,6 +25,7 @@ import type {
   AccessibilityState,
   AccessibilityValue,
 } from '../View/ViewAccessibility';
+import type {KeyboardEventProps} from '../View/ViewPropTypes'; // [macOS]
 
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
@@ -174,27 +174,7 @@ type Props = $ReadOnly<{|
    */
   onBlur?: ?(event: BlurEvent) => void,
 
-  /**
-   * Called after a key down event is detected.
-   */
-  onKeyDown?: ?(event: KeyEvent) => void,
-
-  /**
-   * Called after a key up event is detected.
-   */
-  onKeyUp?: ?(event: KeyEvent) => void,
-
-  /**
-   * Array of keys to receive key down events for
-   * For arrow keys, add "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
-   */
-  validKeysDown?: ?Array<string>,
-
-  /**
-   * Array of keys to receive key up events for
-   * For arrow keys, add "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
-   */
-  validKeysUp?: ?Array<string>,
+  ...KeyboardEventProps, // [macOS]
 
   /**
    * Specifies whether the view should receive the mouse down event when the

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -12,6 +12,7 @@ import type {
   BlurEvent,
   // [macOS
   FocusEvent,
+  KeyEvent,
   LayoutEvent,
   MouseEvent,
   PressEvent,
@@ -25,7 +26,7 @@ import type {
   AccessibilityState,
   AccessibilityValue,
 } from '../View/ViewAccessibility';
-import type {KeyboardEventProps} from '../View/ViewPropTypes'; // [macOS]
+import type {HandledKeyboardEvent} from '../View/ViewPropTypes'; // [macOS]
 
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
@@ -174,7 +175,38 @@ type Props = $ReadOnly<{|
    */
   onBlur?: ?(event: BlurEvent) => void,
 
-  ...KeyboardEventProps, // [macOS]
+  /**
+   * Called after a key down event is detected.
+   */
+  onKeyDown?: ?(event: KeyEvent) => void,
+
+  /**
+   * Called after a key up event is detected.
+   */
+  onKeyUp?: ?(event: KeyEvent) => void,
+
+  /**
+   * When `true`, allows `onKeyDown` and `onKeyUp` to receive events not specified in
+   * `validKeysDown` and `validKeysUp`, respectively. Events matching `validKeysDown` and `validKeysUp`
+   * are still removed from the event queue, but the others are not.
+   *
+   * @platform macos
+   */
+  passthroughAllKeyEvents?: ?boolean,
+
+  /**
+   * Array of keys to receive key down events for. These events are always removed from the system event queue.
+   *
+   * @platform macos
+   */
+  validKeysDown?: ?Array<string | HandledKeyboardEvent>,
+
+  /**
+   * Array of keys to receive key up events for. These events are always removed from the system event queue.
+   *
+   * @platform macos
+   */
+  validKeysUp?: ?Array<string | HandledKeyboardEvent>,
 
   /**
    * Specifies whether the view should receive the mouse down event when the

--- a/Libraries/Components/View/ReactNativeViewAttributes.js
+++ b/Libraries/Components/View/ReactNativeViewAttributes.js
@@ -47,6 +47,7 @@ const UIView = {
   onDrop: true,
   onKeyDown: true,
   onKeyUp: true,
+  passthroughAllKeyEvents: true,
   validKeysDown: true,
   validKeysUp: true,
   draggedTypes: true,

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -107,22 +107,16 @@ type DirectEventProps = $ReadOnly<{|
  * "Tab", "Escape", "Enter", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
  * "Backspace", "Delete", "Home", "End", "PageUp", "PageDown".
  *
- * The rest are modifiers that when absent mean don't care (either state -- true or false --
- * matches), and when present require that modifier state to match. All present modifers must
- * match for the event to pass the filter.
+ * The rest are modifiers that when absent mean false.
  *
  * @platform macos
  */
-export type HandledKey = $ReadOnly<{|
+export type HandledKeyboardEvent = $ReadOnly<{|
+  altKey?: ?boolean,
+  ctrlKey?: ?boolean,
+  metaKey?: ?boolean,
+  shiftKey?: ?boolean,
   key: string,
-  capsLock?: ?boolean,
-  shift?: ?boolean,
-  ctrl?: ?boolean,
-  alt?: ?boolean,
-  meta?: ?boolean,
-  numericPad?: ?boolean,
-  help?: ?boolean,
-  function?: ?boolean,
 |}>;
 
 export type KeyboardEventProps = $ReadOnly<{|
@@ -150,14 +144,14 @@ export type KeyboardEventProps = $ReadOnly<{|
    *
    * @platform macos
    */
-  validKeysDown?: ?Array<string | HandledKey>,
+  validKeysDown?: ?Array<string | HandledKeyboardEvent>,
 
   /**
    * Array of keys to receive key up events for. These events are always removed from the system event queue.
    *
    * @platform macos
    */
-  validKeysUp?: ?Array<string | HandledKey>,
+  validKeysUp?: ?Array<string | HandledKeyboardEvent>,
 |}>;
 // macOS]
 

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -100,22 +100,64 @@ type DirectEventProps = $ReadOnly<{|
 |}>;
 
 // [macOS
-type KeyboardEventProps = $ReadOnly<{|
-  onKeyDown?: ?(event: KeyEvent) => void,
-  onKeyUp?: ?(event: KeyEvent) => void,
+/**
+ * Represents a key that could be passed to `validKeysDown` and `validKeysUp`.
+ *
+ * `key` is the actual key, such as "a", or one of the special values:
+ * "Tab", "Escape", "Enter", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
+ * "Backspace", "Delete", "Home", "End", "PageUp", "PageDown".
+ *
+ * The rest are modifiers that when absent mean don't care (either state -- true or false --
+ * matches), and when present require that modifier state to match. All present modifers must
+ * match for the event to pass the filter.
+ *
+ * @platform macos
+ */
+export type HandledKey = $ReadOnly<{|
+  key: string,
+  capsLock?: ?boolean,
+  shift?: ?boolean,
+  ctrl?: ?boolean,
+  alt?: ?boolean,
+  meta?: ?boolean,
+  numericPad?: ?boolean,
+  help?: ?boolean,
+  function?: ?boolean,
+|}>;
+
+export type KeyboardEventProps = $ReadOnly<{|
   /**
-   * Array of keys to receive key down events for
-   *
-   * @platform macos
+   * Called after a key down event is detected.
    */
-  validKeysDown?: ?Array<string>,
+  onKeyDown?: ?(event: KeyEvent) => void,
 
   /**
-   * Array of keys to receive key up events for
+   * Called after a key up event is detected.
+   */
+  onKeyUp?: ?(event: KeyEvent) => void,
+
+  /**
+   * When `true`, allows `onKeyDown` and `onKeyUp` to receive events not specified in
+   * `validKeysDown` and `validKeysUp`, respectively. Events matching `validKeysDown` and `validKeysUp`
+   * are still removed from the event queue, but the others are not.
    *
    * @platform macos
    */
-  validKeysUp?: ?Array<string>,
+  passthroughAllKeyEvents?: ?boolean,
+
+  /**
+   * Array of keys to receive key down events for. These events are always removed from the system event queue.
+   *
+   * @platform macos
+   */
+  validKeysDown?: ?Array<string | HandledKey>,
+
+  /**
+   * Array of keys to receive key up events for. These events are always removed from the system event queue.
+   *
+   * @platform macos
+   */
+  validKeysUp?: ?Array<string | HandledKey>,
 |}>;
 // macOS]
 

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -140,14 +140,14 @@ export type KeyboardEventProps = $ReadOnly<{|
   passthroughAllKeyEvents?: ?boolean,
 
   /**
-   * Array of keys to receive key down events for. These events are always removed from the system event queue.
+   * Array of keys to receive key down events for. These events have their default native behavior prevented.
    *
    * @platform macos
    */
   validKeysDown?: ?Array<string | HandledKeyboardEvent>,
 
   /**
-   * Array of keys to receive key up events for. These events are always removed from the system event queue.
+   * Array of keys to receive key up events for. These events have their default native behavior prevented.
    *
    * @platform macos
    */

--- a/Libraries/NativeComponent/BaseViewConfig.macos.js
+++ b/Libraries/NativeComponent/BaseViewConfig.macos.js
@@ -52,6 +52,7 @@ const validAttributesForNonEventProps = {
   draggedTypes: true,
   enableFocusRing: true,
   tooltip: true,
+  passthroughAllKeyEvents: true,
   validKeysDown: true,
   validKeysUp: true,
   mouseDownCanMoveWindow: true,

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -555,6 +555,14 @@ static RCTUIColor *defaultPlaceholderColor() // [macOS]
   }
 }
 #else // [macOS
+- (BOOL)performKeyEquivalent:(NSEvent *)event {
+  if (!self.hasMarkedText && ![self.textInputDelegate textInputShouldHandleKeyEvent:event]) {
+    return YES;
+  }
+
+  return [super performKeyEquivalent:event];
+}
+
 - (void)keyDown:(NSEvent *)event {
   // If has marked text, handle by native and return
   // Do this check before textInputShouldHandleKeyEvent as that one attempts to send the event to JS

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -21,6 +21,7 @@
 #import <React/RCTTextSelection.h>
 #import <React/RCTUITextView.h> // [macOS]
 #import "../RCTTextUIKit.h" // [macOS]
+#import "RCTHandledKey.h" // [macOS]
 
 @implementation RCTBaseTextInputView {
   __weak RCTBridge *_bridge;
@@ -668,7 +669,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 }
 
 - (BOOL)hasValidKeyDownOrValidKeyUp:(NSString *)key {
-  return [self.validKeysDown containsObject:key] || [self.validKeysUp containsObject:key];
+  return [RCTHandledKey key:key matchesFilter:self.validKeysDown]
+	||  [RCTHandledKey key:key matchesFilter:self.validKeysUp];
 }
 
 - (NSDragOperation)textInputDraggingEntered:(id<NSDraggingInfo>)draggingInfo

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -21,7 +21,7 @@
 #import <React/RCTTextSelection.h>
 #import <React/RCTUITextView.h> // [macOS]
 #import "../RCTTextUIKit.h" // [macOS]
-#import "RCTHandledKey.h" // [macOS]
+#import <React/RCTHandledKey.h> // [macOS]
 
 @implementation RCTBaseTextInputView {
   __weak RCTBridge *_bridge;

--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -20,6 +20,8 @@
 #import <WebKit/WebKit.h>
 #endif
 
+@class RCTHandledKey; // [macOS]
+
 /**
  * This class provides a collection of conversion functions for mapping
  * JSON objects to native types and classes. These are useful when writing
@@ -147,6 +149,8 @@ typedef BOOL css_backface_visibility_t;
 
 #if TARGET_OS_OSX // [macOS
 + (NSString *)accessibilityRoleFromTraits:(id)json;
+
++ (NSArray<RCTHandledKey *> *)RCTHandledKeyArray:(id)json;
 #endif // macOS]
 @end
 

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -12,6 +12,7 @@
 #import <CoreText/CoreText.h>
 
 #import "RCTDefines.h"
+#import "RCTHandledKey.h" // [macOS]
 #import "RCTImageSource.h"
 #import "RCTParserUtils.h"
 #import "RCTUtils.h"
@@ -1500,6 +1501,9 @@ RCT_ENUM_CONVERTER(
   }
   return NSAccessibilityUnknownRole;
 }
+
+RCT_JSON_ARRAY_CONVERTER(RCTHandledKey);
+
 #endif // macOS]
 
 @end

--- a/React/Views/RCTHandledKey.h
+++ b/React/Views/RCTHandledKey.h
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#if TARGET_OS_OSX // [macOS
+// [macOS]
+
+#if TARGET_OS_OSX
 #import <React/RCTConvert.h>
 
+// This class is used for specifying key filtering e.g. for -[RCTView validKeysDown] and -[RCTView validKeysUp]
+// Also see RCTViewKeyboardEvent, which is a React representation of an actual NSEvent that is dispatched to JS.
 @interface RCTHandledKey : NSObject
 
 + (BOOL)event:(NSEvent *)event matchesFilter:(NSArray<RCTHandledKey *> *)filter;
@@ -17,10 +21,13 @@
 - (BOOL)matchesEvent:(NSEvent *)event;
 
 @property (nonatomic, copy) NSString *key;
-@property (nonatomic, assign) NSNumber *altKey; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *ctrlKey; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *metaKey; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *shiftKey; // boolean; nil == don't care
+
+// For the following modifiers, nil means we don't care about the presence of the modifier when filtering the key
+// They are still expected to be only boolean when not nil.
+@property (nonatomic, assign) NSNumber *altKey;
+@property (nonatomic, assign) NSNumber *ctrlKey;
+@property (nonatomic, assign) NSNumber *metaKey;
+@property (nonatomic, assign) NSNumber *shiftKey;
 
 @end
 
@@ -30,4 +37,4 @@
 
 @end
 
-#endif // macOS]
+#endif

--- a/React/Views/RCTHandledKey.h
+++ b/React/Views/RCTHandledKey.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if TARGET_OS_OSX // [macOS
+#import <React/RCTConvert.h>
+
+@interface RCTHandledKey : NSObject
+
++ (BOOL)event:(NSEvent *)event matchesFilter:(NSArray<RCTHandledKey *> *)filter;
++ (BOOL)key:(NSString *)key matchesFilter:(NSArray<RCTHandledKey *> *)filter;
+
+- (instancetype)initWithKey:(NSString *)key;
+- (BOOL)matchesEvent:(NSEvent *)event;
+
+@property (nonatomic, copy) NSString *key;
+@property (nonatomic, assign) NSNumber *capsLock; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *shift; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *ctrl; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *alt; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *meta; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *numericPad; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *help; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *function; // boolean; nil == don't care
+
+@end
+
+@interface RCTConvert (RCTHandledKey)
+
++ (RCTHandledKey *)RCTHandledKey:(id)json;
+
+@end
+
+#endif // macOS]

--- a/React/Views/RCTHandledKey.h
+++ b/React/Views/RCTHandledKey.h
@@ -17,14 +17,10 @@
 - (BOOL)matchesEvent:(NSEvent *)event;
 
 @property (nonatomic, copy) NSString *key;
-@property (nonatomic, assign) NSNumber *capsLock; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *shift; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *ctrl; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *alt; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *meta; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *numericPad; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *help; // boolean; nil == don't care
-@property (nonatomic, assign) NSNumber *function; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *altKey; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *ctrlKey; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *metaKey; // boolean; nil == don't care
+@property (nonatomic, assign) NSNumber *shiftKey; // boolean; nil == don't care
 
 @end
 

--- a/React/Views/RCTHandledKey.m
+++ b/React/Views/RCTHandledKey.m
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// [macOS]
+
 #import "objc/runtime.h"
 #import <React/RCTAssert.h>
 #import <React/RCTUtils.h>
@@ -12,7 +14,7 @@
 #import <RCTHandledKey.h>
 #import <RCTViewKeyboardEvent.h>
 
-#if TARGET_OS_OSX // [macOS
+#if TARGET_OS_OSX
 
 @implementation RCTHandledKey
 
@@ -101,10 +103,12 @@
 
 + (RCTHandledKey *)RCTHandledKey:(id)json
 {
+  // legacy way of specifying validKeysDown and validKeysUp -- here we ignore the modifiers when comparing to the NSEvent
   if ([json isKindOfClass:[NSString class]]) {
     return [[RCTHandledKey alloc] initWithKey:(NSString *)json];
   }
 
+  // modern way of specifying validKeys and validKeysUp -- here we assume missing modifiers to mean false\NO
   if ([json isKindOfClass:[NSDictionary class]]) {
     NSDictionary *dict = (NSDictionary *)json;
     NSString *key = dict[@"key"];
@@ -138,4 +142,4 @@
 
 @end
 
-#endif // macOS]
+#endif

--- a/React/Views/RCTHandledKey.m
+++ b/React/Views/RCTHandledKey.m
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "objc/runtime.h"
+#import <React/RCTAssert.h>
+#import <React/RCTUtils.h>
+#import <RCTConvert.h>
+#import <RCTHandledKey.h>
+#import <RCTViewKeyboardEvent.h>
+
+#if TARGET_OS_OSX // [macOS
+
+@implementation RCTHandledKey
+
++ (NSArray<NSString *> *)validModifiers {
+  // keep in sync with actual properties and RCTViewKeyboardEvent
+  return @[@"capsLock", @"shift", @"ctrl", @"alt", @"meta", @"numericPad", @"help", @"function"];
+}
+
++ (BOOL)event:(NSEvent *)event matchesFilter:(NSArray<RCTHandledKey *> *)filter {
+  for (RCTHandledKey *key in filter) {
+	if ([key matchesEvent:event]) {
+	  return YES;
+	}
+  }
+
+  return NO;
+}
+
++ (BOOL)key:(NSString *)key matchesFilter:(NSArray<RCTHandledKey *> *)filter {
+  for (RCTHandledKey *aKey in filter) {
+	if ([[aKey key] isEqualToString:key]) {
+	  return YES;
+	}
+  }
+
+  return NO;
+}
+
+- (instancetype)initWithKey:(NSString *)key {
+  if ((self = [super init])) {
+    self.key = key;
+  }
+  return self;
+}
+
+- (BOOL)matchesEvent:(NSEvent *)event
+{
+  NSEventType type = [event type];
+  if (type != NSEventTypeKeyDown && type != NSEventTypeKeyUp) {
+    RCTFatal(RCTErrorWithMessage([NSString stringWithFormat:@"Wrong event type (%d) sent to -[RCTHandledKey matchesEvent:]", (int)type]));
+    return NO;
+  }
+
+  NSDictionary *body = [RCTViewKeyboardEvent bodyFromEvent:event];
+  if (![body[@"key"] isEqualToString:self.key]) {
+    return NO;
+  }
+
+  NSArray<NSString *> *modifiers = [RCTHandledKey validModifiers];
+  for (NSString *modifier in modifiers) {
+    NSString *modifierKey = [modifier stringByAppendingString:@"Key"];
+    NSNumber *myValue = [self valueForKey:modifier];
+
+    if (myValue == nil) {
+		continue;
+	}
+
+	NSNumber *eventValue = (NSNumber *)body[modifierKey];
+	if (eventValue == nil) {
+		RCTFatal(RCTErrorWithMessage([NSString stringWithFormat:@"Event body has missing value for %@", modifierKey]));
+		return NO;
+	}
+
+	if (![eventValue isKindOfClass:[NSNumber class]]) {
+		RCTFatal(RCTErrorWithMessage([NSString stringWithFormat:@"Event body has unexpected value of class %@ for %@",
+			NSStringFromClass(object_getClass(eventValue)), modifierKey]));
+		return NO;
+    }
+
+	if (![myValue isEqualToNumber:body[modifierKey]]) {
+		return NO;
+	}
+  }
+
+  return YES;  // keys matched; all present modifiers matched
+}
+
+@end
+
+@implementation RCTConvert (RCTHandledKey)
+
++ (RCTHandledKey *)RCTHandledKey:(id)json
+{
+  if ([json isKindOfClass:[NSString class]]) {
+    return [[RCTHandledKey alloc] initWithKey:(NSString *)json];
+  }
+
+  if ([json isKindOfClass:[NSDictionary class]]) {
+    NSDictionary *dict = (NSDictionary *)json;
+    NSString *key = dict[@"key"];
+    if (key == nil) {
+      RCTLogConvertError(dict, @"a RCTHandledKey -- must include \"key\"");
+      return nil;
+    }
+
+	RCTHandledKey *handledKey = [[RCTHandledKey alloc] initWithKey:key];
+    NSArray<NSString *> *modifiers = RCTHandledKey.validModifiers;
+    for (NSString *key in modifiers) {
+      id value = dict[key];
+      if (value == nil) {
+        continue;
+	  }
+
+      if (![value isKindOfClass:[NSNumber class]]) {
+        RCTLogConvertError(value, @"a boolean");
+        return nil;
+      }
+
+      [handledKey setValue:@([(NSNumber *)value boolValue]) forKey:key];
+    }
+
+    return handledKey;
+  }
+
+  RCTLogConvertError(json, @"a RCTHandledKey -- allowed types are string and object");
+  return nil;
+}
+
+@end
+
+#endif // macOS]

--- a/React/Views/RCTSwitch.m
+++ b/React/Views/RCTSwitch.m
@@ -11,6 +11,14 @@
 
 @implementation RCTSwitch
 
+// [macOS
+- (void)setOn:(BOOL)on
+{
+  _wasOn = on;
+  [super setOn:on];
+}
+// macOS]
+
 - (void)setOn:(BOOL)on animated:(BOOL)animated
 {
   _wasOn = on;

--- a/React/Views/RCTSwitch.m
+++ b/React/Views/RCTSwitch.m
@@ -11,14 +11,6 @@
 
 @implementation RCTSwitch
 
-// [macOS
-- (void)setOn:(BOOL)on
-{
-  _wasOn = on;
-  [super setOn:on];
-}
-// macOS]
-
 - (void)setOn:(BOOL)on animated:(BOOL)animated
 {
   _wasOn = on;

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -23,6 +23,8 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 
 @protocol RCTAutoInsetsProtocol;
 
+@class RCTHandledKey; // [macOS]
+
 @interface RCTView : RCTUIView // [macOS]
 
 // [macOS
@@ -161,10 +163,14 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, copy) RCTDirectEventBlock onDrop;
 
 // Keyboarding events
+// NOTE does not properly work with single line text inputs (most key downs). This is because those are
+// presumably handled by the window's field editor. To make it work, we'd need to look into providing
+// a custom field editor for NSTextField controls.
+@property (nonatomic, assign) BOOL passthroughAllKeyEvents;
 @property (nonatomic, copy) RCTDirectEventBlock onKeyDown;
 @property (nonatomic, copy) RCTDirectEventBlock onKeyUp;
-@property (nonatomic, copy) NSArray<NSString*> *validKeysDown;
-@property (nonatomic, copy) NSArray<NSString*> *validKeysUp;
+@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysDown;
+@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysUp;
 
 // Shadow Properties
 @property (nonatomic, strong) NSColor *shadowColor;

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1723,7 +1723,7 @@ NSMutableDictionary<NSNumber *, NSNumber *> *GetEventDispatchStateDictionary(NSE
     ];
   }
 
-  // If a view specifies a key, it will always be removed from the system event queue (i.e. "handled")
+  // If a view specifies a key, it will always be removed from the responder chain (i.e. "handled")
   *shouldBlock = [RCTHandledKey event:event matchesFilter:validKeys];
 
   // If an event isn't being removed from the queue, but was requested to "passthrough" by a view,

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// [macOS
+#import "objc/runtime.h"
+#import "RCTHandledKey.h"
+// macOS]
 #import "RCTView.h"
 
 #import <QuartzCore/QuartzCore.h>
@@ -1691,19 +1695,52 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 
 #pragma mark - Keyboard Events
 
-- (RCTViewKeyboardEvent*)keyboardEvent:(NSEvent*)event {
-  BOOL keyDown = event.type == NSEventTypeKeyDown;
-  NSArray<NSString *> *validKeys = keyDown ? self.validKeysDown : self.validKeysUp;
-  NSString *key = [RCTViewKeyboardEvent keyFromEvent:event];
+// This dictionary is attached to the NSEvent being handled so we can ensure we only dispatch it
+// once per RCTView\nativeTag. The reason we need to track this state is that certain React native
+// views such as RCTUITextView inherit from views (such as NSTextView) which may or may not
+// decide to bubble the event to the next responder, and we don't want to dispatch the same
+// event more than once (e.g. first from RCTUITextView, and then from it's parent RCTView).
+NSMutableDictionary<NSNumber *, NSNumber *> *GetEventDispatchStateDictionary(NSEvent *event) {
+	static const char *key = "RCTEventDispatchStateDictionary";
+	NSMutableDictionary<NSNumber *, NSNumber *> *dict = objc_getAssociatedObject(event, key);
+	if (dict == nil) {
+		dict = [NSMutableDictionary new];
+		objc_setAssociatedObject(event, key, dict, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	}
+	return dict;
+}
 
-  // If the view is focusable and the component didn't explicity set the validKeysDown or Up,
+- (RCTViewKeyboardEvent*)keyboardEvent:(NSEvent*)event shouldBlock:(BOOL *)shouldBlock {
+  BOOL keyDown = event.type == NSEventTypeKeyDown;
+  NSArray<RCTHandledKey *> *validKeys = keyDown ? self.validKeysDown : self.validKeysUp;
+
+  // If the view is focusable and the component didn't explicity set the validKeysDown or validKeysUp,
   // allow enter/return and spacebar key events to mimic the behavior of native controls.
   if (self.focusable && validKeys == nil) {
-    validKeys = @[@"Enter", @" "];
+    validKeys = @[
+      [[RCTHandledKey alloc] initWithKey:@"Enter"],
+      [[RCTHandledKey alloc] initWithKey:@" "]
+    ];
   }
 
-  // Only post events for keys we care about
-  if (![validKeys containsObject:key]) {
+  // If a view specifies a key, it will always be removed from the system event queue (i.e. "handled")
+  *shouldBlock = [RCTHandledKey event:event matchesFilter:validKeys];
+
+  // If an event isn't being removed from the queue, but was requested to "passthrough" by a view,
+  // we want to be sure we dispatch it only once for that view. See note for GetEventDispatchStateDictionary.
+  if ([self passthroughAllKeyEvents] && !*shouldBlock) {
+    NSNumber *tag = [self reactTag];
+    NSMutableDictionary<NSNumber *, NSNumber *> *dict = GetEventDispatchStateDictionary(event);
+
+    if ([dict[tag] boolValue]) {
+		return nil;
+	}
+
+	dict[tag] = @YES;
+  }
+
+  // Don't pass events we don't care about
+  if (![self passthroughAllKeyEvents] && !*shouldBlock) {
     return nil;
   }
 
@@ -1712,10 +1749,11 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 
 - (BOOL)handleKeyboardEvent:(NSEvent *)event {
   if (event.type == NSEventTypeKeyDown ? self.onKeyDown : self.onKeyUp) {
-    RCTViewKeyboardEvent *keyboardEvent = [self keyboardEvent:event];
+	BOOL shouldBlock = YES;
+    RCTViewKeyboardEvent *keyboardEvent = [self keyboardEvent:event shouldBlock:&shouldBlock];
     if (keyboardEvent) {
       [_eventDispatcher sendEvent:keyboardEvent];
-      return YES;
+      return shouldBlock;
     }
   }
   return NO;
@@ -1733,4 +1771,5 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
   }
 }
 #endif // macOS]
-                                        @end
+
+@end

--- a/React/Views/RCTViewKeyboardEvent.m
+++ b/React/Views/RCTViewKeyboardEvent.m
@@ -18,6 +18,7 @@
   NSString *key = [self keyFromEvent:event];
   NSEventModifierFlags modifierFlags = event.modifierFlags;
 
+  // when making changes here, also consider what should happen to RCTHandledKey. [macOS]
   return @{
     @"key" : key,
     @"capsLockKey" : (modifierFlags & NSEventModifierFlagCapsLock) ? @YES : @NO,
@@ -54,15 +55,15 @@
     return @"Backspace";
   } else if (code == NSDeleteFunctionKey) {
     return @"Delete";
-	} else if (code == NSHomeFunctionKey) {
-		return @"Home";
-	} else if (code == NSEndFunctionKey) {
-		return @"End";
-	} else if (code == NSPageUpFunctionKey) {
-		return @"PageUp";
-	} else if (code == NSPageDownFunctionKey) {
-		return @"PageDown";
-	}
+  } else if (code == NSHomeFunctionKey) {
+    return @"Home";
+  } else if (code == NSEndFunctionKey) {
+    return @"End";
+  } else if (code == NSPageUpFunctionKey) {
+    return @"PageUp";
+  } else if (code == NSPageDownFunctionKey) {
+    return @"PageDown";
+  }
 
   return key;
 }

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -525,10 +525,11 @@ RCT_EXPORT_VIEW_PROPERTY(onMouseLeave, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDragEnter, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDragLeave, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onDrop, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(passthroughAllKeyEvents, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onKeyDown, RCTDirectEventBlock) // macOS keyboard events
 RCT_EXPORT_VIEW_PROPERTY(onKeyUp, RCTDirectEventBlock) // macOS keyboard events
-RCT_EXPORT_VIEW_PROPERTY(validKeysDown, NSArray<NSString*>)
-RCT_EXPORT_VIEW_PROPERTY(validKeysUp, NSArray<NSString*>)
+RCT_EXPORT_VIEW_PROPERTY(validKeysDown, NSArray<RCTHandledKey *>)
+RCT_EXPORT_VIEW_PROPERTY(validKeysUp, NSArray<RCTHandledKey *>)
 
 #endif // macOS]
 

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -10,6 +10,7 @@
 #import <React/RCTUIKit.h> // [macOS]
 
 #import "RCTConvert.h"
+#import "RCTHandledKey.h" // [macOS]
 #import "RCTLog.h"
 #import "RCTScrollEvent.h"
 #import "RCTUIManager.h"
@@ -1276,11 +1277,10 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 #if TARGET_OS_OSX
 - (RCTViewKeyboardEvent*)keyboardEvent:(NSEvent*)event {
 	BOOL keyDown = event.type == NSEventTypeKeyDown;
-	NSArray<NSString *> *validKeys = keyDown ? self.validKeysDown : self.validKeysUp;
-	NSString *key = [RCTViewKeyboardEvent keyFromEvent:event];
+	NSArray<RCTHandledKey *> *validKeys = keyDown ? self.validKeysDown : self.validKeysUp;
 
 	// Only post events for keys we care about
-	if (![validKeys containsObject:key]) {
+	if (![RCTHandledKey event:event matchesFilter:validKeys]) {
 		return nil;
 	}
 

--- a/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
+++ b/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
@@ -144,7 +144,7 @@ function KeyEventExample(): React.Node {
                     validKeysDown={[
                       'ArrowRight',
                       'ArrowDown',
-                      {key: 'Enter', ctrl: true},
+                      {key: 'Enter', ctrlKey: true},
                     ]}
                     onKeyDown={handleKeyDown}
                     validKeysUp={['Escape', 'Enter']}
@@ -159,7 +159,7 @@ function KeyEventExample(): React.Node {
                     validKeysDown={[
                       'ArrowRight',
                       'ArrowDown',
-                      {key: 'Enter', ctrl: true},
+                      {key: 'Enter', ctrlKey: true},
                     ]}
                     onKeyDown={handleKeyDown}
                     validKeysUp={['Escape', 'Enter']}

--- a/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
+++ b/packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
@@ -13,88 +13,216 @@
 const React = require('react');
 const ReactNative = require('react-native');
 import {Platform} from 'react-native';
-const {StyleSheet, Text, TextInput, View} = ReactNative;
+import type {KeyEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+
+const {Button, ScrollView, StyleSheet, Switch, Text, TextInput, View} =
+  ReactNative;
+
+const switchStyle = {
+  alignItems: 'center',
+  padding: 10,
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+};
 
 function KeyEventExample(): React.Node {
   const [log, setLog] = React.useState([]);
-  const appendLog = (line: string) => {
-    const limit = 12;
-    let newLog = log.slice(0, limit - 1);
-    newLog.unshift(line);
-    setLog(newLog);
-  };
+
+  const clearLog = React.useCallback(() => {
+    setLog([]);
+  }, [setLog]);
+
+  const appendLog = React.useCallback(
+    (line: string) => {
+      const limit = 12;
+      let newLog = log.slice(0, limit - 1);
+      newLog.unshift(line);
+      setLog(newLog);
+    },
+    [log, setLog],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (e: KeyEvent) => {
+      appendLog('Key Down:' + e.nativeEvent.key);
+    },
+    [appendLog],
+  );
+
+  const handleKeyUp = React.useCallback(
+    (e: KeyEvent) => {
+      appendLog('Key Up:' + e.nativeEvent.key);
+    },
+    [appendLog],
+  );
+
+  const [showView, setShowView] = React.useState(true);
+  const toggleShowView = React.useCallback(
+    (value: boolean) => {
+      setShowView(value);
+    },
+    [setShowView],
+  );
+
+  const [showTextInput, setShowTextInput] = React.useState(true);
+  const toggleShowTextInput = React.useCallback(
+    (value: boolean) => {
+      setShowTextInput(value);
+    },
+    [setShowTextInput],
+  );
+
+  const [showTextInput2, setShowTextInput2] = React.useState(true);
+  const toggleShowTextInput2 = React.useCallback(
+    (value: boolean) => {
+      setShowTextInput2(value);
+    },
+    [setShowTextInput2],
+  );
+
+  const [passthroughAllKeyEvents, setPassthroughAllKeyEvents] =
+    React.useState(false);
+  const toggleSwitch = React.useCallback(
+    (value: boolean) => {
+      setPassthroughAllKeyEvents(value);
+    },
+    [setPassthroughAllKeyEvents],
+  );
 
   return (
-    <View style={{padding: 10}}>
-      <Text>
-        Key events are called when a component detects a key press.To tab
-        between views on macOS: Enable System Preferences / Keyboard / Shortcuts
-        > Use keyboard navigation to move focus between controls.
-      </Text>
-      <View>
-        {Platform.OS === 'macos' ? (
-          <>
-            <Text style={styles.title}>View</Text>
-            <Text style={styles.text}>
-              validKeysDown: [g, Escape, Enter, ArrowLeft]{'\n'}
-              validKeysUp: [c, d]
-            </Text>
-            <View
-              focusable={true}
-              style={styles.row}
-              validKeysDown={['g', 'Escape', 'Enter', 'ArrowLeft']}
-              onKeyDown={e => appendLog('Key Down:' + e.nativeEvent.key)}
-              validKeysUp={['c', 'd']}
-              onKeyUp={e => appendLog('Key Up:' + e.nativeEvent.key)}
+    <ScrollView>
+      <View style={{padding: 10}}>
+        <Text>
+          Key events are called when a component detects a key press.To tab
+          between views on macOS: Enable System Preferences / Keyboard /
+          Shortcuts > Use keyboard navigation to move focus between controls.
+        </Text>
+        <View>
+          {Platform.OS === 'macos' ? (
+            <>
+              <View style={switchStyle}>
+                <Text style={styles.title}>View</Text>
+                <Switch value={showView} onValueChange={toggleShowView} />
+              </View>
+              {showView ? (
+                <>
+                  <Text style={styles.text}>
+                    validKeysDown: [g, Escape, Enter, ArrowLeft]{'\n'}
+                    validKeysUp: [c, d]
+                  </Text>
+                  <View
+                    focusable={true}
+                    style={styles.row}
+                    passthroughAllKeyEvents={passthroughAllKeyEvents}
+                    validKeysDown={['g', 'Escape', 'Enter', 'ArrowLeft']}
+                    onKeyDown={handleKeyDown}
+                    validKeysUp={['c', 'd']}
+                    onKeyUp={handleKeyUp}
+                  />
+                </>
+              ) : null}
+              <View style={switchStyle}>
+                <Text style={styles.title}>TextInput</Text>
+                <Switch
+                  value={showTextInput}
+                  onValueChange={toggleShowTextInput}
+                />
+              </View>
+              {showTextInput ? (
+                <>
+                  <Text style={styles.text}>
+                    validKeysDown: [ArrowRight, ArrowDown, Ctrl+Enter]{'\n'}
+                    validKeysUp: [Escape, Enter]
+                  </Text>
+                  <TextInput
+                    blurOnSubmit={false}
+                    placeholder={'Singleline textInput'}
+                    multiline={false}
+                    focusable={true}
+                    style={styles.row}
+                    passthroughAllKeyEvents={passthroughAllKeyEvents}
+                    validKeysDown={[
+                      'ArrowRight',
+                      'ArrowDown',
+                      {key: 'Enter', ctrl: true},
+                    ]}
+                    onKeyDown={handleKeyDown}
+                    validKeysUp={['Escape', 'Enter']}
+                    onKeyUp={handleKeyUp}
+                  />
+                  <TextInput
+                    placeholder={'Multiline textInput'}
+                    multiline={true}
+                    focusable={true}
+                    style={styles.row}
+                    passthroughAllKeyEvents={passthroughAllKeyEvents}
+                    validKeysDown={[
+                      'ArrowRight',
+                      'ArrowDown',
+                      {key: 'Enter', ctrl: true},
+                    ]}
+                    onKeyDown={handleKeyDown}
+                    validKeysUp={['Escape', 'Enter']}
+                    onKeyUp={handleKeyUp}
+                  />
+                </>
+              ) : null}
+              <View style={switchStyle}>
+                <Text style={styles.title}>TextInput with no handled keys</Text>
+                <Switch
+                  value={showTextInput2}
+                  onValueChange={toggleShowTextInput2}
+                />
+              </View>
+              {showTextInput2 ? (
+                <>
+                  <Text style={styles.text}>
+                    validKeysDown: []{'\n'}
+                    validKeysUp: []
+                  </Text>
+                  <TextInput
+                    blurOnSubmit={false}
+                    placeholder={'Singleline textInput'}
+                    multiline={false}
+                    focusable={true}
+                    style={styles.row}
+                    passthroughAllKeyEvents={passthroughAllKeyEvents}
+                    validKeysDown={[]}
+                    onKeyDown={handleKeyDown}
+                    validKeysUp={[]}
+                    onKeyUp={handleKeyUp}
+                  />
+                  <TextInput
+                    placeholder={'Multiline textInput'}
+                    multiline={true}
+                    focusable={true}
+                    style={styles.row}
+                    passthroughAllKeyEvents={passthroughAllKeyEvents}
+                    validKeysDown={[]}
+                    onKeyDown={handleKeyDown}
+                    validKeysUp={[]}
+                    onKeyUp={handleKeyUp}
+                  />
+                </>
+              ) : null}
+            </>
+          ) : null}
+          <View style={switchStyle}>
+            <Text>{'Pass through all key events'}</Text>
+            <Switch
+              value={passthroughAllKeyEvents}
+              onValueChange={toggleSwitch}
             />
-            <Text style={styles.title}>TextInput</Text>
-            <Text style={styles.text}>
-              validKeysDown: [ArrowRight, ArrowDown]{'\n'}
-              validKeysUp: [Escape, Enter]
-            </Text>
-            <TextInput
-              blurOnSubmit={false}
-              placeholder={'Singleline textInput'}
-              multiline={false}
-              focusable={true}
-              style={styles.row}
-              validKeysDown={['ArrowRight', 'ArrowDown']}
-              onKeyDown={e => appendLog('Key Down:' + e.nativeEvent.key)}
-              validKeysUp={['Escape', 'Enter']}
-              onKeyUp={e => appendLog('Key Up:' + e.nativeEvent.key)}
-            />
-            <TextInput
-              placeholder={'Multiline textInput'}
-              multiline={true}
-              focusable={true}
-              style={styles.row}
-              validKeysDown={['ArrowRight', 'ArrowDown']}
-              onKeyDown={e => appendLog('Key Down:' + e.nativeEvent.key)}
-              validKeysUp={['Escape', 'Enter']}
-              onKeyUp={e => appendLog('Key Up:' + e.nativeEvent.key)}
-            />
-            <Text style={styles.text}>
-              validKeysDown: []{'\n'}
-              validKeysUp: []
-            </Text>
-            <TextInput
-              blurOnSubmit={false}
-              placeholder={'Singleline textInput'}
-              multiline={false}
-              focusable={true}
-              style={styles.row}
-            />
-            <TextInput
-              placeholder={'Multiline textInput'}
-              multiline={true}
-              focusable={true}
-              style={styles.row}
-            />
-          </>
-        ) : null}
-        <Text>{'Events:\n' + log.join('\n')}</Text>
+          </View>
+          <Button
+            testID="event_clear_button"
+            onPress={clearLog}
+            title="Clear event log"
+          />
+          <Text>{'Events:\n' + log.join('\n')}</Text>
+        </View>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -19,6 +19,7 @@ const {
   TextInput,
   View,
   StyleSheet,
+  Switch,
 } = require('react-native');
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
@@ -79,6 +80,12 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 13,
     padding: 4,
+  },
+  passthroughAllKeyEvents: {
+    alignItems: 'center',
+    padding: 10,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
 });
 
@@ -334,6 +341,8 @@ class SubmitBehaviorExample extends React.Component<{...}> {
   }
 }
 
+let counter = 0;
+
 class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
   state:
     | any
@@ -341,22 +350,54 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
         curText: string,
         prev2Text: string,
         prev3Text: string,
+        prev4Text: string,
+        prev5Text: string,
+        prev6Text: string,
         prevText: string,
+        passthroughAllKeyEvents: boolean,
       } = {
     curText: '<No Event>',
     prevText: '<No Event>',
     prev2Text: '<No Event>',
     prev3Text: '<No Event>',
+    prev4Text: '<No Event>',
+    prev5Text: '<No Event>',
+    prev6Text: '<No Event>',
+    passthroughAllKeyEvents: false,
   };
 
   updateText = (text: string) => {
+    counter++;
     this.setState(state => {
       return {
-        curText: text,
+        curText: text + ' [' + counter + ']',
         prevText: state.curText,
         prev2Text: state.prevText,
         prev3Text: state.prev2Text,
+        prev4Text: state.prev3Text,
+        prev5Text: state.prev4Text,
+        prev6Text: state.prev5Text,
       };
+    });
+  };
+
+  clearLog = () => {
+    this.setState(() => {
+      return {
+        curText: '<No Event>',
+        prevText: '<No Event>',
+        prev2Text: '<No Event>',
+        prev3Text: '<No Event>',
+        prev4Text: '<No Event>',
+        prev5Text: '<No Event>',
+        prev6Text: '<No Event>',
+      };
+    });
+  };
+
+  toggleSwitch = (value: boolean) => {
+    this.setState(() => {
+      return {passthroughAllKeyEvents: value};
     });
   };
 
@@ -385,9 +426,16 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
           onSubmitEditing={event =>
             this.updateText('onSubmitEditing text: ' + event.nativeEvent.text)
           }
+          onKeyDown={event =>
+            this.updateText('onKeyDown key: ' + event.nativeEvent.key)
+          }
           onKeyPress={event =>
             this.updateText('onKeyPress key: ' + event.nativeEvent.key)
           }
+          onKeyUp={event =>
+            this.updateText('onKeyUp key: ' + event.nativeEvent.key)
+          }
+          passthroughAllKeyEvents={this.state.passthroughAllKeyEvents}
           style={styles.singleLine}
         />
         <Text style={styles.eventLabel}>
@@ -395,8 +443,23 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
           {'\n'}
           (prev: {this.state.prevText}){'\n'}
           (prev2: {this.state.prev2Text}){'\n'}
-          (prev3: {this.state.prev3Text})
+          (prev3: {this.state.prev3Text}){'\n'}
+          (prev4: {this.state.prev4Text}){'\n'}
+          (prev5: {this.state.prev5Text}){'\n'}
+          (prev6: {this.state.prev6Text})
         </Text>
+        <Button
+          testID="event_clear_button"
+          onPress={this.clearLog}
+          title="Clear event log"
+        />
+        <View style={styles.passthroughAllKeyEvents}>
+          <Text>{'Pass through all key events'}</Text>
+          <Switch
+            value={this.state.passthroughAllKeyEvents}
+            onValueChange={this.toggleSwitch}
+          />
+        </View>
       </View>
     );
   }

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -19,7 +19,7 @@ const {
   TextInput,
   View,
   StyleSheet,
-  Switch,
+  Switch, // [macOS]
 } = require('react-native');
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
@@ -81,12 +81,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     padding: 4,
   },
+  // [macOS
   passthroughAllKeyEvents: {
     alignItems: 'center',
     padding: 10,
     flexDirection: 'row',
     justifyContent: 'space-between',
   },
+  // macOS]
 });
 
 class WithLabel extends React.Component<$FlowFixMeProps> {
@@ -341,7 +343,7 @@ class SubmitBehaviorExample extends React.Component<{...}> {
   }
 }
 
-let counter = 0;
+let counter = 0; // [macOS]
 
 class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
   state:
@@ -350,37 +352,44 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
         curText: string,
         prev2Text: string,
         prev3Text: string,
+        // [macOS
         prev4Text: string,
         prev5Text: string,
         prev6Text: string,
+        // macOS]
         prevText: string,
-        passthroughAllKeyEvents: boolean,
+        passthroughAllKeyEvents: boolean, // [macOS]
       } = {
     curText: '<No Event>',
     prevText: '<No Event>',
     prev2Text: '<No Event>',
     prev3Text: '<No Event>',
+    // [macOS
     prev4Text: '<No Event>',
     prev5Text: '<No Event>',
     prev6Text: '<No Event>',
     passthroughAllKeyEvents: false,
+    // macOS]
   };
 
   updateText = (text: string) => {
-    counter++;
+    counter++; // [macOS]
     this.setState(state => {
       return {
-        curText: text + ' [' + counter + ']',
+        curText: text + ' [' + counter + ']', // [macOS]
         prevText: state.curText,
         prev2Text: state.prevText,
         prev3Text: state.prev2Text,
+        // [macOS
         prev4Text: state.prev3Text,
         prev5Text: state.prev4Text,
         prev6Text: state.prev5Text,
+        // macOS]
       };
     });
   };
 
+  // [macOS
   clearLog = () => {
     this.setState(() => {
       return {
@@ -400,6 +409,7 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
       return {passthroughAllKeyEvents: value};
     });
   };
+  // macOS]
 
   render(): React.Node {
     return (
@@ -426,16 +436,18 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
           onSubmitEditing={event =>
             this.updateText('onSubmitEditing text: ' + event.nativeEvent.text)
           }
-          onKeyDown={event =>
-            this.updateText('onKeyDown key: ' + event.nativeEvent.key)
-          }
           onKeyPress={event =>
             this.updateText('onKeyPress key: ' + event.nativeEvent.key)
+          }
+          // [macOS
+          onKeyDown={event =>
+            this.updateText('onKeyDown key: ' + event.nativeEvent.key)
           }
           onKeyUp={event =>
             this.updateText('onKeyUp key: ' + event.nativeEvent.key)
           }
           passthroughAllKeyEvents={this.state.passthroughAllKeyEvents}
+          // macOS]
           style={styles.singleLine}
         />
         <Text style={styles.eventLabel}>
@@ -448,6 +460,7 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
           (prev5: {this.state.prev5Text}){'\n'}
           (prev6: {this.state.prev6Text})
         </Text>
+        {/* [macOS */}
         <Button
           testID="event_clear_button"
           onPress={this.clearLog}
@@ -460,6 +473,7 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
             onValueChange={this.toggleSwitch}
           />
         </View>
+        {/* macOS] */}
       </View>
     );
   }


### PR DESCRIPTION
There are scenarios where it might be necessary to look at the incoming events without removing from the system queue. Currently that's impossible today on React Native macOS, since views are required to specify `validKeysDown` or `validKeysUp`, and such events are always removed from the queue.

To mitigate, let's add a new `passthroughAllKeyEvents` prop to `RCTView`. We could keep it forever (towards an interest to reduce event spam from native to JS), or we could use it towards the path to making it the default behavior (stage 1: default false, i.e. opt in, stage 2: default true, i.e. opt out, stage 3: remove, is default behavior).
- React/Views/RCTView.h
- React/Views/RCTView.m
- React/Views/RCTViewManager.m

Note that this doesn't properly work with `RCTUITextField` (i.e. single line text fields). From what I can tell, that would need us to possibly provide a custom field editor for the window (or an event monitor). I am scoping this out for this PR.

Another peculiarity to note is regarding `RCTUITextView` (i.e. multi line text fields). Here, it looks like the text view itself isn't exposed to the JS (this view doesn't have a `nativeTag`), so there's a `RCTView` holding a child `RCTUITextView` where the former dispatches events to JS on behalf for the latter. The reason this matters (specifically for "pass through" events) is because the latter can dispatch certain events to the JS, and then depending on the super class implementation (`NSTextView`), it may or may not *also* pass the `NSEvent` to the next responder (i.e. parent view, i.e. `RCTView`). Passing the action to the next responder *can* cause us to send duplicate JS events for the same `NSEvent`. I couldn't find anything in macOS APIs to determine if the view the event was generated for is a specific view, so I am introducing a book-keeping mechanism to not send duplicate events.

Also note that on the web, it looks like input events generated by input controls (and the like) bubble to parent elements even when "handled" (as in, inserted into the text input). Given how things are currently implemented (direct events originated from NSResponder selectors), once an event is "handled" (e.g. inserted into a NSTextView), it stops propagating along the responder chain, meaning we don't simulate the web behavior (e.g. even if a parent React view opts into all keyboard events)

Introduce `RCTHandledKey` for specifying modifiers for `validKeysDown` and `validKeysUp`. Behavior noted in type definitions.
- Libraries/Text/TextInput/RCTBaseTextInputView.m
- React/Base/RCTConvert.h
- React/Base/RCTConvert.m
- React/Views/RCTHandledKey.h
- React/Views/RCTHandledKey.m
- React/Views/RCTView.h
- React/Views/RCTView.m
- React/Views/RCTViewKeyboardEvent.m
- React/Views/RCTViewManager.m
- React/Views/ScrollView/RCTScrollView.m

macOS *usually* does things on key down (as opposed to, say, Win32, which seems to *usually* does things on key up). Like `RCTUITextField`, passs `performKeyEquivalent:` to `textInputDelegate` so we can handle the alternate `keyDown:` path (e.g. Cmd+A). This will be needed for properly handling keystrokes that go through said alternate path. There are probably several other selectors that also need implementing (`deleteBackward:`) to full pass through every possible key, but I am leaving that for some other time.
- Libraries/Text/TextInput/Multiline/RCTUITextView.m

Make a totally unrelated fix to `RCTSwitch`. In a test page where I added an on-by-default switch, I noticed the first toggle (ON->OFF) doesn't do anything. The second toggle (OFF->ON) then doesn't (expectedly) do anything. Found wrong behavior on the switch test page -- tempted to instead remove `wasOn`, but for now repeating the pattern in `setOn:animated:`
- React/Views/RCTSwitch.m

This demonstrates the wrong\before behavior:
- https://github.com/microsoft/react-native-macos/assets/72474613/2a7cff6a-663d-4c26-bfac-2547a720b125
- https://github.com/microsoft/react-native-macos/assets/72474613/927bb840-352d-498d-9ea9-7455140ed9fd

Flow stuff. `passthroughAllKeyEvents` is now a valid thing to pass to `View` types.
- Libraries/Components/View/ReactNativeViewAttributes.js
- Libraries/Components/View/ViewPropTypes.js
- Libraries/NativeComponent/BaseViewConfig.macos.js

Update signatures for `validKeysDown` and `validKeysUp`
- Libraries/Components/View/ViewPropTypes.js

Remove duplicated specifications on `Pressable`. Just use the one from `View`. As a benefit, future changes allow us to not have to touch `Pressable` anymore.
- Libraries/Components/Pressable/Pressable.js
- Libraries/Components/View/ViewPropTypes.js

Update test pages with `passthoughAllKeyEvents` and the keyboard events page with an example modifier usage.
- packages/rn-tester/js/examples/KeyboardEventsExample/KeyboardEventsExample.js
- packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

1. Adding an API to pass through all key down and key up events
2. Modifying validKeysDown and validKeysUp to allow specifying modifiers
3. Bug fix for on-by-default switch

## Changelog

* [General] [Added] Initial version

## Test plan

* Using the keyboard events test page, validate "pass through" of all events for simple view, single line text input, multi line text input. Sanity test existing (non-"pass through") behavior.
* Using the text input test page, ordering of `keyDown` and `keyUp` events w.r.t. other events (such as `keyPress` -- which isn't dispatched for every key)
* Using the switch test page, sanity test switch behaviors
