### PR TITLE
Move `transform3D` property from `RCTView` to `RCTUIView`

### DIFF
--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -123,6 +123,12 @@ NS_ASSUME_NONNULL_END
 
 #import <AppKit/AppKit.h>
 
+#import <React/RCTComponent.h>
+
+// We use a forward declaration because importing RCTHandledKey.h would introduce an import cycle:
+// RCTUIKit > RCTHandledKey > RCTConvert > RCTUIKit
+@class RCTHandledKey;
+
 NS_ASSUME_NONNULL_BEGIN
 
 //
@@ -416,6 +422,42 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
  * Specifies whether focus ring should be drawn when the view has the first responder status.
  */
 @property (nonatomic, assign) BOOL enableFocusRing;
+
+#if TARGET_OS_OSX // [macOS
+// macOS Properties
+
+// We purposely don't use RCTCursor for the parameter type here because it would introduce an import cycle:
+// RCTUIKit > RCTCursor > RCTConvert > RCTUIKit
+@property (nonatomic, assign) NSInteger cursor;
+
+@property (nonatomic, assign) CATransform3D transform3D;
+
+// `allowsVibrancy` is readonly on NSView, so let's create a new property to make it assignable
+// that we can set through JS and the getter for `allowsVibrancy` can read in RCTView.
+@property (nonatomic, assign) BOOL allowsVibrancyInternal;
+
+@property (nonatomic, copy) RCTDirectEventBlock onMouseEnter;
+@property (nonatomic, copy) RCTDirectEventBlock onMouseLeave;
+@property (nonatomic, copy) RCTDirectEventBlock onDragEnter;
+@property (nonatomic, copy) RCTDirectEventBlock onDragLeave;
+@property (nonatomic, copy) RCTDirectEventBlock onDrop;
+
+// Keyboarding events
+// NOTE does not properly work with single line text inputs (most key downs). This is because those are
+// presumably handled by the window's field editor. To make it work, we'd need to look into providing
+// a custom field editor for NSTextField controls.
+@property (nonatomic, assign) BOOL passthroughAllKeyEvents;
+@property (nonatomic, copy) RCTDirectEventBlock onKeyDown;
+@property (nonatomic, copy) RCTDirectEventBlock onKeyUp;
+@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysDown;
+@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysUp;
+
+// Shadow Properties
+@property (nonatomic, strong) NSColor* _Nullable shadowColor;
+@property (nonatomic, assign) CGFloat shadowOpacity;
+@property (nonatomic, assign) CGFloat shadowRadius;
+@property (nonatomic, assign) CGSize shadowOffset;
+#endif // macOS]
 
 @end
 

--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -123,12 +123,6 @@ NS_ASSUME_NONNULL_END
 
 #import <AppKit/AppKit.h>
 
-#import <React/RCTComponent.h>
-
-// We use a forward declaration because importing RCTHandledKey.h would introduce an import cycle:
-// RCTUIKit > RCTHandledKey > RCTConvert > RCTUIKit
-@class RCTHandledKey;
-
 NS_ASSUME_NONNULL_BEGIN
 
 //
@@ -425,38 +419,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 #if TARGET_OS_OSX // [macOS
 // macOS Properties
-
-// We purposely don't use RCTCursor for the parameter type here because it would introduce an import cycle:
-// RCTUIKit > RCTCursor > RCTConvert > RCTUIKit
-@property (nonatomic, assign) NSInteger cursor;
-
 @property (nonatomic, assign) CATransform3D transform3D;
