### PR TITLE
[0.71] [Xcode 15] Silence warning with mismatched NSView.clipsToBounds property

### DIFF
--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -395,8 +395,8 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 - (void)setNeedsDisplay;
 
-// An override of an undocumented API that controls the layer's masksToBounds property
-@property (nonatomic) BOOL clipsToBounds;
+// FUTURE: When Xcode 14 is no longer supported (CI is building with Xcode 15), we can remove this override since it's now declared on NSView
+@property BOOL clipsToBounds;
 @property (nonatomic, copy) NSColor *backgroundColor;
 @property (nonatomic) CGAffineTransform transform;
 


### PR DESCRIPTION
Port #1864 to 0.71-stable. Note that RCTUIImageView doesn't exist in 0.71 so only one instance of the change comes over