### PR TITLE
Update package.json - fix typo in repo URL

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/micosoft/react-native-macos.git",
+    "url": "https://github.com/microsoft/react-native-macos.git",
     "directory": "packages/react-native"
   },
   "homepage": "https://reactnative.dev/",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

I found broken URL on the npm readme page:
![CleanShot 2023-12-28 at 09 28 18@2x](https://github.com/microsoft/react-native-macos/assets/784018/d9c0991b-d662-4440-9f26-63c05c1f4020)

## Changelog:

[INTERNAL] [FIXED] - Fix repository URL
