### PR TITLE
Fix `build_codegen!` not finding `@react-native/codegen` in pnpm setups

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -68,7 +68,7 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pod::Executable.executed_commands.length, 0)
     end
 
-    def testCheckAndGenerateEmptyThirdPartyProvider_whenHeaderMissingAndCodegenMissing_raiseError()
+    def testCheckAndGenerateEmptyThirdPartyProvider_whenHeaderMissingAndCodegenMissing_dontBuildCodegen()
 
         # Arrange
         FileMock.mocked_existing_files([
@@ -76,7 +76,7 @@ class CodegenTests < Test::Unit::TestCase
         ])
 
         # Act
-        assert_raise {
+        assert_nothing_raised {
             checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, dir_manager: DirMock, file_manager: FileMock)
         }
 
@@ -84,16 +84,18 @@ class CodegenTests < Test::Unit::TestCase
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
-            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header
+            @base_path + "/" + @prefix + "/React/Fabric/" + @third_party_provider_header,
+            @base_path + "/" + @prefix + "/React/Fabric/tmpSchemaList.txt",
         ])
         assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/"+ @prefix + "/../react-native-codegen",
-            @base_path + "/"+ @prefix + "/../@react-native/codegen",
         ])
-        assert_equal(Pod::UI.collected_messages, [])
+        assert_equal(Pod::UI.collected_messages, [
+          "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider",
+        ])
         assert_equal($collected_commands, [])
-        assert_equal(FileMock.open_files.length, 0)
-        assert_equal(Pod::Executable.executed_commands.length, 0)
+        assert_equal(FileMock.open_files.length, 1)
+        assert_equal(Pod::Executable.executed_commands.length, 1)
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenImplementationMissingAndCodegenrepoExists_dontBuildCodegen()
@@ -145,7 +147,7 @@ class CodegenTests < Test::Unit::TestCase
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenBothMissing_buildCodegen()
         # Arrange
-        codegen_cli_path = @base_path + "/" + @prefix + "/../@react-native/codegen"
+        codegen_cli_path = @base_path + "/" + @prefix + "/../react-native-codegen"
         DirMock.mocked_existing_dirs([
             codegen_cli_path,
         ])
@@ -160,15 +162,14 @@ class CodegenTests < Test::Unit::TestCase
             @base_path + "/" + @prefix + "/React/Fabric/" + @tmp_schema_list_file
         ])
         assert_equal(DirMock.exist_invocation_params, [
-            @base_path + "/" + @prefix + "/../react-native-codegen",
             codegen_cli_path,
             codegen_cli_path + "/lib",
         ])
         assert_equal(Pod::UI.collected_messages, [
-            "[Codegen] building #{codegen_cli_path}.",
+            "[Codegen] building #{codegen_cli_path}",
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
-        assert_equal($collected_commands, ["~/app/ios/../../../@react-native/codegen/scripts/oss/build.sh"])
+        assert_equal($collected_commands, ["~/app/ios/../../../react-native-codegen/scripts/oss/build.sh"])
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands[0], {
@@ -185,7 +186,7 @@ class CodegenTests < Test::Unit::TestCase
     def testCheckAndGenerateEmptyThirdPartyProvider_withAbsoluteReactNativePath_buildCodegen()
         # Arrange
         rn_path = 'packages/react-native'
-        codegen_cli_path = rn_path + "/../@react-native/codegen"
+        codegen_cli_path = rn_path + "/../react-native-codegen"
         DirMock.mocked_existing_dirs([
             @base_path + "/" + codegen_cli_path,
         ])
@@ -201,15 +202,16 @@ class CodegenTests < Test::Unit::TestCase
             @base_path + "/" + rn_path + "/React/Fabric/" + @tmp_schema_list_file
         ])
         assert_equal(DirMock.exist_invocation_params, [
-            @base_path + "/" + rn_path + "/../react-native-codegen",
             @base_path + "/" + codegen_cli_path,
             @base_path + "/" + codegen_cli_path + "/lib",
         ])
         assert_equal(Pod::UI.collected_messages, [
-            "[Codegen] building #{@base_path + "/" + codegen_cli_path}.",
+            "[Codegen] building #{@base_path + "/" + codegen_cli_path}",
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
-        assert_equal($collected_commands, [@base_path + "/" + rn_path + "/../@react-native/codegen/scripts/oss/build.sh"])
+        assert_equal($collected_commands, [
+          @base_path + "/" + rn_path + "/../react-native-codegen/scripts/oss/build.sh",
+        ])
         assert_equal(FileMock.open_files[0].collected_write, ["[]"])
         assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands[0], {

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -11,23 +11,12 @@
 # - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
 # @throws an error if it could not find the codegen folder.
 def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
-    codegen_repo_path = "#{basePath(react_native_path, relative_installation_root)}/../react-native-codegen";
-    codegen_npm_path = "#{basePath(react_native_path, relative_installation_root)}/../@react-native/codegen";
-    codegen_cli_path = ""
+  codegen_repo_path = "#{basePath(react_native_path, relative_installation_root)}/../react-native-codegen"
+  return unless dir_manager.exist?(codegen_repo_path) && !dir_manager.exist?("#{codegen_repo_path}/lib")
 
-    if dir_manager.exist?(codegen_repo_path)
-      codegen_cli_path = codegen_repo_path
-    elsif dir_manager.exist?(codegen_npm_path)
-      codegen_cli_path = codegen_npm_path
-    else
-      raise "[codegen] Could not find react-native-codegen."
-    end
-
-    if !dir_manager.exist?("#{codegen_cli_path}/lib")
-      Pod::UI.puts "[Codegen] building #{codegen_cli_path}."
-      system("#{codegen_cli_path}/scripts/oss/build.sh")
-    end
-  end
+  Pod::UI.puts "[Codegen] building #{codegen_repo_path}"
+  system("#{codegen_repo_path}/scripts/oss/build.sh")
+end
 
 # It generates an empty `ThirdPartyProvider`, required by Fabric to load the components
 #


### PR DESCRIPTION
#### Please select one of the following

- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

`build_codegen!` currently assumes that `@react-native/codegen` gets installed next to `react-native`. In a pnpm setup, it's found under `/~/react-native/node_modules/@react-native/codegen` instead.

However, as @dmytrorykun pointed out, we don't actually need to build it outside of this repository.

Cherry-picks https://github.com/facebook/react-native/commit/3dd6a83c0e39c54b4ff050589e4e13f1ccc66a5d

## Changelog:

[GENERAL] [FIXED] - `@react-native/codegen` shouldn't be built unless it's in the repo — fixes `pod install` failures in pnpm setups

## Test Plan:

We have a patched version of `react-native` working in a pnpm setup here: https://github.com/microsoft/rnx-kit/pull/2811