### PR TITLE
[iOS/macOS] [TextInput] Implement ghost text

### DIFF
--- a/Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js
@@ -23,7 +23,7 @@ type NativeType = HostComponent<mixed>;
 type NativeCommands = TextInputNativeCommands<NativeType>;
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['focus', 'blur', 'setTextAndSelection'],
+  supportedCommands: ['focus', 'blur', 'setTextAndSelection', 'setGhostText'], // [macOS]
 });
 
 export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {

--- a/Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js
@@ -23,7 +23,7 @@ type NativeType = HostComponent<mixed>;
 type NativeCommands = TextInputNativeCommands<NativeType>;
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['focus', 'blur', 'setTextAndSelection'],
+  supportedCommands: ['focus', 'blur', 'setTextAndSelection', 'setGhostText'], // [macOS]
 });
 
 export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {

--- a/Libraries/Components/TextInput/TextInput.flow.js
+++ b/Libraries/Components/TextInput/TextInput.flow.js
@@ -1052,6 +1052,7 @@ type ImperativeMethods = $ReadOnly<{|
   isFocused: () => boolean,
   getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
   setSelection: (start: number, end: number) => void,
+  setGhostText: (ghostText: ?string) => void, // [macOS]
 |}>;
 
 /**

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -40,7 +40,7 @@ type TextInputInstance = React.ElementRef<HostComponent<mixed>> & {
   +isFocused: () => boolean,
   +getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
   +setSelection: (start: number, end: number) => void,
-  setGhostText: (ghostText: ?string) => void, // [macOS]
+  +setGhostText: (ghostText: ?string) => void, // [macOS]
 };
 
 let AndroidTextInput;

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -40,6 +40,7 @@ type TextInputInstance = React.ElementRef<HostComponent<mixed>> & {
   +isFocused: () => boolean,
   +getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
   +setSelection: (start: number, end: number) => void,
+  setGhostText: (ghostText: ?string) => void, // [macOS]
 };
 
 let AndroidTextInput;
@@ -1408,6 +1409,13 @@ function InternalTextInput(props: Props): React.Node {
               );
             }
           },
+          // [macOS
+          setGhostText(ghostText: ?string): void {
+            if (inputRef.current != null) {
+              viewCommands.setGhostText(inputRef.current, ghostText);
+            }
+          },
+          // macOS]
         });
       }
     },

--- a/Libraries/Components/TextInput/TextInputNativeCommands.js
+++ b/Libraries/Components/TextInput/TextInputNativeCommands.js
@@ -22,8 +22,20 @@ export interface TextInputNativeCommands<T> {
     start: Int32,
     end: Int32,
   ) => void;
+  // [macOS
+  // NYI on Android
+  +setGhostText: (
+    viewRef: React.ElementRef<T>,
+    value: ?string, // in theory this is nullable
+  ) => void;
+  // macOS]
 }
 
-const supportedCommands = ['focus', 'blur', 'setTextAndSelection'];
+const supportedCommands = [
+  'focus',
+  'blur',
+  'setTextAndSelection',
+  'setGhostText',
+]; // [macOS]
 
 export default supportedCommands;

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -58,6 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setReadablePasteBoardTypes:(NSArray<NSPasteboardType> *)readablePasteboardTypes;
 #endif // macOS]
 
+@property (nonatomic, getter=isGhostTextChanging) BOOL ghostTextChanging; // [macOS]
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -383,7 +383,10 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 {
   if (![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
     [self textViewDidChange:_backedTextInputView];
-    _ignoreNextTextInputCall = YES;
+
+    if (![_backedTextInputView isGhostTextChanging]) { // [macOS]
+      _ignoreNextTextInputCall = YES;
+    } // [macOS]
   }
   [self textViewProbablyDidChangeSelection];
 }

--- a/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -87,6 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
 // Use `attributedText.string` instead.
 @property (nonatomic, copy, nullable) NSString *text NS_UNAVAILABLE;
 
+@property (nonatomic, getter=isGhostTextChanging) BOOL ghostTextChanging; // [macOS]
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -69,6 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL showSoftInputOnFocus;
 #endif // [macOS]
 
+@property (nonatomic, copy, nullable) NSString *ghostText; // [macOS]
+
 /**
  Sets selection intext input if both start and end are within range of the text input.
  **/

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -26,6 +26,9 @@
 @implementation RCTBaseTextInputView {
   __weak RCTBridge *_bridge;
   __weak id<RCTEventDispatcherProtocol> _eventDispatcher;
+
+  NSInteger _ghostTextPosition; // [macOS] only valid if _ghostText != nil
+
   BOOL _hasInputAccesoryView;
   // [macOS] remove explicit _predictedText ivar declaration
   BOOL _didMoveToWindow;
@@ -164,7 +167,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 
   textNeedsUpdate = ([self textOf:attributedTextCopy equals:backedTextInputViewTextCopy] == NO);
 
-  if (eventLag == 0 && textNeedsUpdate) {
+  if ((eventLag == 0 || self.backedTextInputView.ghostTextChanging) && textNeedsUpdate) { // [macOS]
 #if !TARGET_OS_OSX // [macOS]
     UITextRange *selection = self.backedTextInputView.selectedTextRange;
 #else // [macOS
@@ -191,7 +194,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
           [self.backedTextInputView positionFromPosition:self.backedTextInputView.beginningOfDocument offset:newOffset];
       [self.backedTextInputView setSelectedTextRange:[self.backedTextInputView textRangeFromPosition:position
                                                                                           toPosition:position]
-                                      notifyDelegate:YES];
+                                      notifyDelegate:!self.backedTextInputView.ghostTextChanging]; // [macOS]
     }
 #else // [macOS
     if (selection.length == 0) {
@@ -200,7 +203,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
       NSInteger offsetFromEnd = oldTextLength - start;
       NSInteger newOffset = self.backedTextInputView.attributedText.length - offsetFromEnd;
       [self.backedTextInputView setSelectedTextRange:NSMakeRange(newOffset, 0)
-                                      notifyDelegate:YES];
+                                      notifyDelegate:!self.backedTextInputView.ghostTextChanging];
     }
 #endif // macOS]
 
@@ -421,6 +424,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 
 - (void)textInputDidEndEditing
 {
+  self.ghostText = nil; // [macOS]
+
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeEnd
                                  reactTag:self.reactTag
                                      text:[self.backedTextInputView.attributedText.string copy]
@@ -530,6 +535,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 {
   id<RCTBackedTextInputViewProtocol> backedTextInputView = self.backedTextInputView;
 
+  self.ghostText = nil; // [macOS]
+
   if (!backedTextInputView.textWasPasted) {
     [_eventDispatcher sendTextEventWithType:RCTTextEventTypeKeyPress
                                    reactTag:self.reactTag
@@ -596,7 +603,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
                                                                                         withString:text];
   }
 
-  if (_onTextInput) {
+  if (_onTextInput && !self.backedTextInputView.ghostTextChanging) { // [macOS]
     _onTextInput(@{
       // We copy the string here because if it's a mutable string it may get released before we stop using it on a
       // different thread, causing a crash.
@@ -630,20 +637,24 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
     [self setPredictedText:backedTextInputView.attributedText.string]; // [macOS]
   }
 
-  _nativeEventCount++;
+  if (!self.backedTextInputView.ghostTextChanging) { // [macOS]
+    _nativeEventCount++;
 
-  if (_onChange) {
-    _onChange(@{
-      @"text" : [self.attributedText.string copy],
-      @"target" : self.reactTag,
-      @"eventCount" : @(_nativeEventCount),
-    });
-  }
+    if (_onChange) {
+      _onChange(@{
+        @"text" : [self.attributedText.string copy],
+        @"target" : self.reactTag,
+        @"eventCount" : @(_nativeEventCount),
+      });
+    }
+  } // [macOS]
 }
 
 - (void)textInputDidChangeSelection
 {
-  if (!_onSelectionChange) {
+  self.ghostText = nil; // [macOS]
+
+  if (!_onSelectionChange || self.backedTextInputView.ghostTextChanging) { // [macOS]
     return;
   }
 
@@ -880,6 +891,92 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
   }
 }
 #endif // [macOS]
+
+// [macOS
+
+- (NSDictionary<NSAttributedStringKey, id> *)ghostTextAttributes
+{
+  RCTUIView<RCTBackedTextInputViewProtocol> *backedTextInputView = self.backedTextInputView;
+  NSMutableDictionary<NSAttributedStringKey, id> *textAttributes =
+      [backedTextInputView.defaultTextAttributes mutableCopy] ?: [NSMutableDictionary new];
+
+  if (@available(iOS 13.0, *)) {
+    [textAttributes setValue:backedTextInputView.placeholderColor ?: [RCTUIColor placeholderTextColor]
+                      forKey:NSForegroundColorAttributeName];
+  } else {
+    if (backedTextInputView.placeholderColor) {
+      [textAttributes setValue:backedTextInputView.placeholderColor forKey:NSForegroundColorAttributeName];
+    } else {
+      [textAttributes removeObjectForKey:NSForegroundColorAttributeName];
+    }
+  }
+
+  return textAttributes;
+}
+
+- (void)setGhostText:(NSString *)ghostText {
+  RCTTextSelection *selection = self.selection;
+  NSString *newGhostText = ghostText.length > 0 ? ghostText : nil;
+
+  if (selection.start != selection.end) {
+    newGhostText = nil;
+  }
+
+  if ((_ghostText == nil && newGhostText == nil) || [_ghostText isEqual:newGhostText]) {
+    return;
+  }
+
+  if (self.backedTextInputView.ghostTextChanging) {
+    // look out for nested callbacks -- this can happen for example when selection changes in response to
+    // attributed text changing. Such callbacks are initiated by Apple, or we could suppress this other ways.
+    return;
+  }
+
+  self.backedTextInputView.ghostTextChanging = YES;
+
+  if (_ghostText != nil) {
+    BOOL shouldDeleteGhostText = YES;
+    NSRange ghostTextRange = NSMakeRange(_ghostTextPosition, _ghostText.length);
+    NSMutableAttributedString *attributedString = [self.attributedText mutableCopy];
+
+    if ([attributedString length] < NSMaxRange(ghostTextRange)) {
+      RCTAssert(false, @"Ghost text not fully present in text view text");
+      shouldDeleteGhostText = NO;
+    }
+
+    NSString *actualGhostText = shouldDeleteGhostText
+      ? [[attributedString attributedSubstringFromRange:ghostTextRange] string]
+      : nil;
+
+    if (![actualGhostText isEqual:_ghostText]) {
+      RCTAssert(false, @"Ghost text does not match text view text");
+      shouldDeleteGhostText = NO;
+    }
+
+    if (shouldDeleteGhostText) {
+      [attributedString deleteCharactersInRange:ghostTextRange];
+      self.attributedText = attributedString;
+      [self setSelectionStart:selection.start selectionEnd:selection.end];
+    }
+  }
+
+  _ghostText = [newGhostText copy];
+  _ghostTextPosition = selection.start;
+
+  if (_ghostText != nil) {
+    NSMutableAttributedString *attributedString = [self.attributedText mutableCopy];
+    NSAttributedString *ghostAttributedString = [[NSAttributedString alloc] initWithString:_ghostText
+                                                                                attributes:self.ghostTextAttributes];
+
+    [attributedString insertAttributedString:ghostAttributedString atIndex:_ghostTextPosition];
+    self.attributedText = attributedString;
+    [self setSelectionStart:_ghostTextPosition selectionEnd:_ghostTextPosition];
+  }
+
+  self.backedTextInputView.ghostTextChanging = NO;
+}
+
+// macOS]
 
 #pragma mark - Helpers
 

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -171,6 +171,17 @@ RCT_EXPORT_METHOD(setTextAndSelection
   }];
 }
 
+// [macOS
+RCT_EXPORT_METHOD(setGhostText
+				  :(nonnull NSNumber *)reactTag
+				  :(NSString *)text) {
+
+	[self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPlatformView *> *viewRegistry) {
+		[(RCTBaseTextInputView *)viewRegistry[reactTag] setGhostText:text];
+	}];
+}
+// macOS]
+
 #pragma mark - RCTUIManagerObserver
 
 - (void)uiManagerWillPerformMounting:(__unused RCTUIManager *)uiManager

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -62,6 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGFloat pointScaleFactor;
 #endif // macOS]
 
+@property (nonatomic, getter=isGhostTextChanging) BOOL ghostTextChanging; // [macOS]
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -145,6 +145,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final int BLUR_TEXT_INPUT = 2;
   private static final int SET_MOST_RECENT_EVENT_COUNT = 3;
   private static final int SET_TEXT_AND_SELECTION = 4;
+  private static final int SET_GHOST_TEXT = 5; // [macOS]
 
   private static final int INPUT_TYPE_KEYBOARD_NUMBER_PAD = InputType.TYPE_CLASS_NUMBER;
   private static final int INPUT_TYPE_KEYBOARD_DECIMAL_PAD =
@@ -278,7 +279,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @Override
   public @Nullable Map<String, Integer> getCommandsMap() {
-    return MapBuilder.of("focusTextInput", FOCUS_TEXT_INPUT, "blurTextInput", BLUR_TEXT_INPUT);
+    return MapBuilder.of("focusTextInput", FOCUS_TEXT_INPUT, "blurTextInput", BLUR_TEXT_INPUT, "setGhostText", SET_GHOST_TEXT); // [macOS]
   }
 
   @Override
@@ -297,6 +298,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       case SET_TEXT_AND_SELECTION:
         this.receiveCommand(reactEditText, "setTextAndSelection", args);
         break;
+// [macOS
+      case SET_GHOST_TEXT:
+        this.receiveCommand(reactEditText, "setGhostText", args);
+        break;
+// macOS]
     }
   }
 
