### PR TITLE
Fix scope and path names for publish pipeline

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -83,7 +83,7 @@ jobs:
         displayName: Actual NPM Publish
         inputs:
           script: |
-            npm publish packages/react-native --tag $(npmDistTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+            npm publish ./packages/react-native --tag $(npmDistTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
 
       # Set the git tag and push the version update back to Github
 
@@ -115,7 +115,7 @@ jobs:
       
 
   - job: RNMacOSInitNpmJSPublish
-    displayName: NPM Publish react-native-macos-init
+    displayName: NPM Publish beachball packages (e.g., react-native-macos-init)
     pool: cxeiss-ubuntu-20-04-large
     timeoutInMinutes: 90 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
@@ -152,10 +152,10 @@ jobs:
           script: echo "This code is tested as part of an integration test. See the 'Verify react-native-macos-init' task."
 
       - task: CmdLine@2
-        displayName: "Publish react-native-macos-init to npmjs.org"
+        displayName: "Publish beachball packages to npmjs.org"
         inputs:
           script: |
-            npx beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --access public
+            npx beachball publish --scope '!packages/react-native' --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --access public
 
       # beachball modifies the package.json files so run manifest generation after it.
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

This is a follow-up to #1919 and addresses three things:

* Change some display names in our beachball publish pipeline so they line up with their newly generalized roles.
* Remove `packages/react-native` from the beachball publish scope so we don't try to publish it from the main branch. (Note that the beachball publish pipeline only gets run from the main branch.)
* Be explicit about the local file path that we publish react-native-macos from. (For some strange reason, `npm` was trying to interpret the original as a GitHub username and repository.)

## Changelog

[INTERNAL] [FIXED] - More pipeline fixes

## Test Plan

Running `npm publish packages/react-native --dry-run` locally results in this weird error:
> npm ERR! code 128
npm ERR! An unknown git error occurred
npm ERR! command git --no-replace-objects ls-remote ssh://git@github.com/packages/react-native.git
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
npm ERR! 
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.

Running `npm publish ./packages/react-native --dry-run` locally results in this, which is closer to what we want:
> ...
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
...