### PR TITLE
Fix accessibilityRole

### DIFF
--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -284,9 +284,10 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 RCT_REMAP_VIEW_PROPERTY(transform, reactTransform, CATransform3D)
 RCT_REMAP_VIEW_PROPERTY(transformOrigin, reactTransformOrigin, RCTTransformOrigin)
 
-#if !TARGET_OS_OSX // [macOS]
+
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
 {
+  #if !TARGET_OS_OSX // [macOS]
   UIAccessibilityTraits accessibilityRoleTraits =
       json ? [RCTConvert UIAccessibilityTraits:json] : UIAccessibilityTraitNone;
   if (view.reactAccessibilityElement.accessibilityRoleTraits != accessibilityRoleTraits) {
@@ -294,8 +295,16 @@ RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
     view.reactAccessibilityElement.accessibilityRole = json ? [RCTConvert NSString:json] : nil;
     [self updateAccessibilityTraitsForRole:view withDefaultView:defaultView];
   }
+  #else // [macOS
+    if (json) {
+      view.reactAccessibilityElement.accessibilityRole = [RCTConvert accessibilityRoleFromTraits:json];
+    } else {
+      view.reactAccessibilityElement.accessibilityRole = defaultView.accessibilityRole;
+    }
+  #endif // macOS]
 }
 
+#if !TARGET_OS_OSX // [macOS]
 RCT_CUSTOM_VIEW_PROPERTY(role, UIAccessibilityTraits, RCTView)
 {
   UIAccessibilityTraits roleTraits = json ? [RCTConvert UIAccessibilityTraits:json] : UIAccessibilityTraitNone;

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -284,7 +284,6 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 RCT_REMAP_VIEW_PROPERTY(transform, reactTransform, CATransform3D)
 RCT_REMAP_VIEW_PROPERTY(transformOrigin, reactTransformOrigin, RCTTransformOrigin)
 
-
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
 {
   #if !TARGET_OS_OSX // [macOS]


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

In the merges for 0.73, accessibilityRole was inadvertently moved behind a #if block removing it from macOS.  This restores the 0.72 behavior, but more work is coming for the new role prop.  This is the main version of #1997

## Test Plan:

See #1997