### PR TITLE
Applying package update to 0.71.33 ***NO_CI***

### DIFF
--- a/Libraries/Core/ReactNativeVersion.js
+++ b/Libraries/Core/ReactNativeVersion.js
@@ -12,6 +12,6 @@
 exports.version = {
   major: 0,
   minor: 71,
-  patch: 32,
+  patch: 33,
   prerelease: null,
 };

--- a/React/Base/RCTVersion.m
+++ b/React/Base/RCTVersion.m
@@ -23,7 +23,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(71),
-                  RCTVersionPatch: @(32),
+                  RCTVersionPatch: @(33),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.71.32
+VERSION_NAME=0.71.33
 GROUP=com.facebook.react
 
 # JVM Versions

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -17,6 +17,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 71,
-      "patch", 32,
+      "patch", 33,
       "prerelease", null);
 }

--- a/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -17,7 +17,7 @@ namespace facebook::react {
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 71;
-  int32_t Patch = 32;
+  int32_t Patch = 33;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.71.32",
+  "version": "0.71.33",
   "bin": "./cli.js",
   "description": "React Native for macOS",
   "license": "MIT",

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.71.32)
-  - FBReactNativeSpec (0.71.32):
+  - FBLazyVector (0.71.33)
+  - FBReactNativeSpec (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.71.32)
-    - RCTTypeSafety (= 0.71.32)
-    - React-Core (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
+    - RCTRequired (= 0.71.33)
+    - RCTTypeSafety (= 0.71.33)
+    - React-Core (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
   - fmt (6.2.1)
   - glog (0.3.5)
   - OCMock (3.9.1)
@@ -23,26 +23,26 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.71.32)
-  - RCTTypeSafety (0.71.32):
-    - FBLazyVector (= 0.71.32)
-    - RCTRequired (= 0.71.32)
-    - React-Core (= 0.71.32)
-  - React (0.71.32):
-    - React-Core (= 0.71.32)
-    - React-Core/DevSupport (= 0.71.32)
-    - React-Core/RCTWebSocket (= 0.71.32)
-    - React-RCTActionSheet (= 0.71.32)
-    - React-RCTAnimation (= 0.71.32)
-    - React-RCTBlob (= 0.71.32)
-    - React-RCTImage (= 0.71.32)
-    - React-RCTLinking (= 0.71.32)
-    - React-RCTNetwork (= 0.71.32)
-    - React-RCTSettings (= 0.71.32)
-    - React-RCTText (= 0.71.32)
-    - React-RCTVibration (= 0.71.32)
-  - React-callinvoker (0.71.32)
-  - React-Codegen (0.71.32):
+  - RCTRequired (0.71.33)
+  - RCTTypeSafety (0.71.33):
+    - FBLazyVector (= 0.71.33)
+    - RCTRequired (= 0.71.33)
+    - React-Core (= 0.71.33)
+  - React (0.71.33):
+    - React-Core (= 0.71.33)
+    - React-Core/DevSupport (= 0.71.33)
+    - React-Core/RCTWebSocket (= 0.71.33)
+    - React-RCTActionSheet (= 0.71.33)
+    - React-RCTAnimation (= 0.71.33)
+    - React-RCTBlob (= 0.71.33)
+    - React-RCTImage (= 0.71.33)
+    - React-RCTLinking (= 0.71.33)
+    - React-RCTNetwork (= 0.71.33)
+    - React-RCTSettings (= 0.71.33)
+    - React-RCTText (= 0.71.33)
+    - React-RCTVibration (= 0.71.33)
+  - React-callinvoker (0.71.33)
+  - React-Codegen (0.71.33):
     - FBReactNativeSpec
     - RCT-Folly
     - RCTRequired
@@ -53,317 +53,317 @@ PODS:
     - React-jsiexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.71.32):
+  - React-Core (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.32)
-    - React-cxxreact (= 0.71.32)
+    - React-Core/Default (= 0.71.33)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.71.32):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.71.32)
-    - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.71.32):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.32)
-    - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.71.32):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.32)
-    - React-Core/RCTWebSocket (= 0.71.32)
-    - React-cxxreact (= 0.71.32)
-    - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-jsinspector (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.71.32):
+  - React-Core/CoreModulesHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.71.32):
+  - React-Core/Default (0.71.33):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact (= 0.71.33)
+    - React-jsc
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.71.33):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.71.33)
+    - React-Core/RCTWebSocket (= 0.71.33)
+    - React-cxxreact (= 0.71.33)
+    - React-jsc
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-jsinspector (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.71.32):
+  - React-Core/RCTAnimationHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.71.32):
+  - React-Core/RCTBlobHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.71.32):
+  - React-Core/RCTImageHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.71.32):
+  - React-Core/RCTLinkingHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.71.32):
+  - React-Core/RCTNetworkHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.71.32):
+  - React-Core/RCTPushNotificationHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.71.32):
+  - React-Core/RCTSettingsHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.71.32):
+  - React-Core/RCTTextHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.32)
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.71.32):
+  - React-Core/RCTVibrationHeaders (0.71.33):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.32)
-    - React-cxxreact (= 0.71.32)
+    - React-Core/Default
+    - React-cxxreact (= 0.71.33)
     - React-jsc
