### PR TITLE
[CI] remove useRubyVersion

### DIFF
--- a/.ado/templates/apple-tools-setup.yml
+++ b/.ado/templates/apple-tools-setup.yml
@@ -3,9 +3,5 @@ steps:
     inputs:
       versionSpec: '18.x'
 
-  - task: UseRubyVersion@0
-    inputs:
-      versionSpec: '>= 2.7'
-
   - script: 'brew bundle --file .ado/Brewfile'
     displayName: 'brew bundle'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

As of https://github.com/facebook/react-native/pull/36281, React Native doesn't require a specific version of Ruby, and should work with the system default. Let's remove our CI enforcement over Ruby versions.

## Changelog

[INTERNAL] [REMOVED] - Remove Ruby version enforcement in CI

## Test Plan

CI should pass