-
-// `allowsVibrancy` is readonly on NSView, so let's create a new property to make it assignable
-// that we can set through JS and the getter for `allowsVibrancy` can read in RCTView.
-@property (nonatomic, assign) BOOL allowsVibrancyInternal;
-
-@property (nonatomic, copy) RCTDirectEventBlock onMouseEnter;
-@property (nonatomic, copy) RCTDirectEventBlock onMouseLeave;
-@property (nonatomic, copy) RCTDirectEventBlock onDragEnter;
-@property (nonatomic, copy) RCTDirectEventBlock onDragLeave;
-@property (nonatomic, copy) RCTDirectEventBlock onDrop;
-
-// Keyboarding events
-// NOTE does not properly work with single line text inputs (most key downs). This is because those are
-// presumably handled by the window's field editor. To make it work, we'd need to look into providing
-// a custom field editor for NSTextField controls.
-@property (nonatomic, assign) BOOL passthroughAllKeyEvents;
-@property (nonatomic, copy) RCTDirectEventBlock onKeyDown;
-@property (nonatomic, copy) RCTDirectEventBlock onKeyUp;
-@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysDown;
-@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysUp;
-
-// Shadow Properties
-@property (nonatomic, strong) NSColor* _Nullable shadowColor;
-@property (nonatomic, assign) CGFloat shadowOpacity;
-@property (nonatomic, assign) CGFloat shadowRadius;
-@property (nonatomic, assign) CGSize shadowOffset;
 #endif // macOS]
 
 @end

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -246,7 +246,6 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
     self->_enableFocusRing = YES;
     self->_mouseDownCanMoveWindow = YES;
     self->_transform3D = CATransform3DIdentity;
-    self->_shadowColor = nil;
   }
   return self;
 }

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -245,6 +245,8 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
     self->_userInteractionEnabled = YES;
     self->_enableFocusRing = YES;
     self->_mouseDownCanMoveWindow = YES;
+    self->_transform3D = CATransform3DIdentity;
+    self->_shadowColor = nil;
   }
   return self;
 }

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -155,6 +155,39 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOver;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOut;
 
+#if TARGET_OS_OSX // [macOS
+/**
+ * macOS Properties
+ */
+@property (nonatomic, assign) RCTCursor cursor;
+
+// `allowsVibrancy` is readonly on NSView, so let's create a new property to make it assignable
+// that we can set through JS and the getter for `allowsVibrancy` can read in RCTView.
+@property (nonatomic, assign) BOOL allowsVibrancyInternal;
+
+@property (nonatomic, copy) RCTDirectEventBlock onMouseEnter;
+@property (nonatomic, copy) RCTDirectEventBlock onMouseLeave;
+@property (nonatomic, copy) RCTDirectEventBlock onDragEnter;
+@property (nonatomic, copy) RCTDirectEventBlock onDragLeave;
+@property (nonatomic, copy) RCTDirectEventBlock onDrop;
+
+// Keyboarding events
+// NOTE does not properly work with single line text inputs (most key downs). This is because those are
+// presumably handled by the window's field editor. To make it work, we'd need to look into providing
+// a custom field editor for NSTextField controls.
+@property (nonatomic, assign) BOOL passthroughAllKeyEvents;
+@property (nonatomic, copy) RCTDirectEventBlock onKeyDown;
+@property (nonatomic, copy) RCTDirectEventBlock onKeyUp;
+@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysDown;
+@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysUp;
+
+// Shadow Properties
+@property (nonatomic, strong) NSColor *shadowColor;
+@property (nonatomic, assign) CGFloat shadowOpacity;
+@property (nonatomic, assign) CGFloat shadowRadius;
+@property (nonatomic, assign) CGSize shadowOffset;
+#endif // macOS]
+
 /**
  * Common Focus Properties
  */

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -155,41 +155,6 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOver;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOut;
 
-#if TARGET_OS_OSX // [macOS
-/**
- * macOS Properties
- */
-@property (nonatomic, assign) RCTCursor cursor;
-
-@property (nonatomic, assign) CATransform3D transform3D;
-
-// `allowsVibrancy` is readonly on NSView, so let's create a new property to make it assignable
-// that we can set through JS and the getter for `allowsVibrancy` can read in RCTView.
-@property (nonatomic, assign) BOOL allowsVibrancyInternal;
-
-@property (nonatomic, copy) RCTDirectEventBlock onMouseEnter;
-@property (nonatomic, copy) RCTDirectEventBlock onMouseLeave;
-@property (nonatomic, copy) RCTDirectEventBlock onDragEnter;
-@property (nonatomic, copy) RCTDirectEventBlock onDragLeave;
-@property (nonatomic, copy) RCTDirectEventBlock onDrop;
-
-// Keyboarding events
-// NOTE does not properly work with single line text inputs (most key downs). This is because those are
-// presumably handled by the window's field editor. To make it work, we'd need to look into providing
-// a custom field editor for NSTextField controls.
-@property (nonatomic, assign) BOOL passthroughAllKeyEvents;
-@property (nonatomic, copy) RCTDirectEventBlock onKeyDown;
-@property (nonatomic, copy) RCTDirectEventBlock onKeyUp;
-@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysDown;
-@property (nonatomic, copy) NSArray<RCTHandledKey*> *validKeysUp;
-
-// Shadow Properties
-@property (nonatomic, strong) NSColor *shadowColor;
-@property (nonatomic, assign) CGFloat shadowOpacity;
-@property (nonatomic, assign) CGFloat shadowRadius;
-@property (nonatomic, assign) CGSize shadowOffset;
-#endif // macOS]
-
 /**
  * Common Focus Properties
  */

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -179,8 +179,6 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
     _borderStyle = RCTBorderStyleSolid;
     _hitTestEdgeInsets = UIEdgeInsetsZero;
 #if TARGET_OS_OSX // [macOS
