### PR TITLE
[CI] Fix more CI issues

### DIFF
--- a/change/@react-native-mac-virtualized-lists-ff168bbc-375a-451a-859e-a599045a960a.json
+++ b/change/@react-native-mac-virtualized-lists-ff168bbc-375a-451a-859e-a599045a960a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Force bump @react-native-mac/virtualized-lists to 0.73.3-0",
-  "packageName": "@react-native-mac/virtualized-lists",
-  "email": "adgleitm@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-mac/virtualized-lists",
-  "version": "0.73.2",
+  "version": "0.73.3",
   "description": "Virtualized lists for React Native macOS.",
   "license": "MIT",
   "repository": {

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -16,6 +16,23 @@ const {
   getCurrentCommit,
   isTaggedLatest,
 } = require('./scm-utils');
+const path = require('path'); // [macOS]
+const fs = require('fs'); // [macOS]
+
+// [macOS] Function to get our version from package.json instead of the CircleCI build tag.
+function getPkgJsonVersion() {
+  const RN_PACKAGE_DIRECTORY = path.resolve(
+    __dirname,
+    '..',
+    'packages',
+    'react-native',
+  );
+  const pkgJsonPath = path.resolve(RN_PACKAGE_DIRECTORY, 'package.json');
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+  const pkgJsonVersion = pkgJson.version;
+  return pkgJsonVersion;
+}
+// macOS]
 
 // Get `next` version from npm and +1 on the minor for `main` version
 function getMainVersion() {
@@ -48,7 +65,7 @@ function getNpmInfo(buildType) {
   }
 
   const {version, major, minor, prerelease} = parseVersion(
-    process.env.CIRCLE_TAG,
+    getPkgJsonVersion(), // [macOS] We can't use the CircleCI build tag, so we use the version argument instead.
     buildType,
   );
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

This PR fixes two followup issues uncovered on our publish pipeline:

1) `@react-native-mac/virtualized-lists v0.73.3` got published to NPM, but the followup git commit to delete the change file and bump versions never happened. Let's manually sync by doing both.

2) In `0.73-stable`, some of the upstream NPM publish scripts got refactored that removed some of our diffs to not use the `process.env.CIRCLE_TAG` variable. Let's just bring back our diff to use the `package.json` version instead of relying on a CircleCI environment variable.

## Changelog:

[INTERNAL] [FIXED] - Fix more CI issues

## Test Plan:

CI should pass.
