### PR TITLE
Correctly declare runtime dependencies

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -31,7 +31,10 @@
   "dependencies": {
     "@babel/parser": "^7.20.0",
     "flow-parser": "^0.206.0",
+    "glob": "^7.1.1",
+    "invariant": "^2.2.4",
     "jscodeshift": "^0.14.0",
+    "mkdirp": "^0.5.1",
     "nullthrows": "^1.1.1"
   },
   "beachball": {
@@ -49,10 +52,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "chalk": "^4.0.0",
-    "glob": "^7.1.1",
-    "invariant": "^2.2.4",
     "micromatch": "^4.0.4",
-    "mkdirp": "^0.5.1",
     "prettier": "2.8.8",
     "rimraf": "^3.0.2"
   },


### PR DESCRIPTION
#### Please select one of the following

- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

In pnpm setups, codegen will fail during build because it cannot find its dependencies. Some of the dependencies it relies on at runtime are currently declared under `devDependencies`. This change moves them to `dependencies`.

Cherry-picks c58e19e89aadcc01c2ac8ead876831ed8a2f6c5d.

## Changelog:

[GENERAL] [FIXED] - Fix `react-native/codegen` not being able to resolve dependencies in pnpm setups

## Test Plan:

We are currently trying to [enable pnpm mode](https://github.com/microsoft/rnx-kit/pull/2811) in rnx-kit and hit this issue. We've patched this package locally and it works.