### PR TITLE
[0.71] Fixing release-only crash for when specifying validKeys[Down|Up]

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1502,7 +1502,7 @@ RCT_ENUM_CONVERTER(
   return NSAccessibilityUnknownRole;
 }
 
-RCT_JSON_ARRAY_CONVERTER(RCTHandledKey);
+RCT_ARRAY_CONVERTER(RCTHandledKey);
 
 #endif // macOS]
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Wrong macro -- use `RCT_ARRAY_CONVERTER`, not `RCT_JSON_ARRAY_CONVERTER`. The latter is for "directly representable json array values that require no conversion.":

```
/**
 * This macro is used for creating converter functions for directly
 * representable json array values that require no conversion.
 */
#if RCT_DEBUG
#define RCT_JSON_ARRAY_CONVERTER_NAMED(type, name) RCT_ARRAY_CONVERTER_NAMED(type, name)
#else
#define RCT_JSON_ARRAY_CONVERTER_NAMED(type, name) \
  +(NSArray *)name##Array : (id)json               \
  {                                                \
    return json;                                   \
  }
#endif
#define RCT_JSON_ARRAY_CONVERTER(type) RCT_JSON_ARRAY_CONVERTER_NAMED(type, type)
```

```
/**
 * This macro is used for creating converter functions for typed arrays.
 * RCT_ARRAY_CONVERTER_NAMED may be used when type contains characters
 * which are disallowed in selector names.
 */
#define RCT_ARRAY_CONVERTER(type) RCT_ARRAY_CONVERTER_NAMED(type, type)
```

## Changelog

[GENERAL] [FIXED] - Initial commit

## Test Plan

No more crashing. Verified we properly call the converter for release