### PR TITLE
[0.73] Fix accessibilityRole

### DIFF
--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -292,9 +292,9 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 RCT_REMAP_VIEW_PROPERTY(transform, reactTransform, CATransform3D)
 RCT_REMAP_VIEW_PROPERTY(transformOrigin, reactTransformOrigin, RCTTransformOrigin)
 
-#if !TARGET_OS_OSX // [macOS]
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
 {
+  #if !TARGET_OS_OSX // [macOS]
   UIAccessibilityTraits accessibilityRoleTraits =
       json ? [RCTConvert UIAccessibilityTraits:json] : UIAccessibilityTraitNone;
   if (view.reactAccessibilityElement.accessibilityRoleTraits != accessibilityRoleTraits) {
@@ -302,8 +302,16 @@ RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
     view.reactAccessibilityElement.accessibilityRole = json ? [RCTConvert NSString:json] : nil;
     [self updateAccessibilityTraitsForRole:view withDefaultView:defaultView];
   }
+  #else // [macOS
+    if (json) {
+      view.reactAccessibilityElement.accessibilityRole = [RCTConvert accessibilityRoleFromTraits:json];
+    } else {
+      view.reactAccessibilityElement.accessibilityRole = defaultView.accessibilityRole;
+    }
+  #endif // macOS]
 }
 
+#if !TARGET_OS_OSX // [macOS]
 RCT_CUSTOM_VIEW_PROPERTY(role, UIAccessibilityTraits, RCTView)
 {
   UIAccessibilityTraits roleTraits = json ? [RCTConvert UIAccessibilityTraits:json] : UIAccessibilityTraitNone;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

During the merge for 0.73, accessibilityRole was accidentally put behind an #if block removing it from macOS's implementation.  This simply restores the functionality of the prop to what it was in 0.72, but more changes are forthcoming to refactor and support the new role prop.

## Changelog:

[MACOS] [FIXED] - Fixed accessibilityRole

## Test Plan:

See before/after of Accessibility Inspector for accessibilityRole="button" changing from AXUnknown to AXButton

![Screenshot 2023-12-19 at 12 11 20 PM](https://github.com/microsoft/react-native-macos/assets/7664112/c2f49560-aa72-469e-9e22-926c26740033)
![Screenshot 2023-12-19 at 12 12 18 PM](https://github.com/microsoft/react-native-macos/assets/7664112/304fd5fd-4f00-4ee1-ad46-3d263b2b2fd8)