-    _transform3D = CATransform3DIdentity;
-    _shadowColor = nil;
     _mouseDownCanMoveWindow = YES;
 #endif // macOS]
 
@@ -728,36 +726,36 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 #if TARGET_OS_OSX // [macOS
 - (void)setShadowColor:(NSColor *)shadowColor
 {
-    if (_shadowColor != shadowColor)
+    if ([super shadowColor] != shadowColor)
     {
-        _shadowColor = shadowColor;
+        [super setShadowColor:shadowColor];
         [self didUpdateShadow];
     }
 }
 
 - (void)setShadowOffset:(CGSize)shadowOffset
 {
-    if (!CGSizeEqualToSize(_shadowOffset, shadowOffset))
+    if (!CGSizeEqualToSize([super shadowOffset], shadowOffset))
     {
-        _shadowOffset = shadowOffset;
+        [super setShadowOffset:shadowOffset];
         [self didUpdateShadow];
     }
 }
 
 - (void)setShadowOpacity:(CGFloat)shadowOpacity
 {
-    if (_shadowOpacity != shadowOpacity)
+    if ([super shadowOpacity] != shadowOpacity)
     {
-        _shadowOpacity = shadowOpacity;
+        [super setShadowOpacity:shadowOpacity];
         [self didUpdateShadow];
     }
 }
 
 - (void)setShadowRadius:(CGFloat)shadowRadius
 {
-    if (_shadowRadius != shadowRadius)
+    if ([super shadowRadius] != shadowRadius)
     {
-        _shadowRadius = shadowRadius;
+        [super setShadowRadius:shadowRadius];
         [self didUpdateShadow];
     }
 }
@@ -1533,7 +1531,7 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 }
 
 - (BOOL)allowsVibrancy {
-  return _allowsVibrancyInternal;
+  return [self allowsVibrancyInternal];
 }
 
 - (NSDictionary*)locationInfoFromEvent:(NSEvent*)event

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -179,6 +179,7 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
     _borderStyle = RCTBorderStyleSolid;
     _hitTestEdgeInsets = UIEdgeInsetsZero;
 #if TARGET_OS_OSX // [macOS
+    _shadowColor = nil;
     _mouseDownCanMoveWindow = YES;
 #endif // macOS]
 
@@ -726,36 +727,36 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 #if TARGET_OS_OSX // [macOS
 - (void)setShadowColor:(NSColor *)shadowColor
 {
-    if ([super shadowColor] != shadowColor)
+    if (_shadowColor != shadowColor)
     {
-        [super setShadowColor:shadowColor];
+        _shadowColor = shadowColor;
         [self didUpdateShadow];
     }
 }
 
 - (void)setShadowOffset:(CGSize)shadowOffset
 {
-    if (!CGSizeEqualToSize([super shadowOffset], shadowOffset))
+    if (!CGSizeEqualToSize(_shadowOffset, shadowOffset))
     {
-        [super setShadowOffset:shadowOffset];
+        _shadowOffset = shadowOffset;
         [self didUpdateShadow];
     }
 }
 
 - (void)setShadowOpacity:(CGFloat)shadowOpacity
 {
-    if ([super shadowOpacity] != shadowOpacity)
+    if (_shadowOpacity != shadowOpacity)
     {
-        [super setShadowOpacity:shadowOpacity];
+        _shadowOpacity = shadowOpacity;
         [self didUpdateShadow];
     }
 }
 
 - (void)setShadowRadius:(CGFloat)shadowRadius
 {
-    if ([super shadowRadius] != shadowRadius)
+    if (_shadowRadius != shadowRadius)
     {
-        [super setShadowRadius:shadowRadius];
+        _shadowRadius = shadowRadius;
         [self didUpdateShadow];
     }
 }
