### PR TITLE
[0.71][JSCRuntime] Add runtimeConfig to set debugger options

### DIFF
--- a/React/CxxBridge/JSCExecutorFactory.h
+++ b/React/CxxBridge/JSCExecutorFactory.h
@@ -17,12 +17,19 @@ class JSCExecutorFactory : public JSExecutorFactory {
   explicit JSCExecutorFactory(JSIExecutor::RuntimeInstaller runtimeInstaller)
       : runtimeInstaller_(std::move(runtimeInstaller)) {}
 
+  void setEnableDebugger(bool enableDebugger);
+
+  void setDebuggerName(const std::string &debuggerName);
+
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
       std::shared_ptr<MessageQueueThread> jsQueue) override;
 
  private:
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
+
+  bool enableDebugger_ = true;
+  std::string debuggerName_ = "JSC React Native";
 };
 
 } // namespace react

--- a/React/CxxBridge/JSCExecutorFactory.h
+++ b/React/CxxBridge/JSCExecutorFactory.h
@@ -17,9 +17,11 @@ class JSCExecutorFactory : public JSExecutorFactory {
   explicit JSCExecutorFactory(JSIExecutor::RuntimeInstaller runtimeInstaller)
       : runtimeInstaller_(std::move(runtimeInstaller)) {}
 
+  // [macOS
   void setEnableDebugger(bool enableDebugger);
 
   void setDebuggerName(const std::string &debuggerName);
+  // macOS]
 
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
@@ -28,8 +30,10 @@ class JSCExecutorFactory : public JSExecutorFactory {
  private:
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
 
+  // [macOS
   bool enableDebugger_ = true;
   std::string debuggerName_ = "JSC React Native";
+  // macOS]
 };
 
 } // namespace react

