### PR TITLE
Specify PROJECT_ROOT in rn-tester yarn start script

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/rn-tester"
   },
   "scripts": {
-    "start": "../react-native/scripts/packager.sh",
+    "start": "PROJECT_ROOT=. ../react-native/scripts/packager.sh",
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

RNTester's `yarn start` needs to specify its `PROJECT_ROOT` due to how the repo is structured.

## Changelog

[INTERNAL] [FIXED] - Specify PROJECT_ROOT in rn-tester yarn start script

## Test Plan

Launched RNTester using the bundler from `yarn start`, and it works.
