### PR TITLE
Fix invalid onScroll events breaking FlatList

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -381,7 +381,7 @@
   BOOL _allowNextScrollNoMatterWhat;
 #if TARGET_OS_OSX // [macOS
   BOOL _notifyDidScroll;
-  NSPoint _lastDocumentOrigin;
+  NSPoint _lastScrollPosition;
 #endif // macOS]
   CGRect _lastClippedToRect;
   uint16_t _coalescingKey;
@@ -476,7 +476,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     _scrollView.delaysContentTouches = NO;
 #else // [macOS
     _scrollView.postsBoundsChangedNotifications = YES;
-    _lastDocumentOrigin = NSZeroPoint;
+    _lastScrollPosition = NSZeroPoint;
 #endif // macOS]
 
 #if !TARGET_OS_OSX // [macOS]
@@ -877,9 +877,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
     [_scrollView setContentOffset:_scrollView.contentOffset];
   }
 
-  // only send didScroll event if scrollView is ready or document origin changed
-  BOOL didScroll = !NSEqualPoints(_scrollView.documentView.frame.origin, _lastDocumentOrigin);
-  if (_notifyDidScroll && didScroll) {
+  if (_notifyDidScroll) {
     [self scrollViewDidScroll:_scrollView];
   }
 }
@@ -925,11 +923,24 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 
 - (void)scrollViewDidScroll:(RCTCustomScrollView *)scrollView // [macOS]
 {
-#if TARGET_OS_OSX // [macOS
-  _lastDocumentOrigin = scrollView.documentView.frame.origin;
-#endif // macOS]
   NSTimeInterval now = CACurrentMediaTime();
   [self updateClippedSubviews];
+  
+#if TARGET_OS_OSX // [macOS
+  /**
+   * To check for effective scroll position changes, the comparison with lastScrollPosition should happen
+   * after updateClippedSubviews. updateClippedSubviews will update the display of the vertical/horizontal 
+   * scrollers which can change the clipview bounds.
+   * This change also ensures that no onScroll events are sent when the React setFrame call is running,
+   * which could submit onScroll events while the content view was not setup yet.
+   */
+  BOOL didScroll = !NSEqualPoints(scrollView.contentView.bounds.origin, _lastScrollPosition);
+  if (!didScroll) {
+    return;
+  }
+  _lastScrollPosition = scrollView.contentView.bounds.origin;
+#endif // macOS]
+  
   /**
    * TODO: this logic looks wrong, and it may be because it is. Currently, if _scrollEventThrottle
    * is set to zero (the default), the "didScroll" event is only sent once per scroll, instead of repeatedly


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

`RCTScrollView` was submitting `onScroll` events after an `onContentSizeChanged` event. This was caused by the `setFrame` call leading to a `DocumentViewBoundsChanged` notification that would get triggered a second time after the horizontal/vertical scrollers would be enabled/disabled.

This double notification would trigger a `scrollViewDidScroll` call with an `onScroll` event being sent because the scroll position would toggle temporarily due to the scrollers being shown/hidden.

This PR updates the scroll view to compare the scroll position with the last sent position after the scrollers were set. This fixes the wrong `onScroll` event during the `setFrame` because the scroll position is stable and valid by the time we do the comparison.

## Changelog

[macOS] [FIXED] - Update ScrollView to emit only valid onScroll events

## Test Plan

Tested by running RNTester on macOS with paper and using the FlatList examples.

<img width="990" alt="Screenshot 2023-07-06 at 19 04 50" src="https://github.com/microsoft/react-native-macos/assets/151054/9a041130-dbe6-4aaa-ad27-eeeaf1ee0ccb">
