### PR TITLE
Fix some ADO pipeline stuff

### DIFF
--- a/.ado/apple-integration.yml
+++ b/.ado/apple-integration.yml
@@ -74,6 +74,17 @@ jobs:
           cat package.json | jq .devDependencies
         displayName: Modify example app dependencies
         workingDirectory: react-native-test-app/example
+      - template: templates/verdaccio-init.yml
+      - bash: |
+          npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
+        displayName: Publish beachball packages to verdaccio
+      - bash: |
+          cat .yarnrc.yml | sed 's_^npmRegistryServer: ".*"$_npmRegistryServer: "http://localhost:4873"_' > .yarnrc.yml.copy
+          rm .yarnrc.yml
+          mv .yarnrc.yml.copy .yarnrc.yml
+          echo -e '\nunsafeHttpWhitelist: ["localhost"]' >> .yarnrc.yml
+        displayName: Point react-native-test-app registry to verdaccio server
+        workingDirectory: react-native-test-app
       - bash: |
           yarn --no-immutable
         displayName: Install npm dependencies

--- a/.ado/templates/react-native-macos-init.yml
+++ b/.ado/templates/react-native-macos-init.yml
@@ -31,36 +31,14 @@ steps:
         cd packages/react-native-macos-init
         yarn build
 
-  - task: CmdLine@2
-    displayName: Launch test npm server (verdaccio)
-    inputs:
-      script: |
-        npx verdaccio --config ./.ado/verdaccio/config.yaml &
-
-  - script: |
-      npm set registry http://localhost:4873
-    displayName: Modify default npm config to point to local verdaccio server
-
-  - script: |
-      node .ado/waitForVerdaccio.js
-    displayName: Wait for verdaccio server to boot
-
-  - script: |
-      node .ado/npmAddUser.js user pass mail@nomail.com http://localhost:4873
-    displayName: Add npm user to verdaccio
+  - template: verdaccio-init.yml
 
   - task: CmdLine@2
     displayName: Set package version
     inputs:
       script: node scripts/set-rn-version.js -b dry-run -v 1000.0.0
 
-  - script: |
-      npm publish --registry http://localhost:4873
-    displayName: Publish react-native-macos to verdaccio
-
-  - script: |
-      npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
-    displayName: Publish react-native-macos-init to verdaccio
+  - template: verdaccio-publish.yml
 
   - task: CmdLine@2
     displayName: Init new project

--- a/.ado/templates/verdaccio-init.yml
+++ b/.ado/templates/verdaccio-init.yml
@@ -1,0 +1,20 @@
+# Initializes a verdaccio server.
+
+steps:
+  - task: CmdLine@2
+    displayName: Launch test npm server (verdaccio)
+    inputs:
+      script: |
+        npx verdaccio --config ./.ado/verdaccio/config.yaml &
+
+  - script: |
+      npm set registry http://localhost:4873
+    displayName: Modify default npm config to point to local verdaccio server
+
+  - script: |
+      node .ado/waitForVerdaccio.js
+    displayName: Wait for verdaccio server to boot
+
+  - script: |
+      node .ado/npmAddUser.js user pass mail@nomail.com http://localhost:4873
+    displayName: Add npm user to verdaccio

--- a/.ado/templates/verdaccio-publish.yml
+++ b/.ado/templates/verdaccio-publish.yml
@@ -1,0 +1,10 @@
+# Publishes local packages to our verdaccio server.
+
+steps:
+  - script: |
+      npm publish --registry http://localhost:4873
+    displayName: Publish react-native-macos to verdaccio
+
+  - script: |
+      npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
+    displayName: Publish react-native-macos-init to verdaccio

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@react-native/gradle-plugin": "^0.72.5",
     "@react-native/js-polyfills": "^0.72.1",
     "@react-native/normalize-colors": "^0.72.0",
-    "@react-native-mac/virtualized-lists": "^0.0.1",
+    "@react-native-mac/virtualized-lists": "^0.1.0",
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "base64-js": "^1.1.2",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

#1894 caused a few issues with some of our pipelines. We provide the following fixes:
* Manually bump `@react-native-mac/virtualized-lists` to `^0.1.0`. (I'm not sure why beachball didn't do this automatically, but at least we're doing it now.)
* Use a Verdaccio server in our Integration pipeline. The pipeline will probably still be broken, but it was broken anyway, so we're at least getting it back up to our previous baseline. We can fix it while finishing up the 0.72 merge.

## Changelog

[INTERNAL] [FIXED] - ADO pipeline fixes

## Test Plan

Required pipelines should pass, and the `yarn install` phase should succeed for the Integration pipeline.