@@ -1531,7 +1532,7 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 }
 
 - (BOOL)allowsVibrancy {
-  return [self allowsVibrancyInternal];
+  return _allowsVibrancyInternal;
 }
 
 - (NSDictionary*)locationInfoFromEvent:(NSEvent*)event

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -508,46 +508,46 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 8fa3cd00fa17ef6c3221e5fd283fa93e81d23017
   DoubleConversion: acaf5db79676d2e9119015819153f0f99191de12
-  FBLazyVector: 176707f924b9708f9de38acc7e1c7915904af14f
-  FBReactNativeSpec: eb3033de959a2fde373a91512917dfebd2935dc5
+  FBLazyVector: bfab2c0bc9280c8bfd781564a092af8dc4a67e56
+  FBReactNativeSpec: 43311df1a38d8a4e993f630ae0dc52eb7b7aaa9d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 6df0a3d6e2750a50609471fd1a01fd2948d405b5
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   RCT-Folly: bf7b4921a91932051ebf1c5c2d297154b1fa3c8c
-  RCTRequired: 91ae426058a0742e67790c51008cee67677ccb98
-  RCTTypeSafety: e19ab710dc6150aadb5c59726eaa396fce9b4e9b
-  React: 6070063fa11878a2a22f1928d9ef7397a60efe9d
-  React-callinvoker: bd40b272527ecc54bc8ef5441cb78c0eca434827
+  RCTRequired: 9b39aba15f4a994ef17e281fc4d24ebfb2b76066
+  RCTTypeSafety: 29b97b4e5e756b45511b99d3c8d0704f51019a90
+  React: da2281cd2bea28e9ba308fd6ab35fce2edf7aeae
+  React-callinvoker: cca8942f666421669aa586285020e6e4adaf0252
   React-Codegen: 9e4433cdb48a2cda2a1407715abcc6ef43ab097e
