### PR TITLE
Ignore publish errors in get-and-update-nightlies

### DIFF
--- a/scripts/monorepo/get-and-update-nightlies.js
+++ b/scripts/monorepo/get-and-update-nightlies.js
@@ -127,7 +127,8 @@ function updateDependencies(
 
 /**
  * Publish the passed set of packages to npm with the `nightly` tag.
- * In case a package fails to be published, it throws an error, stopping the nightly publishing completely
+ * [macOS] In case a package fails to be published, the upstream version of this script throws an error.
+ * However, since this fork defers publishing to a separate ADO step, we just log the error and move on.
  */
 function publishPackages(packages /*: PackageMap */) {
   for (const [packageName, packageMetadata] of Object.entries(packages)) {
@@ -140,9 +141,12 @@ function publishPackages(packages /*: PackageMap */) {
     });
 
     if (result.code !== 0) {
-      throw new Error(
+      // [macOS - Our publish-npm.js script doesn't actually publish, so we shouldn't throw an error on failure
+      console.log(
         `\u274c Failed to publish version ${nightlyVersion} of ${packageName}. npm publish exited with code ${result.code}:`,
       );
+      console.error(result.stderr);
+      // macOS]
     }
 
     console.log(`\u2705 Successfully published new version of ${packageName}`);

--- a/scripts/monorepo/get-and-update-nightlies.js
+++ b/scripts/monorepo/get-and-update-nightlies.js
@@ -141,7 +141,7 @@ function publishPackages(packages /*: PackageMap */) {
     });
 
     if (result.code !== 0) {
-      // [macOS - Our publish-npm.js script doesn't actually publish, so we shouldn't throw an error on failure
+      // [macOS Our publish-npm.js script doesn't actually publish, so we shouldn't throw an error on failure
       console.log(
         `\u274c Failed to publish version ${nightlyVersion} of ${packageName}. npm publish exited with code ${result.code}:`,
       );


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

Right now, our nightly publishing pipelines are broken, which prevents our scripts from running component detection. This was caused by 52104c6ee30b8fe3e59b6be417e65d2d51cdba52, which we inherited from RNCore, and their publishing process is slightly different.

This reverts to the previous, more lenient way of checking things.

## Changelog:

[INTERNAL] [FIXED] - Fix build scripts

## Test Plan:

The spot we changed is where the error we were logging came from, so this reversion should work.