### PR TITLE
[0.72-stable] Make socketConnections NSDictionary thread-safe

### DIFF
--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -136,7 +136,6 @@ static void sendEventToAllConnections(NSString *event)
       RCTLogError(@"failed to initialize RCTInspectorPackagerConnection");
     }
     // macOS]
-    
   }
   [connectionsLock unlock]; // [macOS]
 

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -67,7 +67,7 @@ static NSMutableDictionary<NSString *, RCTInspectorPackagerConnection *> *socket
 
 static void sendEventToAllConnections(NSString *event)
 {
-  @synchronized (socketConnections) {
+  @synchronized (socketConnections) { // [macOS]
     for (NSString *socketId in socketConnections) {
       [socketConnections[socketId] sendEventToAllConnections:event];
     }
@@ -107,7 +107,7 @@ static void sendEventToAllConnections(NSString *event)
   // Note, using a static dictionary isn't really the greatest design, but
   // the packager connection does the same thing, so it's at least consistent.
   // This is a static map that holds different inspector clients per the inspectorURL
-  @synchronized (socketConnections) {
+  @synchronized (socketConnections) { // [macOS]
     if (socketConnections == nil) {
       socketConnections = [NSMutableDictionary new];
     }
@@ -123,7 +123,7 @@ static void sendEventToAllConnections(NSString *event)
 
   RCTInspectorPackagerConnection *connection;
 
-  @synchronized (socketConnections) {
+  @synchronized (socketConnections) { // [macOS]
     connection = socketConnections[key];
     if (!connection || !connection.isConnected) {
       connection = [[RCTInspectorPackagerConnection alloc] initWithURL:inspectorURL];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

Cherry-pick of commits from #1980.

## Changelog:

[IOS] [FIXED] - Improve `RCTInspectorDevServerHelper` thread safety

## Test Plan:

Tested this change in an internal app that consumes React Native and confirmed that it doesn't crash. (Without this change, crashes happened intermittently but frequently enough that it was noticeable.)