-    - React-jsi (= 0.71.32)
-    - React-jsiexecutor (= 0.71.32)
-    - React-perflogger (= 0.71.32)
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.71.32):
+  - React-Core/RCTWebSocket (0.71.33):
+    - glog
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.32)
-    - React-Codegen (= 0.71.32)
-    - React-Core/CoreModulesHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
+    - React-Core/Default (= 0.71.33)
+    - React-cxxreact (= 0.71.33)
+    - React-jsc
+    - React-jsi (= 0.71.33)
+    - React-jsiexecutor (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.71.33):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.71.33)
+    - React-Codegen (= 0.71.33)
+    - React-Core/CoreModulesHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
     - React-RCTBlob
-    - React-RCTImage (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
+    - React-RCTImage (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.71.32):
+  - React-cxxreact (0.71.33):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - React-jsinspector (= 0.71.32)
-    - React-logger (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-    - React-runtimeexecutor (= 0.71.32)
-  - React-jsc (0.71.32):
-    - React-jsc/Fabric (= 0.71.32)
-    - React-jsi (= 0.71.32)
-  - React-jsc/Fabric (0.71.32):
-    - React-jsi (= 0.71.32)
-  - React-jsi (0.71.32):
+    - React-callinvoker (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - React-jsinspector (= 0.71.33)
+    - React-logger (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+    - React-runtimeexecutor (= 0.71.33)
+  - React-jsc (0.71.33):
+    - React-jsc/Fabric (= 0.71.33)
+    - React-jsi (= 0.71.33)
+  - React-jsc/Fabric (0.71.33):
+    - React-jsi (= 0.71.33)
+  - React-jsi (0.71.33):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.71.32):
+  - React-jsiexecutor (0.71.33):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-  - React-jsinspector (0.71.32)
-  - React-logger (0.71.32):
+    - React-cxxreact (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+  - React-jsinspector (0.71.33)
+  - React-logger (0.71.33):
     - glog
-  - React-perflogger (0.71.32)
-  - React-RCTActionSheet (0.71.32):
-    - React-Core/RCTActionSheetHeaders (= 0.71.32)
-  - React-RCTAnimation (0.71.32):
+  - React-perflogger (0.71.33)
+  - React-RCTActionSheet (0.71.33):
+    - React-Core/RCTActionSheetHeaders (= 0.71.33)
+  - React-RCTAnimation (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.32)
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTAnimationHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTAppDelegate (0.71.32):
+    - RCTTypeSafety (= 0.71.33)
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTAnimationHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTAppDelegate (0.71.33):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.71.32):
+  - React-RCTBlob (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTBlobHeaders (= 0.71.32)
-    - React-Core/RCTWebSocket (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - React-RCTNetwork (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTImage (0.71.32):
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTBlobHeaders (= 0.71.33)
+    - React-Core/RCTWebSocket (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - React-RCTNetwork (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTImage (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.32)
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTImageHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - React-RCTNetwork (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTLinking (0.71.32):
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTLinkingHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTNetwork (0.71.32):
+    - RCTTypeSafety (= 0.71.33)
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTImageHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - React-RCTNetwork (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTLinking (0.71.33):
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTLinkingHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTNetwork (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.32)
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTNetworkHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTPushNotification (0.71.32):
-    - RCTTypeSafety (= 0.71.32)
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTPushNotificationHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTSettings (0.71.32):
+    - RCTTypeSafety (= 0.71.33)
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTNetworkHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTPushNotification (0.71.33):
+    - RCTTypeSafety (= 0.71.33)
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTPushNotificationHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTSettings (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.32)
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTSettingsHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTTest (0.71.32):
+    - RCTTypeSafety (= 0.71.33)
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTSettingsHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTTest (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core (= 0.71.32)
-    - React-CoreModules (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-RCTText (0.71.32):
-    - React-Core/RCTTextHeaders (= 0.71.32)
-  - React-RCTVibration (0.71.32):
+    - React-Core (= 0.71.33)
+    - React-CoreModules (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-RCTText (0.71.33):
+    - React-Core/RCTTextHeaders (= 0.71.33)
+  - React-RCTVibration (0.71.33):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.32)
-    - React-Core/RCTVibrationHeaders (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
-  - React-runtimeexecutor (0.71.32):
-    - React-jsi (= 0.71.32)
-  - ReactCommon/turbomodule/bridging (0.71.32):
+    - React-Codegen (= 0.71.33)
+    - React-Core/RCTVibrationHeaders (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
+  - React-runtimeexecutor (0.71.33):
+    - React-jsi (= 0.71.33)
+  - ReactCommon/turbomodule/bridging (0.71.33):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.32)
-    - React-Core (= 0.71.32)
-    - React-cxxreact (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - React-logger (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-  - ReactCommon/turbomodule/core (0.71.32):
+    - React-callinvoker (= 0.71.33)
+    - React-Core (= 0.71.33)
+    - React-cxxreact (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - React-logger (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+  - ReactCommon/turbomodule/core (0.71.33):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.32)
-    - React-Core (= 0.71.32)
-    - React-cxxreact (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - React-logger (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-  - ReactCommon/turbomodule/samples (0.71.32):
+    - React-callinvoker (= 0.71.33)
+    - React-Core (= 0.71.33)
+    - React-cxxreact (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - React-logger (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+  - ReactCommon/turbomodule/samples (0.71.33):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.32)
-    - React-Core (= 0.71.32)
-    - React-cxxreact (= 0.71.32)
-    - React-jsi (= 0.71.32)
-    - React-logger (= 0.71.32)
-    - React-perflogger (= 0.71.32)
-    - ReactCommon/turbomodule/core (= 0.71.32)
+    - React-callinvoker (= 0.71.33)
+    - React-Core (= 0.71.33)
+    - React-cxxreact (= 0.71.33)
+    - React-jsi (= 0.71.33)
+    - React-logger (= 0.71.33)
+    - React-perflogger (= 0.71.33)
+    - ReactCommon/turbomodule/core (= 0.71.33)
   - ScreenshotManager (0.0.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -494,43 +494,43 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 8fa3cd00fa17ef6c3221e5fd283fa93e81d23017
   DoubleConversion: acaf5db79676d2e9119015819153f0f99191de12
-  FBLazyVector: bbda85128f5e65ef62efd54d17d95d55e693b1ad
-  FBReactNativeSpec: 03342fa2e347f600b452f511699dbd5d48ee3a3e
+  FBLazyVector: 732e9894455ba874b5a579460b785a698471abc3
+  FBReactNativeSpec: 6919fbd8d242b62a6ae7cb10e36c1fb9a804ac4b
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 6df0a3d6e2750a50609471fd1a01fd2948d405b5
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   RCT-Folly: bf7b4921a91932051ebf1c5c2d297154b1fa3c8c
-  RCTRequired: bd77234e655f56d17d6b65a092dc390d4ae951f0
-  RCTTypeSafety: 6c03433c3bb1493bdde47b5b6cff5744fc50c42c
-  React: 87f588edd4012ca3f088af93e4b723907758fafe
-  React-callinvoker: b1d38678e69b2bb385837d5c2d31568ad478a029
-  React-Codegen: 2814e91a6d73552b0f2b8e93fd5204e1a42bff15
-  React-Core: 5620cb5967391de99d9642886e149376a684546a
-  React-CoreModules: 32353a3c7cece800bcbadb236e08c4ad7be22389
-  React-cxxreact: e93ea45e0ef0fb738513041971260454009d2663
-  React-jsc: bc258b131656a4f1017db680fccf0cafbe9bb8f1
-  React-jsi: f565e9f9acc8fa9e007148416a4c7e46550fd495
-  React-jsiexecutor: f5e70f24cbe111aaa346a56976cddaf52d9c9f22
-  React-jsinspector: 0676d290b57390bdc6a2cf6a353cfac04127970e
-  React-logger: 3bbf020c2b6e178f4d7321ca19e09a8bd7bebce3
-  React-perflogger: 91ce4a97955910b000b6182a4c08eb2caacfe22f
-  React-RCTActionSheet: ac15eb54e8b94500aef1f7df9650eaaa5c60715f
-  React-RCTAnimation: 859de1bfd2faa1d0da235ce6de36a661c027a8a2
-  React-RCTAppDelegate: 6cd2604d72db9ba6187e6deb2182e71ddaa83e61
-  React-RCTBlob: 2e51f0c7825197e27ad8a69f8f6b37081bd18e50
-  React-RCTImage: 36a34dafdfe888eeeebcaae761f5552a250c03e1
-  React-RCTLinking: c1ac842d2ced4855af5df0a09cf0855662d9c5a3
-  React-RCTNetwork: 6ce0c158b45ccabc8e7d94e0fd514dbc197b2c22
-  React-RCTPushNotification: 112348a27b5bd0acf9d3a0a178f7a1ebdbbcb417
-  React-RCTSettings: e9f1852fbc53941caf0f70442f15a7834939081a
-  React-RCTTest: 484f01a40642e190a488f6e6d7327093f21561e9
-  React-RCTText: abf299079e173f5f5220902948a8fee5707c1749
-  React-RCTVibration: 05e9bd70c4dfdcc41cb379ee1c4a464d502ba8e5
-  React-runtimeexecutor: 02f5e10dc82986982483fe1b277e11ad0245aeba
-  ReactCommon: e4af83d7732dfa1566698a549acb1f02ec19ecd6
+  RCTRequired: b924a3818bef3872776fc35568607e9fd1a7ccef
+  RCTTypeSafety: 34f12e6931e6ecff0d49578c88516574dd75c5fb
+  React: 72acb808d5ea012c54c0d8f3d9e0177a5164ce44
+  React-callinvoker: 7f44c6485e733f907d8adccb8ea7bfd8c661ad73
+  React-Codegen: 0b2114160ce592070f115f5fbff2747d76d0ae8e
+  React-Core: 675a479fdc03725925e1a7f9e5a3bf0548cb24c2
+  React-CoreModules: 87b348ba58c041b57f45f9f5535fd0436479cb28
+  React-cxxreact: 6f1f6ff3172ce0c542b4c32e399773f1643873e8
+  React-jsc: a4b9eebe6ab71197b505b20f17c03b2552cd66b3
+  React-jsi: d2cd70166fa1d42d1854a6fea0759968d4efe262
+  React-jsiexecutor: 9d1f2ab1d5bce258038eb202728210cab73581af
+  React-jsinspector: b482ed08c8233d528c5917e1a916827e2357ab24
+  React-logger: 9cca25c5cbc2bdc03dd79010992d17cbac337139
+  React-perflogger: b2d0d3a34cb21df25dfdef7331c8eace64ebbac4
+  React-RCTActionSheet: e2852db033ff9909d9e31f78a16a8b1a0d72b0b3
+  React-RCTAnimation: af9d4eba93cbb7bf6b2b70ff30f4dde1ae47a4a6
+  React-RCTAppDelegate: 1ed88f20871b6a095159a7f23ee6ba1376bc96e7
+  React-RCTBlob: 00d5f9a111ab8d31c5030975feb9b4cd82dfcf16
+  React-RCTImage: ee42851404992d7a14086ef0daa2a30238d5e175
+  React-RCTLinking: 424dafdd86a0de70210f2bdae72ebe8dcf697493
+  React-RCTNetwork: 9d5462fd172015c6b3fbc9d2dd93a8bc9a2ee5c7
+  React-RCTPushNotification: 45f332b6006fd2815e385159d15800a7985748b6
+  React-RCTSettings: f7dc22a18afb78123c2191bedb3200da9f2bb8ca
+  React-RCTTest: 81382604106b8a22c1f9637e369bb9b4c14ea492
+  React-RCTText: f820084f73880a29393620119d365761c681aef3
+  React-RCTVibration: dae031977d6a1ce3b89f0fbea95a5dd70024685d
+  React-runtimeexecutor: d475f7a753d3aff4c72c146e064cc174e593910e
+  ReactCommon: 79e0b0a3d0baa6d7512c06c8d88ad3c6d8b64339
   ScreenshotManager: 2fac62be553326d7d32ef3019c9fa4fd7b59918d
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: fdbb4587bcc2b1f07c0070e7b2d8f83a3d5f76e1
+  Yoga: 2b1bd30acc9239a612feef50886ca9bd8b313abc
 
 PODFILE CHECKSUM: 3957102092bb49bb662ae384e29ce5c5a237f6a6
 

--- a/template/package.json
+++ b/template/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "18.2.0",
-    "react-native-macos": "0.71.32"
+    "react-native-macos": "0.71.33"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## TL;DR

I made an error, and now the 0.71-stable NPM package & Github branch are out of sync in package versions. This PR rectifies that. 

## Longer Explanation

As it turns out, with my admin privileges, I can push directly to the repos' `0.71-stable` branch. This led to this unfortunate set of events:

1) I accidentally committed directly to `0.71-stable` with https://github.com/microsoft/react-native-macos/commit/3770a1ae8e80a42d6d34c8902f029d73c859e7b9, which caused the publish pipeline to run.
2) I tried to fix this issue by changing settings so that _nobody_ could push a commit to a `*-stable` branch. 
3) Unfortunately, that meant that even `rnbot` (the bot that publishes to NPM for us and pushes the version update back to Github) couldn't push to the branch, and the [publish pipeline job](https://office.visualstudio.com/ISS/_build/results?buildId=22143878&view=logs&j=6bb1d585-fe16-5108-3aa2-8096d3b89a29) succeeded in publishing to NPM, but not back to Github

Result: NPM has `0.71.33`, while our repo only has `0.71.32`. We can fix this by just manually bumping the version in Github ourselves, and adding `***NO_CI***` to the merged commit so that the publish pipeline doesn't run again.