-  React-Core: 08d9a5d3dbec675f242f8aedf15f56017862eb9e
-  React-CoreModules: 44bb8befa85307ad4e0d2f3d4273955fc780e0a8
-  React-cxxreact: eac69ae3ebc86d94521909256dbbb924469653a4
-  React-jsc: b1d4a5f595ed7e38603209eaeb789e807729f224
-  React-jsi: 09dfc805a2e633b854c999f32821d1a7433f8b8b
-  React-jsiexecutor: 5ac94ec4e8d69f29c037aff26591034e6361a7b1
-  React-jsinspector: 0755a8109fcd376099700d3e765b00deb8d89ac7
-  React-logger: a3fe0eceb7bd48b2e0de2a5770de6efc19170831
-  React-NativeModulesApple: 51b8f7da2707101a0df5c8f78760422d2c932b0f
-  React-perflogger: 9ef26e3f3ae2c19587645dd4f6848de3665ba1db
-  React-RCTActionSheet: 88beaa583e21c399b60912447c6b0f8d00f2042e
-  React-RCTAnimation: eeb25120b9fbf56d27dce9fbac4c6d4fcad09382
-  React-RCTAppDelegate: bb56b311a4372636183f4650fb09812f5733b2cb
-  React-RCTBlob: 4653bb1de33531a8ce5b41703a3f5ece6af67b68
-  React-RCTImage: eb7b0acd6d390bd1422068f70a423c109f819120
-  React-RCTLinking: 32441c089b175f857941b62af298309c6bc09c2b
-  React-RCTNetwork: 9910b1590e17fb90f24b7167053d21b996f045bc
-  React-RCTPushNotification: ec1bdb624ace4fb3a7194075167deef484fa3a1f
-  React-RCTSettings: a9dbb00fb55303f82c7c1a7ac9fe54b6e49ffd99
-  React-RCTTest: 6f178d48f3e8c53fefc898dcb1520b30a78f8f11
-  React-RCTText: 79d9516e44548f7d99013c18000eb916b872357a
-  React-RCTVibration: ad5869da284dbaa9590ed16885b85e22bf35eb09
-  React-rncore: a74cce7b114f68391bf546dbe72785da68508f83
-  React-runtimeexecutor: d0c14905923795703276d8a95ecc65fb1d84630c
-  ReactCommon: 458af3b42d83a9c8c97f00a3cc0acba827e1b52d
-  ReactCommon-Samples: 4c1da4d7eeda914a53a40bac142ae745abf0313e
+  React-Core: 77d7114f096645ce9e2189f04e59aacef2f404e5
+  React-CoreModules: 8dcdde5ba05cd6fc233c9a202798635c81dbde72
+  React-cxxreact: b6363e4f784d64b0658f1a1f3f097485fdb289b8
+  React-jsc: ea3527da26dcd4fa2aa59723f41c469fd92179c1
+  React-jsi: 04a0a436a92ff556fe66919dc59684ddf3a78811
+  React-jsiexecutor: d28befea931848d4d2c688b0c9e57d812adad4ac
+  React-jsinspector: 2e53a1498e4e4f3f3822fb780c4aa491608e94f7
+  React-logger: 8f96626cb0e6d1c51e67693178213ec4e43f3da4
+  React-NativeModulesApple: 3f1c4ef6ced26feb43127590044d8fcb579b1cb8
+  React-perflogger: 1e3e950db4c877570e9c58bdbbba343cc6d551c4
+  React-RCTActionSheet: 74543b1c9f338b200166c1d6fa45e6bad854b437
+  React-RCTAnimation: 32384936fc55d7fea9ac1e6e37df2af4b0b3d126
+  React-RCTAppDelegate: 7417844a8b724abd5e311def8d063ce7725578a6
+  React-RCTBlob: fee42be545ffb0b9f07ba268f90a830a9815109a
+  React-RCTImage: c423ba45da6fc52071ec46e1a16faeafd67c789d
+  React-RCTLinking: ccd45cbc0bf912ba8fbed94164874ddc9c28c320
+  React-RCTNetwork: 6f7ecd45c8013893034fa63f75af485ddddf6a8a
+  React-RCTPushNotification: 43882e949070a393872d70ef4c1d8cfa5642423a
+  React-RCTSettings: c92261ca8e1248e7b408a8c908c189c3ce9d9a54
+  React-RCTTest: bf124dfa87a3ca10f650d6da501977a53528f1c4
+  React-RCTText: aee9b75482b51d95b39a6fcf2a74a041793c25fe
+  React-RCTVibration: 43c7a1c348f69e9082f61017859482e5523393be
+  React-rncore: 6f652d176e89279697337ee0685f7ab0cc99b94e
+  React-runtimeexecutor: bf2b2630738b11cd766a925d4abbad1bc2c9b54f
+  ReactCommon: ed564b6a5467a302e997337ddeeb237b3b46cf5b
+  ReactCommon-Samples: a338f161f83f32c99484df3c3c6d56902689d913
   ScreenshotManager: 84f13d11f296b960bbafd9897ba52588a42dd5ca
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: c9ce75134a86c29bf1978dcd738f922b64807f8a
+  Yoga: 4f13708a28b1657dbbee432c21523662f830c07e
 
 PODFILE CHECKSUM: 23258155130fc3ae417bc5bb12e76438f3b9a394
 

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -508,46 +508,46 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 8fa3cd00fa17ef6c3221e5fd283fa93e81d23017
   DoubleConversion: acaf5db79676d2e9119015819153f0f99191de12
