### PR TITLE
[CI] Update to macOS 13 and Xcode 14.3.1

### DIFF
--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -1,4 +1,4 @@
 variables:
-  VmImageApple: internal-macos12
-  slice_name: 'Xcode_14.2'
-  xcode_version: '/Applications/Xcode_14.2.app'
+  VmImageApple: macOS-13
+  slice_name: 'Xcode_14.3.1'
+  xcode_version: '/Applications/Xcode_14.3.1.app'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

As it turns out, we can use the public Azure Pipeline VM images and stay compliant as long we set the variable `BUILDSECMON_OPT_IN`, which we do in `.ado/publish.yml`

## Changelog

[INTERNAL] [CHANGED] - Update CI to macOS 13 and Xcode 14.3.1


## Test Plan

CI should pass
