### PR TITLE
[CI] Update to iOS 17.0.1

### DIFF
--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -2,5 +2,5 @@ variables:
   VmImageApple: macOS-13
   slice_name: 'Xcode_15.0'
   xcode_version: '/Applications/Xcode_15.0.app'
-  ios_version: '17.0'
+  ios_version: '17.0.1'
   ios_simulator: 'iPhone 15'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

Ci seems to be failing because we request `iOS 17.0` instead of `iOS 17.0.1`. This should be a one line fix. 

## Changelog:

[INTERNAL] [CHANGED] - Update CI to iOS 17.0.1

## Test Plan:

CI should pass
