### PR TITLE
Don't recreate identical NSTrackingAreas

### DIFF
--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -1492,16 +1492,21 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 
 - (void)updateTrackingAreas
 {
-  if (_trackingArea) {
-    [self removeTrackingArea:_trackingArea];
-  }
+  BOOL hasMouseHoverEvent = self.onMouseEnter || self.onMouseLeave;
+  BOOL wouldRecreateIdenticalTrackingArea = hasMouseHoverEvent && _trackingArea && NSEqualRects(self.bounds, [_trackingArea rect]);
 
-  if (self.onMouseEnter || self.onMouseLeave) {
-    _trackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds
-                                                 options:NSTrackingActiveAlways|NSTrackingMouseEnteredAndExited
-                                                   owner:self
-                                                userInfo:nil];
-    [self addTrackingArea:_trackingArea];
+  if (!wouldRecreateIdenticalTrackingArea) {
+    if (_trackingArea) {
+      [self removeTrackingArea:_trackingArea];
+    }
+
+    if (hasMouseHoverEvent) {
+      _trackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds
+                                                   options:NSTrackingActiveAlways|NSTrackingMouseEnteredAndExited
+                                                     owner:self
+                                                  userInfo:nil];
+      [self addTrackingArea:_trackingArea];
+    }
   }
 
   [super updateTrackingAreas];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

We've seen an issue where mouse events sometimes behave strangely. The exact cause is unknown, but we found that one problem is that we're constantly recalculating the `NSTrackingArea` despite the fact that the size of the view isn't changing.

To resolve this, we limit the recreation of a new `NSTrackingArea` to when its size would actually change.

## Changelog:

Pick one each for the category and type tags:

[MACOS] [FIXED] - Remove unnecessary recreation of NSTrackingAreas

## Test Plan:

This was tested with the following test component in RNTester (not included as part of this change):
```jsx
<View>
  <View
    width="20%"
    height={50}
    style={{backgroundColor: 'red'}}
    onMouseEnter={() => {
      console.log('onMouseEnter');
    }}
  />
</View>
```
I validated that the `NSTrackingArea` is correct by moving the mouse into the view from all four sides. This even holds between scrolls within RNTester, moving the window, and resizing the window. Furthermore, when resizing the window, `-updateTrackingAreas` only gets called once we release the mouse button and we finalize the new window size.