### PR TITLE
[Hermes] Use correct import for RCTUIKit in RCTHermesInstance.h

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // [macOS]
 
 #import <cxxreact/MessageQueueThread.h>
 #import <hermes/Public/CrashManager.h>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

- Builds w/ Hermes + New Arch were failing on 0.73-stable
`RCT_NEW_ARCH_ENABLED=1 USE_HERMES=1 bundle exec pod install`

## Changelog:

[MACOS] [FIXED] - Use correct import for RCTUIKit for RCTHermesInstance.h

## Test Plan:

RN Tester w/ Hermes enabled:
<img width="1136" alt="CleanShot 2023-10-14 at 14 42 25@2x" src="https://github.com/microsoft/react-native-macos/assets/96719/baaa1d31-6362-4aac-a7a9-975eea141f32">


