### PR TITLE
fix(react-native): `runMacOS.js` depends on `chalk`

### DIFF
--- a/packages/react-native/local-cli/runMacOS/runMacOS.js
+++ b/packages/react-native/local-cli/runMacOS/runMacOS.js
@@ -6,6 +6,23 @@
  */
 'use strict';
 
+/**
+ * @typedef {{
+ *   configuration: string;
+ *   packager: boolean;
+ *   port: number;
+ *   projectPath: string;
+ *   scheme?: string;
+ *   terminal: string | undefined;
+ *   verbose: boolean;
+ * }} Options
+ *
+ * @typedef {{
+ *   name: string;
+ *   isWorkspace: boolean;
+ * }} XcodeProject
+ */
+
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -19,10 +36,10 @@ const {
 
 /**
  * @param {string[]} _
- * @param {Object.<string, *>} ctx
- * @param {{configuration: string, scheme?: string, projectPath: string, packager: boolean, verbose: boolean, port: number, terminal: string | undefined}} args
+ * @param {Record<string, unknown>} _ctx
+ * @param {Options} args
  */
-function runMacOS(_, ctx, args) {
+function runMacOS(_, _ctx, args) {
   if (!fs.existsSync(args.projectPath)) {
     throw new CLIError(
       'macOS project folder not found. Are you sure this is a React Native project?',
@@ -53,9 +70,9 @@ function runMacOS(_, ctx, args) {
 }
 
 /**
- * @param {{name: string, isWorkspace: boolean}} xcodeProject
+ * @param {XcodeProject} xcodeProject
  * @param {string} scheme
- * @param {{configuration: string, scheme?: string, projectPath: string, packager: boolean, verbose: boolean, port: number, terminal: string | undefined}} args
+ * @param {Options} args
  */
 async function run(xcodeProject, scheme, args) {
   await buildProject(xcodeProject, scheme, args);
@@ -99,9 +116,9 @@ async function run(xcodeProject, scheme, args) {
 }
 
 /**
- * @param {{name: string, isWorkspace: boolean}} xcodeProject
+ * @param {XcodeProject} xcodeProject
  * @param {string} scheme
- * @param {{configuration: string, scheme?: string, projectPath: string, packager: boolean, verbose: boolean, port: number, terminal: string | undefined}} args
+ * @param {Options} args
  */
 function buildProject(xcodeProject, scheme, args) {
   return new Promise((resolve, reject) => {
@@ -176,7 +193,7 @@ function buildProject(xcodeProject, scheme, args) {
 }
 
 /**
- * @param {{name: string, isWorkspace: boolean}} xcodeProject
+ * @param {XcodeProject} xcodeProject
  * @param {string} configuration
  * @param {string} scheme
  * @returns {{ FULL_PRODUCT_NAME: string, INFOPLIST_PATH: string, TARGET_BUILD_DIR: string }}
@@ -224,10 +241,8 @@ function xcprettyAvailable() {
 }
 
 /**
- * @param {Object} args
- * @param {boolean} args.packager
- * @param {string|undefined} args.terminal
- * @param {number} args.port
+ * @param {Options} args
+ * @returns {import('child_process').ProcessEnvOptions}
  */
 function getProcessOptions({packager, terminal, port}) {
   if (packager) {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -108,6 +108,7 @@
     "anser": "^1.4.9",
     "ansi-regex": "^5.0.0",
     "base64-js": "^1.5.1",
+    "chalk": "^4.1.2",
     "deprecated-react-native-prop-types": "4.2.1",
     "event-target-shim": "^5.0.1",
     "flow-enums-runtime": "^0.0.6",


### PR DESCRIPTION
#### Please select one of the following

- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

`runMacOS.js` uses `chalk` but relies on other dependencies also depending on it and specific hoisting mechanisms to access it. This fails in a pnpm setup.

## Changelog:

[GENERAL] [FIXED] - `runMacOS.js` depends on `chalk` but doesn't declare it

## Test Plan:

n/a