@@ -331,6 +337,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         }
         reactEditText.maybeSetSelection(mostRecentEventCount, start, end);
         break;
+// [macOS
+      case "setGhostText":
+      default:
+        throw new IllegalArgumentException(
+          "Unsupported command setGhostText received by ReactTextInputManager.");
+// macOS]
     }
   }
 

--- a/packages/rn-tester/js/examples/GhostText/GhostText.js
+++ b/packages/rn-tester/js/examples/GhostText/GhostText.js
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict'; // [macOS]
+
+const React = require('react');
+const ReactNative = require('react-native');
+
+const {Button, ScrollView, StyleSheet, Text, TextInput, View} = ReactNative;
+
+const ghostTextKeywords = ['Alpha', 'Beta'];
+
+function isWhitespace(str: string): boolean {
+  return str.trim().length === 0;
+}
+
+function lastIndexOfWhitespace(str: string, searchPos: number): number {
+  if (searchPos >= str.length) {
+    searchPos = str.length - 1;
+  }
+
+  while (searchPos >= 0) {
+    if (isWhitespace(str.charAt(searchPos))) {
+      return searchPos;
+    }
+
+    searchPos -= 1;
+  }
+
+  return -1;
+}
+
+function determinePrefixAndSuffix(
+  oldText: string,
+  newText: string,
+): {
+  previousText: string,
+  range: $ReadOnly<{start: number, end: number}>,
+  text: string,
+} {
+  const oldTextLength = oldText.length;
+  const newTextLength = newText.length;
+
+  let suffixLength = 0;
+  while (
+    suffixLength < oldTextLength &&
+    suffixLength < newTextLength &&
+    oldText.charAt(oldTextLength - suffixLength - 1) ===
+      newText.charAt(newTextLength - suffixLength - 1)
+  ) {
+    suffixLength++;
+  }
+
+  let prefixLength = 0;
+  while (
+    prefixLength < oldTextLength - suffixLength &&
+    prefixLength < newTextLength - suffixLength &&
+    oldText.charAt(prefixLength) === newText.charAt(prefixLength)
+  ) {
+    prefixLength++;
+  }
+
+  return {
+    previousText: oldText,
+    range: {start: prefixLength, end: oldTextLength - suffixLength},
+    text: newText.substring(prefixLength, newTextLength - suffixLength),
+  };
+}
+
+function determineGhostText(
+  text: string,
+  selection: $ReadOnly<{start: number, end: number}>,
+  input: string,
+): ?string {
+  if (!input || selection.start !== selection.end) {
+    return undefined;
+  }
+
+  if (
+    selection.start !== text.length &&
+    !isWhitespace(text.charAt(selection.start))
+  ) {
+    return undefined;
+  }
+
+  const spacePos =
+    selection.start > 0 ? lastIndexOfWhitespace(text, selection.start - 1) : -1;
+
+  const query =
+    text.substring(spacePos > 0 ? spacePos + 1 : 0, selection.start) + input;
+
+  for (const keyword of ghostTextKeywords) {
+    if (keyword.indexOf(query) === 0 && keyword !== query) {
+      return keyword.substring(query.length);
+    }
+  }
+
+  return undefined;
+}
+
+function GhostTextExample(): React.Node {
+  const counter = React.useRef(0);
+  const [log, setLog] = React.useState([]);
+
+  const clearLog = React.useCallback(() => {
+    setLog([]);
+  }, [setLog]);
+
+  const appendLog = React.useCallback(
+    (line: string) => {
+      const limit = 20;
+      let newLog = log.slice(0, limit - 1);
+      newLog.unshift('[' + counter.current.toString() + '] ' + line);
+      setLog(newLog);
+      counter.current += 1;
+    },
+    [log, setLog],
+  );
+
+  const textInput = React.useRef(undefined);
+  const textInput2 = React.useRef(undefined);
+  const oldTextContent = React.useRef('');
+  const oldText2Content = React.useRef('');
+  return (
+    <ScrollView>
+      <View style={styles.root}>
+        <Text>
+          Ghost text is hint text that is inserted inline as a hint to the user
+          (for example predictive text). Unlike autocomplete for combo boxes,
+          which is "visible" to the model, ghost text is "invisible" or
+          transparent to the model (i.e. not observable in any callback or
+          imperative method).
+        </Text>
+        <View>
+          <TextInput
+            ref={textInput}
+            placeholder={'Multi line text input'}
+            multiline
+            onBlur={event =>
+              appendLog('onBlur: ' + JSON.stringify(event.nativeEvent))
+            }
+            onChangeText={text => {
+              appendLog('onChangeText: ' + text);
+              const changes = determinePrefixAndSuffix(
+                oldTextContent.current,
+                text,
+              );
+              textInput.current?.setGhostText(
+                determineGhostText(
+                  changes.previousText,
+                  changes.range,
+                  changes.text,
+                ),
+              );
+              oldTextContent.current = text;
+            }}
+            onEndEditing={event =>
+              appendLog('onEndEditing: ' + event.nativeEvent.text)
+            }
+            onFocus={event =>
+              appendLog('onFocus: ' + JSON.stringify(event.nativeEvent))
+            }
+            onSelectionChange={event => {
+              appendLog(
+                'onSelectionChange: ' +
+                  JSON.stringify(event.nativeEvent.selection),
+              );
+            }}
+            onSubmitEditing={event =>
+              appendLog('onSubmitEditing: ' + event.nativeEvent.text)
+            }
+            style={styles.row}
+          />
+          <TextInput
+            ref={textInput2}
+            placeholder={'Single line text input'}
+            onBlur={event =>
+              appendLog('onBlur: ' + JSON.stringify(event.nativeEvent))
+            }
+            onChangeText={text => {
+              appendLog('onChangeText: ' + text);
+              const changes = determinePrefixAndSuffix(
+                oldText2Content.current,
+                text,
+              );
+              textInput2.current?.setGhostText(
+                determineGhostText(
+                  changes.previousText,
+                  changes.range,
+                  changes.text,
+                ),
+              );
+              oldText2Content.current = text;
+            }}
+            onEndEditing={event =>
+              appendLog('onEndEditing: ' + event.nativeEvent.text)
+            }
+            onFocus={event =>
+              appendLog('onFocus: ' + JSON.stringify(event.nativeEvent))
+            }
+            onSelectionChange={event => {
+              appendLog(
+                'onSelectionChange: ' +
+                  JSON.stringify(event.nativeEvent.selection),
+              );
+            }}
+            onSubmitEditing={event =>
+              appendLog('onSubmitEditing: ' + event.nativeEvent.text)
+            }
+            style={styles.row}
+          />
+          <Button
+            testID="event_clear_button"
+            onPress={clearLog}
+            title="Clear event log"
+          />
+          <Text>{'Events:\n' + log.join('\n')}</Text>
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    padding: 10,
+  },
+  row: {
+    height: 36,
+    marginTop: 8,
+    marginBottom: 8,
+    backgroundColor: 'grey',
+    padding: 10,
+  },
+});
+
+exports.title = 'Ghost text';
+exports.description = 'Examples that show how ghost text can be used.';
+exports.examples = [
+  {
+    title: 'GhostTextExample',
+    render: function (): React.Element<any> {
+      return <GhostTextExample />;
+    },
+  },
+];

