### PR TITLE
[DynamicColorMacOS] Downgrade to warning if appearance is nil

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1116,7 +1116,7 @@ static NSColor *RCTColorWithSystemEffect(NSColor* color, NSString *systemEffectS
           } else if (bestMatchingAppearance == NSAppearanceNameAccessibilityHighContrastDarkAqua) {
             return highContrastDarkColor;
           } else {
-            RCTLogWarn("DynamicColorMacOS: Could not resolve current appearance. Defaulting to light.");
+            RCTLogWarn(@"DynamicColorMacOS: Could not resolve current appearance. Defaulting to light.");
             return lightColor;
           }
         }];

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1116,7 +1116,7 @@ static NSColor *RCTColorWithSystemEffect(NSColor* color, NSString *systemEffectS
           } else if (bestMatchingAppearance == NSAppearanceNameAccessibilityHighContrastDarkAqua) {
             return highContrastDarkColor;
           } else {
-            RCTLogConvertError(json, @"an NSColorColor. Could not resolve current appearance. Defaulting to light.");
+            RCTLogWarn("DynamicColorMacOS: Could not resolve current appearance. Defaulting to light.");
             return lightColor;
           }
         }];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When a user cuts/copies text from a `<TextInput>` that has it's text color styled using `DynamicColorMacOS`, we would get a Redbox saying that the current appearance could not be resolved. Looking into it, it seems that at this point in native code, Appkit returns an appearance of `NSAppearanceNameSystem`, which seems to correspond to the "Any" case of an asset catalog if you were specifying a color that way instead.

While I'm not sure why cutting/copying text gets us in this state, it seems this is a valid state to be in, where the OS doesn't have the current appearance and just reports back a generic one. Let's fall back to the light color (as you would with an asset catalog) with a warning instead of an error. 

## Changelog

[MACOS] [CHANGED] - Downgrade  DynamicColorMacOS error to warning if appearance is nil


## Test Plan

Testing in RNTester, we get a yellow box instead of a redbox. 
