### PR TITLE
Remove call to Xcode 12.5 post-install workaround

### DIFF
--- a/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
@@ -22,6 +22,5 @@ target 'HelloWorld-macOS' do
 
   post_install do |installer|
     react_native_post_install(installer)
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

With 0ab8b40fd64ad86b4598293faa0b77e71fc9d349, the Xcode 12.5 post-install workaround is now gone. Let's remove it from one other place where we used to call it.

## Changelog:

[GENERAL] [FIXED] - Remove call to Xcode 12.5 post-install workaround

## Test Plan:

The CIs for #1987 saw a failure related to the existence of this call. If the CI passes, we should be good.