### PR TITLE
Publishing pipeline fixes

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -83,7 +83,7 @@ jobs:
         displayName: Actual NPM Publish
         inputs:
           script: |
-            npm publish --tag $(npmDistTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+            npm publish packages/react-native --tag $(npmDistTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
 
       # Set the git tag and push the version update back to Github
 

--- a/change/@react-native-mac-virtualized-lists-502c73bf-9001-46d1-9d12-648b6fd90294.json
+++ b/change/@react-native-mac-virtualized-lists-502c73bf-9001-46d1-9d12-648b6fd90294.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Manually bump virtualized-lists to 0.72.0",
-  "packageName": "@react-native-mac/virtualized-lists",
-  "email": "adgleitm@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -88,7 +88,7 @@
     "@react-native/gradle-plugin": "^0.72.5",
     "@react-native/js-polyfills": "^0.72.1",
     "@react-native/normalize-colors": "^0.72.0",
-    "@react-native-mac/virtualized-lists": "^0.72.0-0",
+    "@react-native-mac/virtualized-lists": "^0.72.0",
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "base64-js": "^1.1.2",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-mac/virtualized-lists",
-  "version": "0.72.0-0",
+  "version": "0.72.0",
   "description": "Virtualized lists for React Native macOS.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

After #1914, we had several issues with our publishing script.
* beachball unexpectedly tried to bump and publish react-native-macos from the main branch.
* The canary publish failed because we moved the core bits of react-native-macos to a new location.

While we don't have a full fix for the first issue yet, we can at least finish the job and bump all the relevant version numbers as needed.

The second issue gets resolved by 847315f.

## Changelog

[INTERNAL] [FIXED] - Fix publishing pipeline issues

## Test Plan

As long as our publishing pipeline holds up, we should be good.