### PR TITLE
Make socketConnections NSDictionary thread-safe

### DIFF
--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -64,8 +64,10 @@ static NSMutableDictionary<NSString *, RCTInspectorPackagerConnection *> *socket
 
 static void sendEventToAllConnections(NSString *event)
 {
-  for (NSString *socketId in socketConnections) {
-    [socketConnections[socketId] sendEventToAllConnections:event];
+  @synchronized (socketConnections) {
+    for (NSString *socketId in socketConnections) {
+      [socketConnections[socketId] sendEventToAllConnections:event];
+    }
   }
 }
 
@@ -101,8 +103,10 @@ static void sendEventToAllConnections(NSString *event)
   // Note, using a static dictionary isn't really the greatest design, but
   // the packager connection does the same thing, so it's at least consistent.
   // This is a static map that holds different inspector clients per the inspectorURL
-  if (socketConnections == nil) {
-    socketConnections = [NSMutableDictionary new];
+  @synchronized (socketConnections) {
+    if (socketConnections == nil) {
+      socketConnections = [NSMutableDictionary new];
+    }
   }
 
   NSString *key = [inspectorURL absoluteString];
@@ -112,17 +116,22 @@ static void sendEventToAllConnections(NSString *event)
     return nil;
   }
   // macOS]
-  RCTInspectorPackagerConnection *connection = socketConnections[key];
-  if (!connection || !connection.isConnected) {
-    connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];
-    // [macOS safety check to avoid a crash
-    if (connection == nil) {
-      RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
-      return nil;
+
+  RCTInspectorPackagerConnection *connection;
+
+  @synchronized (socketConnections) {
+    connection = socketConnections[key];
+    if (!connection || !connection.isConnected) {
+      connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];
+      // [macOS safety check to avoid a crash
+      if (connection == nil) {
+        RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
+        return nil;
+      }
+      // macOS]
+      socketConnections[key] = connection;
+      [connection connect];
     }
-    // macOS]
-    socketConnections[key] = connection;
-    [connection connect];
   }
 
   return connection;

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -64,7 +64,7 @@ static NSMutableDictionary<NSString *, RCTInspectorPackagerConnection *> *socket
 
 static void sendEventToAllConnections(NSString *event)
 {
-  @synchronized (socketConnections) {
+  @synchronized (socketConnections) { // [macOS]
     for (NSString *socketId in socketConnections) {
       [socketConnections[socketId] sendEventToAllConnections:event];
     }
@@ -103,7 +103,7 @@ static void sendEventToAllConnections(NSString *event)
   // Note, using a static dictionary isn't really the greatest design, but
   // the packager connection does the same thing, so it's at least consistent.
   // This is a static map that holds different inspector clients per the inspectorURL
-  @synchronized (socketConnections) {
+  @synchronized (socketConnections) { // [macOS]
     if (socketConnections == nil) {
       socketConnections = [NSMutableDictionary new];
     }
@@ -119,7 +119,7 @@ static void sendEventToAllConnections(NSString *event)
 
   RCTInspectorPackagerConnection *connection;
 
-  @synchronized (socketConnections) {
+  @synchronized (socketConnections) { // [macOS]
     connection = socketConnections[key];
     if (!connection || !connection.isConnected) {
       connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -132,7 +132,6 @@ static void sendEventToAllConnections(NSString *event)
       RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
     }
     // macOS]
-    
   }
   [connectionsLock unlock]; // [macOS]
 

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -61,14 +61,15 @@ static NSURL *getInspectorDeviceUrl(NSURL *bundleURL)
 RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 static NSMutableDictionary<NSString *, RCTInspectorPackagerConnection *> *socketConnections = nil;
+static NSLock *connectionsLock = [NSLock new];
 
 static void sendEventToAllConnections(NSString *event)
 {
-  @synchronized (socketConnections) { // [macOS]
-    for (NSString *socketId in socketConnections) {
-      [socketConnections[socketId] sendEventToAllConnections:event];
-    }
+  [connectionsLock lock]; // [macOS]
+  for (NSString *socketId in socketConnections) {
+    [socketConnections[socketId] sendEventToAllConnections:event];
   }
+  [connectionsLock unlock]; // [macOS]
 }
 
 + (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage
@@ -103,11 +104,11 @@ static void sendEventToAllConnections(NSString *event)
   // Note, using a static dictionary isn't really the greatest design, but
   // the packager connection does the same thing, so it's at least consistent.
   // This is a static map that holds different inspector clients per the inspectorURL
-  @synchronized (socketConnections) { // [macOS]
-    if (socketConnections == nil) {
-      socketConnections = [NSMutableDictionary new];
-    }
+  [connectionsLock lock]; // [macOS]
+  if (socketConnections == nil) {
+    socketConnections = [NSMutableDictionary new];
   }
+  [connectionsLock unlock]; // [macOS]
 
   NSString *key = [inspectorURL absoluteString];
   // [macOS safety check to avoid a crash
@@ -119,20 +120,21 @@ static void sendEventToAllConnections(NSString *event)
 
   RCTInspectorPackagerConnection *connection;
 
-  @synchronized (socketConnections) { // [macOS]
-    connection = socketConnections[key];
-    if (!connection || !connection.isConnected) {
-      connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];
-      // [macOS safety check to avoid a crash
-      if (connection == nil) {
-        RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
-        return nil;
-      }
-      // macOS]
+  [connectionsLock lock]; // [macOS]
+  connection = socketConnections[key];
+  if (!connection || !connection.isConnected) {
+    connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];
+    // [macOS safety check to avoid a crash
+    if (connection != nil) {
       socketConnections[key] = connection;
       [connection connect];
+    } else {
+      RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
     }
+    // macOS]
+    
   }
+  [connectionsLock unlock]; // [macOS]
 
   return connection;
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

We've seen a crash when we have multiple instances of React Native running in an app. It appears to be caused by multiple threads accessing `+[RCTInspectorDevServerHelper connectWithBundleURL:]` at the same time.

To fix this, we put all accesses to the `socketConnections` dictionary in a `@synchronized` block. This brings the iOS/macOS implementations up to speed with [Android](https://github.com/facebook/react-native/blob/050a5a379766318c3a9f322ceb5e13ef4cd8e7d2/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java#L47), which uses a `ConcurrentHashMap`.

## Changelog:

[IOS] [FIXED] - Improve `RCTInspectorDevServerHelper` thread safety

## Test Plan:

Tested this change in an internal app that consumes React Native and confirmed that it doesn't crash. (Without this change, crashes happened intermittently but frequently enough that it was noticeable.)
