### PR TITLE
Override reactAccessibilityElement for RCTTextView

### DIFF
--- a/.ado/Brewfile
+++ b/.ado/Brewfile
@@ -1,4 +1,3 @@
-brew "watchman"
 brew "xcbeautify"
 # macOS 12 doesn't have `realpath` but macOS 13 does. Remove this line when Azure Pipelines supports macOS 13 images.
 brew "coreutils"

--- a/.ado/Brewfile.lock.json
+++ b/.ado/Brewfile.lock.json
@@ -46,45 +46,45 @@
         }
       },
       "xcbeautify": {
-        "version": "1.0.0",
+        "version": "1.0.1",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:c8f49160c9c1df0f01ebc1a4530289fb0b4d69093bf6a1a501f5647844c1437b",
-              "sha256": "c8f49160c9c1df0f01ebc1a4530289fb0b4d69093bf6a1a501f5647844c1437b"
+              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:4a5479b847e453d31a6f0db5dc2025a7cec02a3abee949633f3d4b933c63d4bf",
+              "sha256": "4a5479b847e453d31a6f0db5dc2025a7cec02a3abee949633f3d4b933c63d4bf"
             },
             "arm64_ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:bacf88c0dd3a4132e5cf01dc9af94d69678e8adc9faadc0b55eca53dfeb4edd6",
-              "sha256": "bacf88c0dd3a4132e5cf01dc9af94d69678e8adc9faadc0b55eca53dfeb4edd6"
+              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:65c88205f9cad6b2decfc1822e020474e29f39cee2b0829e5ee45d730f916dff",
+              "sha256": "65c88205f9cad6b2decfc1822e020474e29f39cee2b0829e5ee45d730f916dff"
             },
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:6a46df2ced30543c8ec0fb7ea53a1ffd45f69db7ed9b59a5ca5fbc6885606f9c",
-              "sha256": "6a46df2ced30543c8ec0fb7ea53a1ffd45f69db7ed9b59a5ca5fbc6885606f9c"
+              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:07d7483ef82ce4f8e5454192ab57af31081ddce1dc1a59e0b78047083b3c2d46",
+              "sha256": "07d7483ef82ce4f8e5454192ab57af31081ddce1dc1a59e0b78047083b3c2d46"
             },
             "sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:400ad7359e6c260156e1982dc2d0227034c3294b95db899555c2c3375651417c",
-              "sha256": "400ad7359e6c260156e1982dc2d0227034c3294b95db899555c2c3375651417c"
+              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:ba9a4d02d7c11272c5772a751d6e3429071c208f599c6f72359a59db3ba7ab50",
+              "sha256": "ba9a4d02d7c11272c5772a751d6e3429071c208f599c6f72359a59db3ba7ab50"
             },
             "ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:2d7d8323275c3d5f808434c84808a59c4d8eabb128053f05630f298b592d5bfe",
-              "sha256": "2d7d8323275c3d5f808434c84808a59c4d8eabb128053f05630f298b592d5bfe"
+              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:28704b049d5826632dca6a0d4df678d9420debdc6e72b7d9a74569fd6ad749ca",
+              "sha256": "28704b049d5826632dca6a0d4df678d9420debdc6e72b7d9a74569fd6ad749ca"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:4688cfc59364db9efa881f2cb4c99f2304149c0f69e2bc4164cbae5d525ca7ed",
-              "sha256": "4688cfc59364db9efa881f2cb4c99f2304149c0f69e2bc4164cbae5d525ca7ed"
+              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:698a79eefa07f2bc8371961ae59efd863fba1dab4c50cca0a79d935d9c42cffe",
+              "sha256": "698a79eefa07f2bc8371961ae59efd863fba1dab4c50cca0a79d935d9c42cffe"
             },
             "x86_64_linux": {
               "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:4f4ed4b6e2367b3ac361e4916186778de7aef1b6a2dd772e4609437f05ec3f3f",
-              "sha256": "4f4ed4b6e2367b3ac361e4916186778de7aef1b6a2dd772e4609437f05ec3f3f"
+              "url": "https://ghcr.io/v2/homebrew/core/xcbeautify/blobs/sha256:8bf201e9ccf569c24001db8c4cf14d86272de79d844a6e24c3f63a7d5a391a89",
+              "sha256": "8bf201e9ccf569c24001db8c4cf14d86272de79d844a6e24c3f63a7d5a391a89"
             }
           }
         }
@@ -162,6 +162,14 @@
         "CLT": "14.2.0.0.1.1668646533",
         "Xcode": "14.2",
         "macOS": "12.7"
+      },
+      "sonoma": {
+        "HOMEBREW_VERSION": "4.1.22",
+        "HOMEBREW_PREFIX": "/opt/homebrew",
+        "Homebrew/homebrew-core": "api",
+        "CLT": "15.0.0.0.1.1694021235",
+        "Xcode": "14.3",
+        "macOS": "14.1"
       }
     }
   }

