### PR TITLE
Run packager from correct folder (cherry-pick of 40f816d)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "outputName": "js-test-results.xml"
   },
   "scripts": {
-    "start": "react-native start",
+    "start": "cd packages/rn-tester && npm run start",
+    "android": "cd packages/rn-tester && npm run android",
     "test": "jest",
     "test-ci": "jest --maxWorkers=2 --ci --reporters=\"default\" --reporters=\"jest-junit\"",
     "flow": "flow",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -11,7 +11,8 @@
     "directory": "packages/rn-tester"
   },
   "scripts": {
-    "start": "../react-native/scripts/packager.sh",
+    "start": "react-native start",
+    "android": "react-native run-android --mode HermesDebug --appId 'com.facebook.react.uiapp' --main-activity 'com.facebook.react.uiapp.RNTesterActivity'",
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -29,5 +29,8 @@ module.exports = {
     ios: {
       sourceDir: '.',
     },
+    android: {
+      sourceDir: '../../',
+    },
   },
 };


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This is an alternative to #1910 where we cherry-pick a commit from upstream that fixes the problem in a slightly different way.

This ensures that `PROJECT_ROOT` has the correct value so the JS bundler knows how to resolve things properly.

## Changelog

[INTERNAL] [FIXED] - Specify PROJECT_ROOT in rn-tester yarn start script

## Test Plan

Launched RNTester using the bundler from `yarn start`, and it works.
