### PR TITLE
Fix switch not emitting value change on first toggle when value set to true

### DIFF
--- a/React/Views/RCTSwitchManager.m
+++ b/React/Views/RCTSwitchManager.m
@@ -30,12 +30,16 @@ RCT_EXPORT_MODULE()
 
 - (void)onChange:(RCTSwitch *)sender
 {
+#if !TARGET_OS_OSX // [macOS]
   if (sender.wasOn != sender.on) {
     if (sender.onChange) {
       sender.onChange(@{@"value" : @(sender.on)});
     }
     sender.wasOn = sender.on;
   }
+#else // [macOS
+  sender.onChange(@{ @"value": @(sender.on) });
+#endif // macOS]
 }
 
 RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)viewTag toValue : (BOOL)value)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When mounting a `<Switch>` component with the `value` set to `true`, the first toggle would not emit an `onChange`/`onValueChange`. This is due to the `setValue` command sent to the native component not triggering the registered action because on AppKit the action is not being called when the value is set programmatically. In `Switch.js` it is expected that the native component would call onChange, which is then used to record the native component's last value.

On 0.68 we fixed this by always calling onChange when the native component is toggled, since we don't need to filter out switch value changes that were done programmatically. This allows `Switch.js` to always receive and store the value of the native component.

## Changelog

[macOS] [FIXED] - Fix switch not emitting value change on first toggle when value set to true

## Test Plan

Tested by running RNTester on macOS with paper and using the Switch example. The first toggle of the Switch that is "on" will not result in the value label on the right to change to "off".

Without the fix:

https://github.com/microsoft/react-native-macos/assets/151054/32d35fb1-7e16-44ae-bb37-fedd1edea924


With the fix:

https://github.com/microsoft/react-native-macos/assets/151054/f70170fe-931e-4c05-8f04-edebca71c9ba

