### PR TITLE
[RCTTouchHandler] Add a small optimization to coordinate conversion

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -229,11 +229,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
   NSEvent *nativeTouch = _nativeTouches[touchIndex];
   CGPoint location = nativeTouch.locationInWindow;
   RCTAssert(_cachedRootView, @"We were unable to find a root view for the touch");
-  CGPoint rootViewLocation = [_cachedRootView.window.contentView convertPoint:location toView:_cachedRootView];
+  CGPoint rootViewLocation = [_cachedRootView convertPoint:location fromView:nil];
+
   NSView *touchView = _touchViews[touchIndex];
   CGPoint touchViewLocation = [touchView convertPoint:location fromView:nil];
-  // JavaScript expects coordinates to have (0,0) at top left, unlike the macOS coordinate system
-  rootViewLocation.y = NSHeight([[_cachedRootView window] frame]) - rootViewLocation.y; 
 #endif // macOS]
 
   NSMutableDictionary *reactTouch = _reactTouches[touchIndex];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Back in #1862, we made a fix to make sure that macOS screen coordinates (where the Y coordinate is flipped) are converted before being sent to JS, where we assume the coordinate system that every other platform uses (AKA, origin at top left). @lenaic pointed out there's a simpler way to do this, so let's make a small optimization. To quote:

> Using this line to assign rootViewLocation instead of the weird _cachedRootView.window.contentView conversion fixes the flipping, allowing to remove the flipping you added below.

Note, it seems we've changed this particular block before, with #1619 . Seems it's a strongly-hit code path 😄

## Changeling

[MACOS] [CHANGED] - Add a small optimization to RCTTouchHandlers' coordinate conversion

## Test Plan

Sanity checked the Pressable test page with and without the change and didn't really see a difference.
