### PR TITLE
Align App Transport Security setting with rntester-ios and rntester-macOS

### DIFF
--- a/packages/rn-tester/RNTester-macOS/Info.plist
+++ b/packages/rn-tester/RNTester-macOS/Info.plist
@@ -34,6 +34,8 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

This applies the same settings as used in iOS:
https://github.com/microsoft/react-native-macos/blob/main/packages/rn-tester/RNTester/Info.plist#L38-L44

See:
https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowsarbitraryloads?language=objc

## Changelog:

Changelog: [Internal]

## Test Plan:

CircleCI
