### PR TITLE
Add new macOS View prop `allowsVibrancy`

### DIFF
--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -233,6 +233,16 @@ type Props = $ReadOnly<{|
   enableFocusRing?: ?boolean,
 
   /**
+   * Specifies whether the view ensures it is vibrant on top of other content.
+   * For more information, see the following apple documentation:
+   * https://developer.apple.com/documentation/appkit/nsview/1483793-allowsvibrancy
+   * https://developer.apple.com/documentation/appkit/nsvisualeffectview#1674177
+   *
+   * @platform macos
+   */
+  allowsVibrancy?: ?boolean,
+
+  /**
    * Specifies the Tooltip for the Pressable.
    * @platform macos
    */

--- a/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/Libraries/Components/View/ViewPropTypes.d.ts
@@ -172,6 +172,7 @@ export type DraggedType = 'fileUrl';
 export type DraggedTypesType = DraggedType | DraggedType[];
 
 export interface ViewPropsMacOS {
+  allowsVibrancy?: boolean | undefined;
   acceptsFirstMouse?: boolean | undefined;
   mouseDownCanMoveWindow?: boolean | undefined;
   enableFocusRing?: boolean | undefined;

--- a/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/Libraries/Components/View/ViewPropTypes.d.ts
@@ -172,8 +172,8 @@ export type DraggedType = 'fileUrl';
 export type DraggedTypesType = DraggedType | DraggedType[];
 
 export interface ViewPropsMacOS {
-  allowsVibrancy?: boolean | undefined;
   acceptsFirstMouse?: boolean | undefined;
+  allowsVibrancy?: boolean | undefined;
   mouseDownCanMoveWindow?: boolean | undefined;
   enableFocusRing?: boolean | undefined;
   onMouseEnter?: ((event: MouseEvent) => void) | undefined;

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -561,7 +561,7 @@ type MacOSViewProps = $ReadOnly<{|
    *
    * @platform macos
    */
-  allowsVibrancy?: boolean | undefined,
+  allowsVibrancy?: ?boolean,
 
   /**
    * Specifies whether system focus ring should be drawn when the view has keyboard focus.

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -561,7 +561,7 @@ type MacOSViewProps = $ReadOnly<{|
    *
    * @platform macos
    */
-  allowsVibrancy?: boolean | undefined;
+  allowsVibrancy?: boolean | undefined,
 
   /**
    * Specifies whether system focus ring should be drawn when the view has keyboard focus.

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -554,6 +554,16 @@ type MacOSViewProps = $ReadOnly<{|
   mouseDownCanMoveWindow?: ?boolean,
 
   /**
+   * Specifies whether the view ensures it is vibrant on top of other content.
+   * For more information, see the following apple documentation:
+   * https://developer.apple.com/documentation/appkit/nsview/1483793-allowsvibrancy
+   * https://developer.apple.com/documentation/appkit/nsvisualeffectview#1674177
+   *
+   * @platform macos
+   */
+  allowsVibrancy?: boolean | undefined;
+
+  /**
    * Specifies whether system focus ring should be drawn when the view has keyboard focus.
    *
    * @platform macos

--- a/Libraries/NativeComponent/BaseViewConfig.macos.js
+++ b/Libraries/NativeComponent/BaseViewConfig.macos.js
@@ -48,6 +48,7 @@ const directEventTypes = {
 const validAttributesForNonEventProps = {
   acceptsFirstMouse: true,
   accessibilityTraits: true,
+  allowsVibrancy: true,
   cursor: true,
   draggedTypes: true,
   enableFocusRing: true,

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -156,6 +156,10 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 
 @property (nonatomic, assign) CATransform3D transform3D;
 
+// `allowsVibrancy` is readonly on NSView, so let's create a new property to make it assignable
+// that we can set through JS and the getter for `allowsVibrancy` can read in RCTView.
+@property (nonatomic, assign) BOOL allowsVibrancyInternal;
+
 @property (nonatomic, copy) RCTDirectEventBlock onMouseEnter;
 @property (nonatomic, copy) RCTDirectEventBlock onMouseLeave;
 @property (nonatomic, copy) RCTDirectEventBlock onDragEnter;

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1520,7 +1520,7 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 }
 
 - (BOOL)allowsVibrancy {
-  return _allowsVibrancyInternal || [super allowsVibrancy];
+  return _allowsVibrancyInternal;
 }
 
 - (NSDictionary*)locationInfoFromEvent:(NSEvent*)event

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1519,6 +1519,9 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 	_mouseDownCanMoveWindow = mouseDownCanMoveWindow;
 }
 
+- (BOOL)allowsVibrancy {
+  return _allowsVibrancyInternal;
+}
 
 - (NSDictionary*)locationInfoFromEvent:(NSEvent*)event
 {

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -1520,7 +1520,7 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 }
 
 - (BOOL)allowsVibrancy {
-  return _allowsVibrancyInternal;
+  return _allowsVibrancyInternal || [super allowsVibrancy];
 }
 
 - (NSDictionary*)locationInfoFromEvent:(NSEvent*)event

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -430,7 +430,7 @@ RCT_CUSTOM_VIEW_PROPERTY(acceptsFirstMouse, BOOL, RCTView)
 
 RCT_EXPORT_VIEW_PROPERTY(mouseDownCanMoveWindow, BOOL)
 
-RCT_REMAP_VIEW_PROPERTY(allowsVibranct, allowsVibrancyInternal, BOOL)
+RCT_REMAP_VIEW_PROPERTY(allowsVibrancy, allowsVibrancyInternal, BOOL)
 
 RCT_CUSTOM_VIEW_PROPERTY(focusable, BOOL, RCTView)
 {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -430,6 +430,8 @@ RCT_CUSTOM_VIEW_PROPERTY(acceptsFirstMouse, BOOL, RCTView)
 
 RCT_EXPORT_VIEW_PROPERTY(mouseDownCanMoveWindow, BOOL)
 
+RCT_REMAP_VIEW_PROPERTY(allowsVibranct, allowsVibrancyInternal, BOOL)
+
 RCT_CUSTOM_VIEW_PROPERTY(focusable, BOOL, RCTView)
 {
   if ([view respondsToSelector:@selector(setFocusable:)]) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Appkit has a prop `allowsVibrancy` that will allow Appkit to subtly change the colors of an NSView inside an NSVisualEffectView to get that "vibrant" effect. There's a property we can override on NSView for custom NSViews so we can get the effect too. Let's expose it on macOS so that we can set it through Javascript. One caveat is the Appkit property is readonly, so I had to add a new RCTView property `allowsVibrancyInternal` that the RCTView getter then reads.

https://developer.apple.com/documentation/appkit/nsview/1483793-allowsvibrancy

## Changelog

[MACOS] [ADDED] - Add new macOS View prop `allowsVibrancy`

## Test Plan

Prototyping this inside FluentUI React Native (by just.. making every RCTView set `allowsVibrancy = true`), you can clearly see a difference between the two Callouts. Both have a solid background color set to them, but one will "blend" the colors of the window behind it, AKA, the vibrant effect.

Without (notice the solid pink):
<img width="368" alt="Screenshot 2023-08-07 at 11 12 17 PM" src="https://github.com/microsoft/react-native-macos/assets/6722175/586afc4d-dd23-4d91-9d37-921e42afafd8">

With (notice the pink is blended on the top left):
<img width="369" alt="Screenshot 2023-08-07 at 11 11 49 PM" src="https://github.com/microsoft/react-native-macos/assets/6722175/56cb8c41-b474-4eed-8aeb-531c613b08bf">



