### PR TITLE
[CI] Fix beachball publish

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -176,4 +176,4 @@ extends:
                displayName: "Publish beachball packages to npmjs.org"
                inputs:
                  script: |
-                   npx beachball publish --scope '!packages/react-native' --branch origin/$(Build.SourceBranchName) -n NOAUTH -yes -m "applying package updates ***NO_CI***" --access public
+                   npx beachball publish --scope '!packages/react-native' --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --access public

--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "beachball": {
+    "shouldPublish": false
   }
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

Our CI was not properly running `beachball publish`. I traced this to two issues:

1) We weren't actually passing in the NPM auth token to beachball. This seems to be a typo from an [earlier PR](https://github.com/microsoft/react-native-macos/pull/1963/) refactoring the publish yml. 
2) One of the packages we inherit from upstream (`@react-native/community-cli-plugin`) was trying to get published. This was probably introduced / added in a merge, and we didn't add the `beachball : { shouldPublish: false }` section to our package.json to account. Let's just fix that

## Changelog:

[INTERNAL] [FIXED] - Fix beachball publish

## Test Plan:

CI should pass. 
