### PR TITLE
Fix ImageView tint color

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageView.mm
+++ b/packages/react-native/Libraries/Image/RCTImageView.mm
@@ -634,9 +634,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   return _imageView;
 }
 
+- (NSColor *)tintColor
+{
+  return _imageView.tintColor;
+}
+
 - (void)setTintColor:(NSColor *)tintColor
 {
-  _imageView.tintColor = tintColor;
+  [_imageView setTintColor:tintColor];
 }
 #endif // macOS]
 

--- a/packages/react-native/Libraries/Image/RCTImageView.mm
+++ b/packages/react-native/Libraries/Image/RCTImageView.mm
@@ -634,14 +634,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   return _imageView;
 }
 
-- (NSColor *)tintColor
-{
-  return _imageView.contentTintColor;
-}
-
 - (void)setTintColor:(NSColor *)tintColor
 {
-  _imageView.contentTintColor = tintColor;
+  _imageView.tintColor = tintColor;
 }
 #endif // macOS]
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

~~ImageView tint color was broken after this change on core:
https://github.com/facebook/react-native/commit/ce7c0b735f476a4618fd0d68fc39157a0bdb4f57~~
This change was from 2015 😅!

Paper should use the RCTUIImageView class for rendering which has the same tintColor property as the iOS UIImageView class.

## Changelog:

[MACOS] [FIXED] - Fix ImageView tint color

## Test Plan:

**RN Tester**
![CleanShot 2023-12-15 at 17 13 12@2x](https://github.com/microsoft/react-native-macos/assets/96719/edf814bc-19e5-4489-ae55-059bead5c3de)
