### PR TITLE
[Switch] make sure `wasOn` is set properly

### DIFF
--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -546,7 +546,7 @@ typedef UISwitch RCTUISwitch;
 #else
 @interface RCTUISwitch : NSSwitch
 NS_ASSUME_NONNULL_BEGIN
-@property (nonatomic, assign, getter=isOn) BOOL on;
+@property (nonatomic, getter=isOn) BOOL on;
 
 - (void)setOn:(BOOL)on animated:(BOOL)animated;
 

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -642,7 +642,7 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 - (void)setOn:(BOOL)on
 {
-	self.state = on ? NSControlStateValueOn : NSControlStateValueOff;
+	[self setOn:on animated:NO];
 }
 
 - (void)setOn:(BOOL)on animated:(BOOL)animated {

--- a/React/Views/RCTSwitchManager.m
+++ b/React/Views/RCTSwitchManager.m
@@ -46,7 +46,7 @@ RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)viewTag toValue : (BOOL)value)
     if ([view isKindOfClass:[RCTSwitch class]]) {
       [(RCTSwitch *)view setOn:value animated:NO];
     } else {
-      RCTLogError(@"view type must be UISwitch");
+      RCTLogError(@"view type must be RCTUISwitch"); // [macOS]
     }
   }];
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Separating out a change from #1867 to reduce the footprint of that PR.

When a <Switch> is created on macOS with an initial value of on, it would not report it's change the first time you toggled it. This seems to be because an internal variable `_wasOn` was not  set properly on macOS, which the `onChange` handler relied on. Comparing Appkit to UIKit, I think this is because in UIKit, setting the property `on` will internally call `setOn:Animated`, which RN overrides to set `_wasOn`. We had to reimplement both `on` and `setOn:Animated` for macOS. Let's just have the setter for `on` call `setOn:Animated` to fix this issue.

## Changelog

Pick one each for the category and type tags:

[MACOS] [FIXED] - Make sure `wasOn` is set properly in Switch


## Test Plan

Before (from #1867):

https://github.com/microsoft/react-native-macos/assets/72474613/2a7cff6a-663d-4c26-bfac-2547a720b125

After:

https://github.com/microsoft/react-native-macos/assets/6722175/ebc772ca-4763-4a70-b274-e1d09ef5997b


