### PR TITLE
[react-native] Fix Hermes version mismatch

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -10,8 +10,10 @@ react_native_path = File.join(__dir__, "..", "..")
 
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+# [macOS
 rn_version = package['version']
 version = findLastestVersionWithArtifact(rn_version) || rn_version
+# macOS]
 
 source_type = hermes_source_type(version, react_native_path)
 source = podspec_source(source_type, version, react_native_path)

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -10,7 +10,8 @@ react_native_path = File.join(__dir__, "..", "..")
 
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
-version = package['version']
+rn_version = package['version']
+version = findLastestVersionWithArtifact(rn_version) || rn_version
 
 source_type = hermes_source_type(version, react_native_path)
 source = podspec_source(source_type, version, react_native_path)

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -5,7 +5,7 @@
 
 require 'net/http'
 require 'rexml/document'
-require 'open3'
+require 'open3' # [macOS]
 
 HERMES_GITHUB_URL = "https://github.com/facebook/hermes.git"
 

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -8,7 +8,6 @@ require 'rexml/document'
 require 'open3'
 
 HERMES_GITHUB_URL = "https://github.com/facebook/hermes.git"
-REACT_NATIVE_ARTIFACTS_MAVEN_URL = "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts"
 
 module HermesEngineSourceType
     LOCAL_PREBUILT_TARBALL = :local_prebuilt_tarball
@@ -205,7 +204,7 @@ end
 def release_tarball_url(version, build_type)
     # Sample url from Maven:
     # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.71.0/react-native-artifacts-0.71.0-hermes-ios-debug.tar.gz
-    return "#{REACT_NATIVE_ARTIFACTS_MAVEN_URL}/#{version}/react-native-artifacts-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
+    return "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/#{version}/react-native-artifacts-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
 end
 
 def download_stable_hermes(react_native_path, version, configuration)
@@ -235,11 +234,11 @@ def resolve_url_redirects(url)
     return (`curl -Ls -o /dev/null -w %{url_effective} \"#{url}\"`)
 end
 
-# react-native-macos does not publish macos specific hermes artifacts
+# [macOS react-native-macos does not publish macos specific hermes artifacts
 # so we attempt to find the latest patch version of the iOS artifacts and use that
 def findLastestVersionWithArtifact(version)
     versionWithoutPatch = version.match(/^(\d+\.\d+)/)
-    xml_data, = Open3.capture3("curl -s #{REACT_NATIVE_ARTIFACTS_MAVEN_URL}/maven-metadata.xml")
+    xml_data, = Open3.capture3("curl -s https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/maven-metadata.xml")
 
     metadata = REXML::Document.new(xml_data)
     versions = metadata.elements.to_a('//metadata/versioning/versions/version')
@@ -255,6 +254,7 @@ def findLastestVersionWithArtifact(version)
 
     return sorted_versions.last
 end
+# macOS]
 
 # This function checks that Hermes artifact exists.
 # As of now it should check it on the Maven repo.


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

The hermes script ([hermes-utils.rb](https://github.com/microsoft/react-native-macos/compare/main...gabrieldonadel:fix-hermes-version-mismatch?expand=1#diff-ff9ad29b570f869cc7f919efbe9d306bd5f90e8fa17dd6b51f8eb83d15c120e4)) uses the react-native-macos version to check for available hermes artifacts on maven but the problem is that whenever react-native-macos version gets ahead of react-native there are no prebuilds to be found and hermes will try to build from source (which does not work). 

This PR fixes this by checking the latest available patch version for a given version and using that as the hermes-version 

## Changelog:

[MACOS] [FIXED] - Fix Hermes version mismatch


## Test Plan:

Enable hermes on rntester, set react-native package.json version to 0.73.2, run pod install and certify it's downloading the prebuild tarball 
