### PR TITLE
[JSCRuntime] Only enable the JSC debugging in DEBUG by default

### DIFF
--- a/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
+++ b/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
@@ -30,7 +30,11 @@ class JSCExecutorFactory : public JSExecutorFactory {
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
 
   // [macOS
+#if DEBUG
   bool enableDebugger_ = true;
+#else
+  bool enableDebugger_ = false;
+#endif
   std::string debuggerName_ = "JSC React Native";
   // macOS]
 };


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

https://github.com/microsoft/react-native-macos/pull/1957 set the JSC debugging to always be true, even on Release builds. Let's ifdef the default so it's only true for debug. This way, we can continue to support allowing a user to enable debugging for release builds if they wish. 

## Changelog:


[GENERAL] [CHANGED] - Only enable JSC debugging in DEBUG by default

## Test Plan:

CI should pass. I couldn't get a good ship build of RN, but this is a fairly simple change. 