--- a/packages/rn-tester/js/examples/GhostText/GhostText.js
+++ b/packages/rn-tester/js/examples/GhostText/GhostText.js
@@ -124,8 +124,10 @@ function GhostTextExample(): React.Node {
     [log, setLog],
   );
 
-  const textInput = React.useRef(undefined);
-  const textInput2 = React.useRef(undefined);
+  const textInput =
+    React.useRef<?React.ElementRef<typeof TextInput>>(undefined);
+  const textInput2 =
+    React.useRef<?React.ElementRef<typeof TextInput>>(undefined);
   const oldTextContent = React.useRef('');
   const oldText2Content = React.useRef('');
   return (

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -41,6 +41,12 @@ const Components: Array<RNTesterModuleInfo> = [
     module: require('../examples/FocusOnMount/FocusOnMount'),
   },
   // macOS]
+  // [macOS
+  {
+    key: 'GhostText',
+    module: require('../examples/GhostText/GhostText'),
+  },
+  // macOS]
   {
     key: 'KeyboardEvents',
     module: require('../examples/KeyboardEventsExample/KeyboardEventsExample'),


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Ghost text is hint text that is inserted inline as a hint to the user (for example predictive text). Unlike autocomplete for combo boxes, which is "visible" to the model, ghost text is "invisible" or transparent to the model (i.e. not observable in any callback or imperative method). Ghost text isn't selectable by the user.

Ideally we do ghost text only in the display layer, meaning it isn't in the model. Unfortunately it doesn't look like we can render ghost text and still have Apple flow text for us (ghost text that is in the middle of regular text will want to reflow the regular text to make room for ghost text). Overriding all text box rendering seems like substantial rework (we need to deal with all drawing, including but not limited to the text box background, text, insertion pointer\selection, ... as well as other ancillary things around positioning related input UI such as IME's), so here we DO introduce it in the model, but try to keep awareness on the native side, and away from Application logic.

Since ghost text is presumed dependent on immediate user context (e.g. text and selection), we reset ghost text automatically when either of these change. We could *not* do that, but that requires us to deal with any possible edits around\on the ghost text, as well as actually ensure we "hide" ghost text from any callbacks made to the app (something we are getting away with right now since we remove ghost text on pretty much any user interaction).

Plumbing for new imperative method to set ghost text.

* Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js
* Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js
* Libraries/Components/TextInput/TextInput.flow.js
* Libraries/Components/TextInput/TextInput.js
* Libraries/Components/TextInput/TextInputNativeCommands.js
* Libraries/Text/TextInput/RCTBaseTextInputViewManager.m

Introduce a property on the `RCTUITextView` and `RCTUITextField` to store state on whether we're currently in the midst of setting\clearing ghost text. We use this to suppress various callbacks to the Application that may be triggered as a result of us changing the ghost text\selection to compensate for addition\removal of ghost text.

* Libraries/Text/TextInput/Multiline/RCTUITextView.h
* Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
* Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
* Libraries/Text/TextInput/Singleline/RCTUITextField.h

Actual ghost text management logic. I placed as much as I reasonably could here since that allows us to share most of the functionality between single and multi line text inputs.

* Libraries/Text/TextInput/RCTBaseTextInputView.h
* Libraries/Text/TextInput/RCTBaseTextInputView.m

Test page for ghost text. Shows predictive text example.

* packages/rn-tester/js/examples/GhostText/GhostText.js
* packages/rn-tester/js/utils/RNTesterList.ios.js

## Changelog

General Changed - Initial commit

## Test Plan

Testing (macOS\iOS x multi\single line):

* Type predictable text (see test page for list), see that we get ghost text and that isn't observable in the callbacks
* Type non-predictable text, check ordering of events consistent with predictable text case
* Log calls to `setGhostText:` on native. Ensure we clear ghost text (due to text chagnes)
* Change selection with ghost text, check that we remove ghost text (due to selection change)
* Hit Esc in text box with ghost text, check that we remove ghost text (due to focus loss)

Test page example video: https://github.com/microsoft/react-native-macos/assets/72474613/38f466c3-695b-4526-bbb2-a5afb8e333d8