--- a/React/CxxBridge/JSCExecutorFactory.mm
+++ b/React/CxxBridge/JSCExecutorFactory.mm
@@ -14,6 +14,7 @@
 namespace facebook {
 namespace react {
 
+// [macOS
 void JSCExecutorFactory::setEnableDebugger(bool enableDebugger) {
   enableDebugger_ = enableDebugger;
 }
@@ -21,16 +22,19 @@ void JSCExecutorFactory::setEnableDebugger(bool enableDebugger) {
 void JSCExecutorFactory::setDebuggerName(const std::string &debuggerName) {
   debuggerName_ = debuggerName;
 }
+// macOS]
 
 std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
     std::shared_ptr<ExecutorDelegate> delegate,
     std::shared_ptr<MessageQueueThread> __unused jsQueue)
 {
+  // [macOS
   facebook::jsc::RuntimeConfig rc = {
     .enableDebugger = enableDebugger_,
     .debuggerName = debuggerName_,
   };
   return std::make_unique<JSIExecutor>(facebook::jsc::makeJSCRuntime(std::move(rc)), delegate, JSIExecutor::defaultTimeoutInvoker, runtimeInstaller_);
+  // macOS]
 }
 
 } // namespace react

--- a/React/CxxBridge/JSCExecutorFactory.mm
+++ b/React/CxxBridge/JSCExecutorFactory.mm
@@ -14,12 +14,23 @@
 namespace facebook {
 namespace react {
 
+void JSCExecutorFactory::setEnableDebugger(bool enableDebugger) {
+  enableDebugger_ = enableDebugger;
+}
+
+void JSCExecutorFactory::setDebuggerName(const std::string &debuggerName) {
+  debuggerName_ = debuggerName;
+}
+
 std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
     std::shared_ptr<ExecutorDelegate> delegate,
     std::shared_ptr<MessageQueueThread> __unused jsQueue)
 {
-  return std::make_unique<JSIExecutor>(
-      facebook::jsc::makeJSCRuntime(), delegate, JSIExecutor::defaultTimeoutInvoker, runtimeInstaller_);
+  facebook::jsc::RuntimeConfig rc = {
+    .enableDebugger = enableDebugger_,
+    .debuggerName = debuggerName_,
+  };
+  return std::make_unique<JSIExecutor>(facebook::jsc::makeJSCRuntime(std::move(rc)), delegate, JSIExecutor::defaultTimeoutInvoker, runtimeInstaller_);
 }
 
 } // namespace react

--- a/ReactCommon/jsc/JSCRuntime.cpp
+++ b/ReactCommon/jsc/JSCRuntime.cpp
@@ -314,6 +314,11 @@ class JSCRuntime : public jsi::Runtime {
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_12
 #define _JSC_NO_ARRAY_BUFFERS
 #endif
+// [macOS
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130300
+#define _JSC_HAS_INSPECTABLE
+#endif
+// macOS]
 #endif
 
 // JSStringRef utilities

--- a/ReactCommon/jsc/JSCRuntime.cpp
+++ b/ReactCommon/jsc/JSCRuntime.cpp
@@ -36,6 +36,8 @@ class JSCRuntime : public jsi::Runtime {
  public:
   // Creates new context in new context group
   JSCRuntime();
+  // Creates new context in new context group with config
+  JSCRuntime(const facebook::jsc::RuntimeConfig& rc);
   // Retains ctx
   JSCRuntime(JSGlobalContextRef ctx);
   ~JSCRuntime();
@@ -393,6 +395,17 @@ std::string to_string(void *value) {
 JSCRuntime::JSCRuntime()
     : JSCRuntime(JSGlobalContextCreateInGroup(nullptr, nullptr)) {
   JSGlobalContextRelease(ctx_);
+}
+
+JSCRuntime::JSCRuntime(const facebook::jsc::RuntimeConfig& rc)
+	: JSCRuntime() {
+#ifdef _JSC_HAS_INSPECTABLE
+  if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+    JSGlobalContextSetInspectable(ctx_, rc.enableDebugger);
+  }
+#endif
+  JSGlobalContextSetName(ctx_, JSStringCreateWithUTF8CString(rc.debuggerName.c_str()));
+
 }
 
 JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
@@ -1568,6 +1581,10 @@ void JSCRuntime::checkException(
 
 std::unique_ptr<jsi::Runtime> makeJSCRuntime() {
   return std::make_unique<JSCRuntime>();
+}
+
+std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc) {
+  return std::make_unique<JSCRuntime>(rc);
 }
 
 } // namespace jsc

--- a/ReactCommon/jsc/JSCRuntime.cpp
+++ b/ReactCommon/jsc/JSCRuntime.cpp
@@ -36,8 +36,10 @@ class JSCRuntime : public jsi::Runtime {
  public:
   // Creates new context in new context group
   JSCRuntime();
+  // [macOS
   // Creates new context in new context group with config
   JSCRuntime(const facebook::jsc::RuntimeConfig& rc);
+  // macOS]
   // Retains ctx
   JSCRuntime(JSGlobalContextRef ctx);
   ~JSCRuntime();
@@ -397,6 +399,7 @@ JSCRuntime::JSCRuntime()
   JSGlobalContextRelease(ctx_);
 }
 
+// [macOS
 JSCRuntime::JSCRuntime(const facebook::jsc::RuntimeConfig& rc)
 	: JSCRuntime() {
 #ifdef _JSC_HAS_INSPECTABLE
@@ -407,6 +410,7 @@ JSCRuntime::JSCRuntime(const facebook::jsc::RuntimeConfig& rc)
   JSGlobalContextSetName(ctx_, JSStringCreateWithUTF8CString(rc.debuggerName.c_str()));
 
 }
+// macOS]
 
 JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
     : ctx_(JSGlobalContextRetain(ctx)),
@@ -1583,9 +1587,11 @@ std::unique_ptr<jsi::Runtime> makeJSCRuntime() {
   return std::make_unique<JSCRuntime>();
 }
 
+// [macOS
 std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc) {
   return std::make_unique<JSCRuntime>(rc);
 }
+// macOS]
 
 } // namespace jsc
 } // namespace facebook

--- a/ReactCommon/jsc/JSCRuntime.h
+++ b/ReactCommon/jsc/JSCRuntime.h
@@ -13,14 +13,16 @@
 namespace facebook {
 namespace jsc {
 
+// [macOS
 struct RuntimeConfig {
   bool enableDebugger;
   std::string debuggerName;
 };
+// macOS]
 
 std::unique_ptr<jsi::Runtime> makeJSCRuntime();
 
-std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc);
+std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc); // [macOS]
 
 } // namespace jsc
 } // namespace facebook

--- a/ReactCommon/jsc/JSCRuntime.h
+++ b/ReactCommon/jsc/JSCRuntime.h
@@ -13,7 +13,14 @@
 namespace facebook {
 namespace jsc {
 
+struct RuntimeConfig {
+  bool enableDebugger;
+  std::string debuggerName;
+};
+
 std::unique_ptr<jsi::Runtime> makeJSCRuntime();
+
+std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc);
 
 } // namespace jsc
 } // namespace facebook


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

Cherry pick of https://github.com/facebook/react-native/pull/38942 and https://github.com/facebook/react-native/pull/39549 to React Native macOS. The upstream change hasn't landed yet, but we would like to use this change internally regardless.

## Changelog:

[IOS] [CHANGED] - Add facebook::jsc::runtimeConfig to set enable debugger and set debugger

## Test Plan:

Running RNTester with JSC shows the JSContext with the updated name.