-  FBLazyVector: f675a717737d719a18dffde140c984896bc103ca
-  FBReactNativeSpec: 3d185c72e95d7d08af8f30e2928565acc4675c50
+  FBLazyVector: 176707f924b9708f9de38acc7e1c7915904af14f
+  FBReactNativeSpec: eb3033de959a2fde373a91512917dfebd2935dc5
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 6df0a3d6e2750a50609471fd1a01fd2948d405b5
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   RCT-Folly: bf7b4921a91932051ebf1c5c2d297154b1fa3c8c
-  RCTRequired: 23818f8d69af159020a96677b959bb4bc42c5597
-  RCTTypeSafety: 0cd48401b30208bf9424f75b843f81b6fa834599
-  React: 4899eeb992e17d0efdc75757688adc372233ee03
-  React-callinvoker: 974f861054f2802e20909a358232e6d4eaa89e8d
+  RCTRequired: 91ae426058a0742e67790c51008cee67677ccb98
+  RCTTypeSafety: e19ab710dc6150aadb5c59726eaa396fce9b4e9b
+  React: 6070063fa11878a2a22f1928d9ef7397a60efe9d
+  React-callinvoker: bd40b272527ecc54bc8ef5441cb78c0eca434827
   React-Codegen: 9e4433cdb48a2cda2a1407715abcc6ef43ab097e
-  React-Core: 75ccd5ea1dfba94396fe7f42d742b5fad316833f
-  React-CoreModules: c0dae5bd3bfc71d4b9a1a396995e0a96aaea8c38
-  React-cxxreact: f80b96e7ede70dc713f278f801870941df15e482
-  React-jsc: fe34e7cb127ee24c524c0ae0fc4f50f59b815c3c
-  React-jsi: 3c8e8e5571b4616ef87e1741d300340ae3c2bf92
-  React-jsiexecutor: 1a26e4c29fa910dce2383029c746db6ec333665d
-  React-jsinspector: 49ece915ffdb72b97bf7e734ba5dd8d8f1f52cd4
-  React-logger: bd582ff5f4803ed308b57b897b86f48c9ee0c082
-  React-NativeModulesApple: 127aed47c8018865681694fd5cf0857953ae34c7
-  React-perflogger: 73bfde53a5ad9f25c87b12c0f189f5e8501e027d
-  React-RCTActionSheet: 5a5189b2896f1ddd6a0dbaa80ecc09470ba9066a
-  React-RCTAnimation: 61bc6807c9ed65a18384c47b9cf4cccd26ead593
-  React-RCTAppDelegate: 7f97426e3f42629bf58ca4dae9f8495b0fa2f165
-  React-RCTBlob: b678eb7c0e4c24aa496bc9d6ad5d33862c2524e7
-  React-RCTImage: 6b8a3679ff1b8a0a9cbe95373b6b55b705fedd1b
-  React-RCTLinking: 838cfa436d2baf8a92d5ca65d86483a973170f53
-  React-RCTNetwork: 4ba93f65f99209fec7881178b96399722df153fd
-  React-RCTPushNotification: c5ca40c92fc69c61b3d4eb12565426688095c493
-  React-RCTSettings: ebf15e8fea9e2b900145fba0370a06ffd71662b6
-  React-RCTTest: f80d4874ac6926abf0f69cccffad9c932e8c8b2f
-  React-RCTText: e3bb643877f6da844c60186176153548bdfcd259
-  React-RCTVibration: fffcc22fb9eaa8e37a4c92468324aa31d2c9df9d
-  React-rncore: 7afbb7d475c177a67c597613d39d4ba2d47d50b1
-  React-runtimeexecutor: 88a93791d15040cef31b87c025715b006ac7970f
-  ReactCommon: ede267cba0b9b4414fd4b8143912240ed5bf8e35
-  ReactCommon-Samples: 96daa3326279837fc934ac35a57c0a7bb8322bfa
+  React-Core: 08d9a5d3dbec675f242f8aedf15f56017862eb9e
+  React-CoreModules: 44bb8befa85307ad4e0d2f3d4273955fc780e0a8
+  React-cxxreact: eac69ae3ebc86d94521909256dbbb924469653a4
+  React-jsc: b1d4a5f595ed7e38603209eaeb789e807729f224
+  React-jsi: 09dfc805a2e633b854c999f32821d1a7433f8b8b
+  React-jsiexecutor: 5ac94ec4e8d69f29c037aff26591034e6361a7b1
+  React-jsinspector: 0755a8109fcd376099700d3e765b00deb8d89ac7
+  React-logger: a3fe0eceb7bd48b2e0de2a5770de6efc19170831
+  React-NativeModulesApple: 51b8f7da2707101a0df5c8f78760422d2c932b0f
+  React-perflogger: 9ef26e3f3ae2c19587645dd4f6848de3665ba1db
+  React-RCTActionSheet: 88beaa583e21c399b60912447c6b0f8d00f2042e
+  React-RCTAnimation: eeb25120b9fbf56d27dce9fbac4c6d4fcad09382
+  React-RCTAppDelegate: bb56b311a4372636183f4650fb09812f5733b2cb
+  React-RCTBlob: 4653bb1de33531a8ce5b41703a3f5ece6af67b68
+  React-RCTImage: eb7b0acd6d390bd1422068f70a423c109f819120
+  React-RCTLinking: 32441c089b175f857941b62af298309c6bc09c2b
+  React-RCTNetwork: 9910b1590e17fb90f24b7167053d21b996f045bc
+  React-RCTPushNotification: ec1bdb624ace4fb3a7194075167deef484fa3a1f
+  React-RCTSettings: a9dbb00fb55303f82c7c1a7ac9fe54b6e49ffd99
+  React-RCTTest: 6f178d48f3e8c53fefc898dcb1520b30a78f8f11
+  React-RCTText: 79d9516e44548f7d99013c18000eb916b872357a
+  React-RCTVibration: ad5869da284dbaa9590ed16885b85e22bf35eb09
+  React-rncore: a74cce7b114f68391bf546dbe72785da68508f83
+  React-runtimeexecutor: d0c14905923795703276d8a95ecc65fb1d84630c
+  ReactCommon: 458af3b42d83a9c8c97f00a3cc0acba827e1b52d
+  ReactCommon-Samples: 4c1da4d7eeda914a53a40bac142ae745abf0313e
   ScreenshotManager: 84f13d11f296b960bbafd9897ba52588a42dd5ca
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: d322d4a205e5fbc90fc64e7b9af8ef316e2a5338
+  Yoga: c9ce75134a86c29bf1978dcd738f922b64807f8a
 
 PODFILE CHECKSUM: 23258155130fc3ae417bc5bb12e76438f3b9a394
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