--- a/.ado/ado-test-cleanup.sh
+++ b/.ado/ado-test-cleanup.sh
@@ -22,10 +22,6 @@ lsof -i tcp:5555 | awk 'NR!=1 {print $2}' | xargs kill
 # clear packager cache
 rm -fr "$TMPDIR/react-*"
 
-# clear watchman state
-rm -rf /usr/local/var/run/watchman/*
-watchman watch-del-all
-
 # dump the log files created by launchPackager.command and launchWebSocketServer.command
 THIS_DIR=$(dirname "$0")
 PACKAGER_LOG="${THIS_DIR}/launchPackager.log"

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -451,7 +451,10 @@ class Button extends React.Component<ButtonProps> {
         tooltip={tooltip} // [macOS]
         touchSoundDisabled={touchSoundDisabled}>
         <View style={buttonStyles}>
-          <Text style={textStyles} disabled={disabled} accessible={Platform.OS !== 'macos' /* [macOS] */}>
+          <Text
+            style={textStyles}
+            disabled={disabled}
+            accessible={Platform.OS !== 'macos' /* [macOS] */}>
             {formattedTitle}
           </Text>
         </View>

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -451,7 +451,7 @@ class Button extends React.Component<ButtonProps> {
         tooltip={tooltip} // [macOS]
         touchSoundDisabled={touchSoundDisabled}>
         <View style={buttonStyles}>
-          <Text style={textStyles} disabled={disabled}>
+          <Text style={textStyles} disabled={disabled} accessible={Platform.OS !== 'macos' /* [macOS] */}>
             {formattedTitle}
           </Text>
         </View>

--- a/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
+++ b/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
@@ -49,6 +49,7 @@ exports[`<Button /> should be disabled and it should set accessibilityState to d
     }
   >
     <Text
+      accessible={true}
       disabled={true}
       style={
         Array [
@@ -119,6 +120,7 @@ exports[`<Button /> should be disabled when disabled is empty and accessibilityS
     }
   >
     <Text
+      accessible={true}
       disabled={true}
       style={
         Array [
@@ -189,6 +191,7 @@ exports[`<Button /> should be disabled when disabled={true} and accessibilitySta
     }
   >
     <Text
+      accessible={true}
       disabled={true}
       style={
         Array [
@@ -259,6 +262,7 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
     }
   >
     <Text
+      accessible={true}
       style={
         Array [
           Object {
@@ -325,6 +329,7 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
     }
   >
     <Text
+      accessible={true}
       style={
         Array [
           Object {
@@ -390,6 +395,7 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
     }
   >
     <Text
+      accessible={true}
       disabled={false}
       style={
         Array [
@@ -456,6 +462,7 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
     }
   >
     <Text
+      accessible={true}
       disabled={false}
       style={
         Array [
@@ -523,6 +530,7 @@ exports[`<Button /> should overwrite accessibilityState with value of disabled p
     }
   >
     <Text
+      accessible={true}
       disabled={true}
       style={
         Array [
@@ -592,6 +600,7 @@ exports[`<Button /> should render as expected 1`] = `
     }
   >
     <Text
+      accessible={true}
       style={
         Array [
           Object {

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.m
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.m
@@ -98,6 +98,13 @@
   return self;
 }
 
+#if TARGET_OS_OSX // [macOS
+- (RCTPlatformView *)reactAccessibilityElement
+{
+    return _textView;
+}
+#endif // macOS]
+
 #if DEBUG // [macOS] description is a debug-only feature
 - (NSString *)description
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

RCTTextView does not override reactAccessibilityElement to the RCTUnfocusableTextView child.  This causes various properties, like accessible, to not get applied correctly.

In VoiceOver, there's a bug where if you have a Touchable like so:

```
<TouchableOpacity
        accessibilityRole="button"
        accessibilityLabel="Button with accessibility role as button and label"
        onPress={onPress}>
        <Text>Button with A11y Label Defined</Text>
</TouchableOpacity>
```

It reads "button, group".  By making the accessible prop apply correctly, the user can set the `<Text accessible={false} />` and VoiceOver will just read "button".

Before:
![Screenshot 2023-11-29 at 2 40 14 PM](https://github.com/microsoft/react-native-macos/assets/7664112/6ed1ee26-4df6-4286-b1f1-34f908d1f7f0)
After:
![Screenshot 2023-11-29 at 2 39 07 PM](https://github.com/microsoft/react-native-macos/assets/7664112/f07c984b-74b5-4702-ada0-a0a3699e9a0e)

## Changelog:

[INTERNAL] [FIXED] - Make accessibility props apply correctly to <Text> components on macOS.

## Test Plan:

See Summary