### PR TITLE
Bring in RNCore's 0.72-stable changes to virtualized-lists

### DIFF
--- a/change/@react-native-mac-virtualized-lists-8dd7db33-b2cf-4f5c-b6e0-ca0ec377402a.json
+++ b/change/@react-native-mac-virtualized-lists-8dd7db33-b2cf-4f5c-b6e0-ca0ec377402a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bring in 0.72-stable changes to virtualized-lists",
+  "packageName": "@react-native-mac/virtualized-lists",
+  "email": "adgleitm@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
@@ -113,6 +113,7 @@ exports[`FlatList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header />

--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
@@ -243,6 +243,7 @@ exports[`SectionList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -65,6 +65,7 @@ exports[`VirtualizedList forwards correct stickyHeaderIndices when ListHeaderCom
 >
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <Header />
@@ -1013,6 +1014,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   getItemLayout={[Function]}
   invertStickyHeaders={true}
   inverted={true}
+  isInvertedVirtualizedList={true}
   keyExtractor={[Function]}
   onContentSizeChange={[Function]}
   onLayout={[Function]}
@@ -1048,6 +1050,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
       style={
         Object {
@@ -1249,6 +1252,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
 >
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header />
@@ -1834,45 +1838,12 @@ exports[`adjusts render area with non-zero initialScrollIndex 1`] = `
       />
     </View>
     <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={15}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={16}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={17}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={18}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={19}
-      />
-    </View>
+      style={
+        Object {
+          "height": 50,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
@@ -3122,9 +3093,565 @@ exports[`gracefully handles negative initialScrollIndex 1`] = `
       />
     </View>
     <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={5}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={6}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={7}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={8}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={9}
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`handles maintainVisibleContentPosition 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+      Object {
+        "key": 10,
+      },
+      Object {
+        "key": 11,
+      },
+      Object {
+        "key": 12,
+      },
+      Object {
+        "key": 13,
+      },
+      Object {
+        "key": 14,
+      },
+      Object {
+        "key": 15,
+      },
+      Object {
+        "key": 16,
+      },
+      Object {
+        "key": 17,
+      },
+      Object {
+        "key": 18,
+      },
+      Object {
+        "key": 19,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={1}
+  maintainVisibleContentPosition={
+    Object {
+      "minIndexForVisible": 0,
+    }
+  }
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  windowSize={1}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={0}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={1}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={2}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={3}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
       style={
         Object {
-          "height": 60,
+          "height": 150,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`handles maintainVisibleContentPosition 2`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 20,
+      },
+      Object {
+        "key": 21,
+      },
+      Object {
+        "key": 22,
+      },
+      Object {
+        "key": 23,
+      },
+      Object {
+        "key": 24,
+      },
+      Object {
+        "key": 25,
+      },
+      Object {
+        "key": 26,
+      },
+      Object {
+        "key": 27,
+      },
+      Object {
+        "key": 28,
+      },
+      Object {
+        "key": 29,
+      },
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+      Object {
+        "key": 10,
+      },
+      Object {
+        "key": 11,
+      },
+      Object {
+        "key": 12,
+      },
+      Object {
+        "key": 13,
+      },
+      Object {
+        "key": 14,
+      },
+      Object {
+        "key": 15,
+      },
+      Object {
+        "key": 16,
+      },
+      Object {
+        "key": 17,
+      },
+      Object {
+        "key": 18,
+      },
+      Object {
+        "key": 19,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={1}
+  maintainVisibleContentPosition={
+    Object {
+      "minIndexForVisible": 0,
+    }
+  }
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  windowSize={1}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={20}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 90,
+        }
+      }
+    />
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={0}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={1}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={2}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={3}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 150,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`handles maintainVisibleContentPosition 3`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 20,
+      },
+      Object {
+        "key": 21,
+      },
+      Object {
+        "key": 22,
+      },
+      Object {
+        "key": 23,
+      },
+      Object {
+        "key": 24,
+      },
+      Object {
+        "key": 25,
+      },
+      Object {
+        "key": 26,
+      },
+      Object {
+        "key": 27,
+      },
+      Object {
+        "key": 28,
+      },
+      Object {
+        "key": 29,
+      },
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+      Object {
+        "key": 10,
+      },
+      Object {
+        "key": 11,
+      },
+      Object {
+        "key": 12,
+      },
+      Object {
+        "key": 13,
+      },
+      Object {
+        "key": 14,
+      },
+      Object {
+        "key": 15,
+      },
+      Object {
+        "key": 16,
+      },
+      Object {
+        "key": 17,
+      },
+      Object {
+        "key": 18,
+      },
+      Object {
+        "key": 19,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={1}
+  maintainVisibleContentPosition={
+    Object {
+      "minIndexForVisible": 0,
+    }
+  }
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  windowSize={1}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={20}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 80,
+        }
+      }
+    />
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={29}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={0}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={1}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={2}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={3}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 150,
         }
       }
     />
@@ -4072,21 +4599,12 @@ exports[`renders new items when data is updated with non-zero initialScrollIndex
       />
     </View>
     <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={2}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={3}
-      />
-    </View>
+      style={
+        Object {
+          "height": 20,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
@@ -796,6 +796,7 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
   getItemLayout={[Function]}
   invertStickyHeaders={true}
   inverted={true}
+  isInvertedVirtualizedList={true}
   keyExtractor={[Function]}
   onContentSizeChange={[Function]}
   onLayout={[Function]}
@@ -831,6 +832,7 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
       style={
         Object {
@@ -1056,6 +1058,7 @@ exports[`VirtualizedSectionList renders empty list with empty component 1`] = `
 >
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header />

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -22,8 +22,7 @@
     "react-test-renderer": "18.2.0"
   },
   "peerDependencies": {
-    "react-native": "*",
-    "react-test-renderer": "18.2.0"
+    "react-native": "*"
   },
   "beachball": {
     "shouldPublish": true


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

This is a manual cherry-pick of the changes that #1927 makes to `@react-native-mac/virtualized-lists`. This was done by running `git show 0.72-rest:path/to/relevant/file > path/to/relevant/file` for all files that were updated. (For reference, `0.72-rest` is the name of the branch that #1927 is operating from.)

By applying them to the main branch, our publish pipeline will be able to release a new version for consumption in `0.72-stable`.

## Changelog

[GENERAL] [FIXED] - Bring in RNCore's 0.72-stable changes to virtualized-lists

## Test Plan

Our CI cases should still pass.