We've received reports of the following red box in react-native-svg:

`-[RNSVGSvgView setTransform3D:]: unrecognized selector sent to instance <address>`

The reason for this is because of the following inheritance chain:
* **iOS**: `RNSVGSvgView` (subclass of) `RNSVGView` (#defined as) `UIView`
* **macOS**: `RNSVGSvgView` (subclass of) `RNSVGView` (subclass of) `RCTUIView` (subclass of) `RCTPlatformView` (#defined as) `NSView`

`transform3D` exists on `UIView`, but it doesn't exist on `NSView`, so we previously implemented it on `RCTView`, which is a separate subclass of `RCTUIView`. However, `RCTView` (like its counterpart in RNCore) is meant to augment the default OS-level view with RN-specific functionality, while `RCTUIView` (which is exclusive to react-native-macos) is meant to add `UIView`-like features that don't already exist on `NSView`.

By this logic, `transform3D` should really be at the `RCTUIView` level.

### Other Notes

There are a couple of other cases in RNTester-macOS that have similar problems with their inheritance chains:
* FlatList > Basic, which has a problem with `-[RCTSwitch setTransform3D:]`
  * **iOS**: `RCTSwitch` (subclass of) `UISwitch` (subclass of) `UIControl` (subclass of) **`UIView`** ✅
  * **macOS**: `RCTSwitch` (subclass of) `RCTUISwitch` (subclass of) `NSSwitch`, doesn't pass through `RCTUIView` ❌
* Accessibility, which has a problem with `-[RCTTextView setOnKeyUp:]`
  * **iOS**: `RCTTextView` (subclass of) `UIView` ✅
  * **macOS**: `RCTSwitch` (subclass of) `RCTUIView` (subclass of) `RCTPlatformView` (#defined as) `NSView`, doesn't pass through `RCTView` ❌

These require further discussions about how different control views are inherited. These could presumably be fixed by wrapping said control views in a `View` of their own, but this is an awkward experience that ought to be avoidable. We should discuss these at a later time, but this fix on its own still has merit.

## Changelog

[MACOS] [FIXED] - `transform3D` is now a property of `RCTUIView`

## Test Plan

a524840 fixes the issue on the Accessibility page, but that change is arguably too aggressive because of the differences between `RCTView` and `RCTUIView`. Nevertheless, this demonstrates that this solution is viable.
