### PR TITLE
Use correct package.json file when publishing new versions

### DIFF
--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -4,7 +4,7 @@ const path = require("path");
 const semver = require('semver');
 const {execSync} = require('child_process');
 
-const pkgJsonPath = path.resolve(__dirname, "../package.json");
+const pkgJsonPath = path.resolve(__dirname, "../packages/react-native/package.json");
 let publishBranchName = '';
 try {
   publishBranchName = process.env.BUILD_SOURCEBRANCH.match(/refs\/heads\/(.*)/)[1];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Our ADO pipeline didn't get the news that the package.json file with the right version information now lives in a new spot.

## Changelog

[INTERNAL] [FIXED] - Use correct package.json file when publishing new versions

## Test Plan

This only affects the publishing pipeline. We'll know when this gets checked in.
