### PR TITLE
Fix one more package.json path

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -89,7 +89,7 @@ const shortCommit = currentCommit.slice(0, 9);
 
 // [macOS] Function to get our version from package.json instead of the CircleCI build tag.
 function getPkgJsonVersion() {
-  const pkgJsonPath = path.resolve(__dirname, '../package.json');
+  const pkgJsonPath = path.resolve(RN_PACKAGE_DIR, 'package.json');
   const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
   const pkgJsonVersion = pkgJson.version;
   return pkgJsonVersion;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

Yet another path that needs to be fixed.

## Changelog

[INTERNAL] [FIXED] - Pipeline fixes

## Test Plan

Ran the script and confirmed that it pointed to the correct package.json file.