### PR TITLE
fix(react-native): `runMacOS.js` depends on `@react-native-community/cli-tools`

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -97,6 +97,7 @@
     "@react-native-community/cli": "12.0.0-alpha.15",
     "@react-native-community/cli-platform-android": "12.0.0-alpha.15",
     "@react-native-community/cli-platform-ios": "12.0.0-alpha.15",
+    "@react-native-community/cli-tools": "12.0.0-alpha.15",
     "@react-native/assets-registry": "^0.73.0",
     "@react-native/community-cli-plugin": "^0.73.0",
     "@react-native/codegen": "^0.73.0",


### PR DESCRIPTION
#### Please select one of the following

- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

`runMacOS.js` uses `@react-native-community/cli-tools` but relies on other dependencies also depending on it and specific hoisting mechanisms to access it. This fails in a pnpm setup.

Related: https://github.com/microsoft/react-native-macos/pull/1989

## Changelog:

[GENERAL] [FIXED] - `runMacOS.js` depends on `@react-native-community/cli-tools` but doesn't declare it

## Test Plan:

n/a