### PR TITLE
Default dimensions `scale` value to 1.0 if window is nil

### DIFF
--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -335,6 +335,9 @@ NS_INLINE NSEdgeInsets UIEdgeInsetsMake(CGFloat top, CGFloat left, CGFloat botto
 // UIApplication
 #define UIApplication NSApplication
 
+// UIWindow
+#define UIWindow NSWindow
+
 // UIImage
 @compatibility_alias UIImage NSImage;
 

--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -335,9 +335,6 @@ NS_INLINE NSEdgeInsets UIEdgeInsetsMake(CGFloat top, CGFloat left, CGFloat botto
 // UIApplication
 #define UIApplication NSApplication
 
-// UIWindow
-#define UIWindow NSWindow
-
 // UIImage
 @compatibility_alias UIImage NSImage;
 
@@ -498,8 +495,10 @@ NS_ASSUME_NONNULL_END
 
 #if !TARGET_OS_OSX
 typedef UIApplication RCTUIApplication;
+typedef UIWindow RCTUIWindow;
 #else
 typedef NSApplication RCTUIApplication;
+typedef NSWindow RCTUIWindow;
 #endif
 
 //

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -93,11 +93,11 @@ RCT_EXTERN BOOL RCTRunningInAppExtension(void);
 #endif // [macOS]
 
 // Returns the shared UIApplication instance, or nil if running in an App Extension
-RCT_EXTERN UIApplication *__nullable RCTSharedApplication(void);
+RCT_EXTERN RCTUIApplication *__nullable RCTSharedApplication(void); // [macOS]
 
 // Returns the current main window, useful if you need to access the root view
 // or view controller
-RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
+RCT_EXTERN RCTUIWindow *__nullable RCTKeyWindow(void); // [macOS]
 
 #if !TARGET_OS_OSX // [macOS]
 // Returns the presented view controller, useful if you need

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -95,11 +95,11 @@ RCT_EXTERN BOOL RCTRunningInAppExtension(void);
 // Returns the shared UIApplication instance, or nil if running in an App Extension
 RCT_EXTERN UIApplication *__nullable RCTSharedApplication(void);
 
-#if !TARGET_OS_OSX // [macOS]
 // Returns the current main window, useful if you need to access the root view
 // or view controller
 RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
 
+#if !TARGET_OS_OSX // [macOS]
 // Returns the presented view controller, useful if you need
 // e.g. to present a modal view controller or alert over it
 RCT_EXTERN UIViewController *__nullable RCTPresentedViewController(void);

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -581,7 +581,7 @@ BOOL RCTRunningInAppExtension(void)
 }
 #endif // [macOS]
 
-UIApplication *__nullable RCTSharedApplication(void)
+RCTUIApplication *__nullable RCTSharedApplication(void) // [macOS]
 {
 #if !TARGET_OS_OSX // [macOS]
   if (RCTRunningInAppExtension()) {
@@ -593,7 +593,7 @@ UIApplication *__nullable RCTSharedApplication(void)
 #endif // macOS]
 }
 
-RCTPlatformWindow *__nullable RCTKeyWindow(void) // [macOS]
+RCTUIWindow *__nullable RCTKeyWindow(void) // [macOS]
 {
 #if !TARGET_OS_OSX // [macOS]
   if (RCTRunningInAppExtension()) {

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -108,18 +108,10 @@ static BOOL RCTIsIPhoneNotched()
 }
 
 
-#if !TARGET_OS_OSX // [macOS]
-NSDictionary *RCTExportedDimensions(CGFloat fontScale)
-#else // [macOS
-static NSDictionary *RCTExportedDimensions(void)
-#endif // macOS]
+static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 {
   RCTAssertMainQueue();
-#if !TARGET_OS_OSX // [macOS]
   RCTDimensions dimensions = RCTGetDimensions(fontScale);
-#else // [macOS
-  RCTDimensions dimensions = RCTGetDimensions();
-#endif // macOS]
   __typeof(dimensions.window) window = dimensions.window;
   NSDictionary<NSString *, NSNumber *> *dimsWindow = @{
     @"width" : @(window.width),
@@ -144,12 +136,13 @@ static NSDictionary *RCTExportedDimensions(void)
   RCTAccessibilityManager *accessibilityManager =
       (RCTAccessibilityManager *)[_moduleRegistry moduleForName:"AccessibilityManager"];
   RCTAssert(accessibilityManager, @"Failed to get exported dimensions: AccessibilityManager is nil");
-  CGFloat fontScale = accessibilityManager ? accessibilityManager.multiplier : 1.0;
 #if !TARGET_OS_OSX // [macOS]
-  return RCTExportedDimensions(fontScale);
+  CGFloat fontScale = accessibilityManager ? accessibilityManager.multiplier : 1.0;
 #else // [macOS
-  return RCTExportedDimensions();
+  CGFloat fontScale = 1.0;
 #endif // macOS]
+  
+  return RCTExportedDimensions(fontScale);
 }
 
 - (NSDictionary<NSString *, id> *)constantsToExport

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -111,14 +111,14 @@ static BOOL RCTIsIPhoneNotched()
 #if !TARGET_OS_OSX // [macOS]
 NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 #else // [macOS
-static NSDictionary *RCTExportedDimensions(RCTPlatformView *rootView)
+static NSDictionary *RCTExportedDimensions(void)
 #endif // macOS]
 {
   RCTAssertMainQueue();
 #if !TARGET_OS_OSX // [macOS]
   RCTDimensions dimensions = RCTGetDimensions(fontScale);
 #else // [macOS
-  RCTDimensions dimensions = RCTGetDimensions(rootView);
+  RCTDimensions dimensions = RCTGetDimensions();
 #endif // macOS]
   __typeof(dimensions.window) window = dimensions.window;
   NSDictionary<NSString *, NSNumber *> *dimsWindow = @{
@@ -148,8 +148,7 @@ static NSDictionary *RCTExportedDimensions(RCTPlatformView *rootView)
 #if !TARGET_OS_OSX // [macOS]
   return RCTExportedDimensions(fontScale);
 #else // [macOS
-  // TODO: Saad - get root view here
-  return RCTExportedDimensions(nil);
+  return RCTExportedDimensions();
 #endif // macOS]
 }
 

--- a/packages/react-native/React/UIUtils/RCTUIUtils.h
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.h
@@ -22,11 +22,7 @@ typedef struct {
   } window, screen;
 } RCTDimensions;
 extern __attribute__((visibility("default")))
-#if !TARGET_OS_OSX // [macOS]
 RCTDimensions RCTGetDimensions(CGFloat fontScale);
-#else // [macOS
-RCTDimensions RCTGetDimensions(void);
-#endif // macOS]
 
 #ifdef __cplusplus
 }

--- a/packages/react-native/React/UIUtils/RCTUIUtils.h
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.h
@@ -25,7 +25,7 @@ extern __attribute__((visibility("default")))
 #if !TARGET_OS_OSX // [macOS]
 RCTDimensions RCTGetDimensions(CGFloat fontScale);
 #else // [macOS
-RCTDimensions RCTGetDimensions(RCTPlatformView *rootView);
+RCTDimensions RCTGetDimensions(void);
 #endif // macOS]
 
 #ifdef __cplusplus

--- a/packages/react-native/React/UIUtils/RCTUIUtils.m
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.m
@@ -20,11 +20,11 @@ RCTDimensions RCTGetDimensions(CGFloat fontScale)
   // We fallback to screen size if a key window is not found.
   CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
 #else // [macOS
-  NSWindow *window = RCTKeyWindow();
+  RCTUIWindow *window = RCTKeyWindow();
   NSSize windowSize = window ? [window frame].size : CGSizeMake(0, 0);
   NSSize screenSize = window ? [[window screen] frame].size : CGSizeMake(0, 0);
   CGFloat scale = window ? [[window screen] backingScaleFactor] : 1.0; // Default scale to 1.0 if window is nil
-#endif // macOS]
+#endif // macOS
   RCTDimensions result;
 #if !TARGET_OS_OSX // [macOS]
   typeof(result.screen) dimsScreen = {

--- a/packages/react-native/React/UIUtils/RCTUIUtils.m
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.m
@@ -9,11 +9,7 @@
 
 #import "RCTUtils.h"
 
-#if !TARGET_OS_OSX // [macOS]
 RCTDimensions RCTGetDimensions(CGFloat fontScale)
-#else // [macOS
-RCTDimensions RCTGetDimensions(void)
-#endif // macOS]
 {
 #if !TARGET_OS_OSX // [macOS]
   UIScreen *mainScreen = UIScreen.mainScreen;
@@ -24,12 +20,11 @@ RCTDimensions RCTGetDimensions(void)
   // We fallback to screen size if a key window is not found.
   CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
 #else // [macOS
-  NSWindow *window = [NSApp keyWindow];
+  NSWindow *window = RCTKeyWindow();
   NSSize windowSize = window ? [window frame].size : CGSizeMake(0, 0);
   NSSize screenSize = window ? [[window screen] frame].size : CGSizeMake(0, 0);
   CGFloat scale = window ? [[window screen] backingScaleFactor] : 1.0; // Default scale to 1.0 if window is nil
-  CGFloat fontScale = 1;
-#endif
+#endif // macOS]
   RCTDimensions result;
 #if !TARGET_OS_OSX // [macOS]
   typeof(result.screen) dimsScreen = {

--- a/packages/react-native/React/UIUtils/RCTUIUtils.m
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.m
@@ -12,7 +12,7 @@
 #if !TARGET_OS_OSX // [macOS]
 RCTDimensions RCTGetDimensions(CGFloat fontScale)
 #else // [macOS
-RCTDimensions RCTGetDimensions(RCTPlatformView *rootView)
+RCTDimensions RCTGetDimensions(void)
 #endif // macOS]
 {
 #if !TARGET_OS_OSX // [macOS]
@@ -24,20 +24,12 @@ RCTDimensions RCTGetDimensions(RCTPlatformView *rootView)
   // We fallback to screen size if a key window is not found.
   CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
 #else // [macOS
-  NSWindow *window = nil;
-  NSSize windowSize;
-  NSSize screenSize;
-  if (rootView != nil) {
-	  window = [rootView window];
-	  windowSize = [window frame].size;
-  } else {
-    // We don't have a root view so fall back to the app's key window
-    window = [NSApp keyWindow];
-    windowSize = [window frame].size;
-  }
-  screenSize = [[window screen] frame].size;
+  NSWindow *window = [NSApp keyWindow];
+  NSSize windowSize = window ? [window frame].size : CGSizeMake(0, 0);
+  NSSize screenSize = window ? [[window screen] frame].size : CGSizeMake(0, 0);
+  CGFloat scale = window ? [[window screen] backingScaleFactor] : 1.0; // Default scale to 1.0 if window is nil
+  CGFloat fontScale = 1;
 #endif
-
   RCTDimensions result;
 #if !TARGET_OS_OSX // [macOS]
   typeof(result.screen) dimsScreen = {
@@ -48,13 +40,13 @@ RCTDimensions RCTGetDimensions(RCTPlatformView *rootView)
   typeof(result.screen) dimsScreen = {
       .width = screenSize.width, 
       .height = screenSize.height, 
-      .scale = [[window screen] backingScaleFactor],
-      .fontScale = 1};
+      .scale = scale,
+      .fontScale = fontScale};
   typeof(result.window) dimsWindow = {
       .width = windowSize.width, 
       .height = windowSize.height, 
-      .scale = [[window screen] backingScaleFactor], 
-      .fontScale = 1};
+      .scale = scale,
+      .fontScale = fontScale};
 #endif // macOS]
   result.screen = dimsScreen;
   result.window = dimsWindow;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

In 0.73 on Paper, `StyleSheet.hairlineWidth` would throw an `NaN` error when `PixelRatio.get()` returned 0.
https://github.com/microsoft/react-native-macos/blob/43122d4e34e1b950530bfacc706d687ada6cb45a/packages/react-native/Libraries/StyleSheet/StyleSheet.js#L166-L169

This was because we were calculating the scale before the window was created and returning zero.
https://github.com/microsoft/react-native-macos/blob/43122d4e34e1b950530bfacc706d687ada6cb45a/packages/react-native/React/UIUtils/RCTUIUtils.m#L51

With the New Arch Enabled flag, the `RCTDeviceInfo` Turbomodule will run after the window is created so it will always have a current window.

## Changelog:

[MACOS] [FIXED] - Default dimensions `scale` value to 1.0 if window is nil

## Test Plan:

**Paper - Before window is created**
<img width="766" alt="CleanShot 2023-11-03 at 16 23 21@2x" src="https://github.com/microsoft/react-native-macos/assets/96719/89affdba-d0e7-4930-832b-2fa1a3e03e07">

**Paper - After window is created**
<img width="757" alt="CleanShot 2023-11-03 at 16 24 25@2x" src="https://github.com/microsoft/react-native-macos/assets/96719/7a96fdfc-cb62-47e7-89cf-388b19bee192">

**Fabric**
<img width="790" alt="CleanShot 2023-11-03 at 16 01 35@2x" src="https://github.com/microsoft/react-native-macos/assets/96719/cd1ca365-b74b-4aa0-ae61-311f0e9b2db3">
