### PR TITLE
Pull in a few pipeline fixes from 0.72-stable

### DIFF
--- a/.ado/apple-integration.yml
+++ b/.ado/apple-integration.yml
@@ -40,6 +40,7 @@ jobs:
           echo "##vso[task.setvariable variable=rncli_android_version]$(cat package.json | jq '.dependencies."@react-native-community/cli-platform-android"')"
           echo "##vso[task.setvariable variable=rncli_ios_version]$(cat package.json | jq '.dependencies."@react-native-community/cli-platform-ios"')"
         displayName: 'Determine react-native-macos version'
+        workingDirectory: packages/react-native
       - bash: |
           npm pack ./packages/react-native
         displayName: 'Pack react-native-macos'

--- a/.ado/get-next-semver-version.js
+++ b/.ado/get-next-semver-version.js
@@ -10,16 +10,14 @@ function getNextVersion(patchVersionPrefix) {
 
     const prerelease = semver.prerelease(releaseVersion);
 
-    if (!prerelease) {
+    if (!prerelease || prerelease[0] === 'ready') {
       if (patchVersionPrefix) {
         releaseVersion = semver.inc(releaseVersion, 'prerelease', patchVersionPrefix);
       }
       else {
-      releaseVersion = semver.inc(releaseVersion, 'patch');
+        releaseVersion = semver.inc(releaseVersion, 'patch');
       }
-    }
-
-    if (prerelease) {
+    } else {
       releaseVersion = semver.inc(releaseVersion, 'prerelease');
       if (patchVersionPrefix) {
         releaseVersion = releaseVersion.replace(`-${prerelease[0]}.`, `-${prerelease[0]}-${patchVersionPrefix}.`);

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -9,8 +9,6 @@ trigger:
     include:
       - main
       - '*-stable'
-    exclude:
-      - 0.72-stable
   paths:
     exclude:
       - package.json

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -4,7 +4,7 @@ const path = require("path");
 const semver = require('semver');
 const {execSync} = require('child_process');
 
-const pkgJsonPath = path.resolve(__dirname, "../package.json");
+const pkgJsonPath = path.resolve(__dirname, "../packages/react-native/package.json");
 let publishBranchName = '';
 try {
   publishBranchName = process.env.BUILD_SOURCEBRANCH.match(/refs\/heads\/(.*)/)[1];

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -69,5 +69,17 @@ The Publish flow does the following:
       3. Call `prepare-package-for-release` to bump versions, tag the commit, and push to git
       4. Call `publish-npm` to publish to NPM the version that was just tagged. 
 4. Generate the correct NPM `dist-tag` and publish to NPM
-5. Commit all changed files and push back to Github 
+5. Commit all changed files and push back to Github
 
+### Publishing New Versions
+
+Each minor version publishes out of its own branch (e.g., 0.71-stable for react-native-macos 0.71.x). In order to ensure initial releases are properly versioned, we have a special prerelease name called `ready`. This will tell our `get-next-semver-version` script that we're ready to release the next version.
+
+We do this so that our first release will have a proper patch version of 0, as shown by this snippet from an interactive Node.js console:
+
+```js
+> semver.inc('0.72.0', 'patch')
+'0.72.1' // Not ideal
+> semver.inc('0.72.0-ready', 'patch')
+'0.72.0' // Better!
+```

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -23,6 +23,40 @@ module.exports = {
       projectConfig: android.projectConfig,
       dependencyConfig: android.dependencyConfig,
     },
+    macos: {
+      linkConfig: () => {
+        return {
+          isInstalled: (
+            _projectConfig /*ProjectConfig*/,
+            _package /*string*/,
+            _dependencyConfig /*DependencyConfig*/,
+          ) => false /*boolean*/,
+          register: (
+            _package /*string*/,
+            _dependencyConfig /*DependencyConfig*/,
+            _obj /*Object*/,
+            _projectConfig /*ProjectConfig*/,
+          ) => {},
+          unregister: (
+            _package /*string*/,
+            _dependencyConfig /*DependencyConfig*/,
+            _projectConfig /*ProjectConfig*/,
+            _dependencyConfigs /*Array<DependencyConfig>*/,
+          ) => {},
+          copyAssets: (
+            _assets /*string[]*/,
+            _projectConfig /*ProjectConfig*/,
+          ) => {},
+          unlinkAssets: (
+            _assets /*string[]*/,
+            _projectConfig /*ProjectConfig*/,
+          ) => {},
+        };
+      },
+      projectConfig: () => null,
+      dependencyConfig: () => null,
+      npmPackageName: 'react-native-macos',
+    },
   },
   reactNativePath: '../react-native',
   project: {

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -23,6 +23,7 @@ module.exports = {
       projectConfig: android.projectConfig,
       dependencyConfig: android.dependencyConfig,
     },
+    // [macOS
     macos: {
       linkConfig: () => {
         return {
@@ -57,6 +58,7 @@ module.exports = {
       dependencyConfig: () => null,
       npmPackageName: 'react-native-macos',
     },
+    // macOS]
   },
   reactNativePath: '../react-native',
   project: {

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -87,7 +87,7 @@ const shortCommit = currentCommit.slice(0, 9);
 
 // [macOS] Function to get our version from package.json instead of the CircleCI build tag.
 function getPkgJsonVersion() {
-  const pkgJsonPath = path.resolve(__dirname, '../package.json');
+  const pkgJsonPath = path.resolve(RN_PACKAGE_DIR, 'package.json');
   const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
   const pkgJsonVersion = pkgJson.version;
   return pkgJsonVersion;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

When getting 0.72 ready for release, we had to make a few changes to our publishing pipeline to account for the new monorepo. This brings those changes over.

Here's a list of changes we're cherry-picking along with a description of what they do and how they affect the main branch:
* 174eff58871dc971a5b7c3b8f87af856ac7d1cc0 - Enables publishing from 0.72-stable, has no effect on the main branch
* 362af5c8555207fae1c2b303523451eed0b31a8d - Hardening up of react-native-test-app integration pipeline
* a3bb438f049a87b1d6115820fb7dfb48c061ce2a - Fix to RNTester config - may not be necessary right now, but we will need it eventually
* f5d699e6920dd4d1e2779ab1e2710fdd767b38e4 - Fixes path to correct package.json file, doesn't affect main branch because both RN and the monorepo are at 1000.0.0
* f35615961881f810355599ee169bfc165c1832b9 - Only applies to prereleases, irrelevant on main branch
* 9aa3d07dc201a1ab95443952f4b46c88e530b955 - Fixes path to correct package.json file, doesn't affect main branch because both RN and the monorepo are at 1000.0.0

## Changelog

[INTERNAL] [FIXED] - Pipeline fixes

## Test Plan

See list of commits cherry-picked above. If the CIs pass, we should be good.
