### PR TITLE
Add visionOS support

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -133,7 +133,11 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
     rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:initProps];
   }
 #if !TARGET_OS_OSX // [macOS]
+#if !TARGET_OS_VISION // [visionOS]
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+#else
+  self.window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 1280, 720)];
+#endif // [visionOS]
   UIViewController *rootViewController = [self createRootViewController];
   [self setRootView:rootView toRootViewController:rootViewController];
   self.window.rootViewController = rootViewController;
@@ -142,7 +146,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
   return YES;
 #else // [macOS
-  NSRect frame = NSMakeRect(0,0,1024,768);
+  NSRect frame = NSMakeRect(0,0,1280,720);
   self.window = [[NSWindow alloc] initWithContentRect:NSZeroRect
 											styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskResizable | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable
 											  backing:NSBackingStoreBuffered

--- a/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
+++ b/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
@@ -193,15 +193,10 @@ static NSUInteger RCTDeviceFreeMemory(void)
 
 - (void)displayDidRefresh:(CADisplayLink *)displayLink
 {
-#if TARGET_OS_UIKITFORMAC
-  // TODO: `displayLink.frameInterval` is not available on UIKitForMac
-  NSTimeInterval durationToNextRefresh = displayLink.duration;
-#else
   // displaylink.duration -- time interval between frames, assuming maximumFramesPerSecond
   // displayLink.preferredFramesPerSecond (>= iOS 10) -- Set to 30 for displayDidRefresh to be called at 30 fps
   // durationToNextRefresh -- Time interval to the next time displayDidRefresh is called
   NSTimeInterval durationToNextRefresh = displayLink.targetTimestamp - displayLink.timestamp;
-#endif
   NSUInteger totalFrameCount = self.totalFrameCount;
   NSUInteger currentFrameIndex = self.currentFrameIndex;
   NSUInteger nextFrameIndex = (currentFrameIndex + 1) % totalFrameCount;

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -54,7 +54,10 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
-	s.ios.frameworks         = "MobileCoreServices" # [macOS] Restrict to iOS
+  # [macOS MobileCoreServices Not available on macOS
+  s.ios.frameworks         = "MobileCoreServices" 
+  s.visionos.frameworks    = "MobileCoreServices"
+  # macOS]
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-Codegen", version

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -20,7 +20,9 @@ typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 #if !TARGET_OS_OSX // [macOS]
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification
               fetchCompletionHandler:(RCTRemoteNotificationCallback)completionHandler;
+#if TARGET_OS_IOS // [visionOS]
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification;
+#endif // [visionOS]
 #endif // [macOS]
 #if TARGET_OS_OSX // [macOS
 + (void)didReceiveUserNotification:(NSUserNotification *)notification;

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -15,7 +15,6 @@ extern NSString *const RCTRemoteNotificationReceived;
 typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 #endif // [macOS]
 
-#if !TARGET_OS_UIKITFORMAC
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
 #if !TARGET_OS_OSX // [macOS]
@@ -27,6 +26,5 @@ typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 + (void)didReceiveUserNotification:(NSUserNotification *)notification;
 #endif // macOS]
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
-#endif
 
 @end

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -118,7 +118,8 @@ static NSDictionary *RCTFormatLocalNotification(UILocalNotification *notificatio
   formattedLocalNotification[@"remote"] = @NO;
   return formattedLocalNotification;
 }
-#else // [macOS
+#endif // [macOS] [visionOS]
+#if TARGET_OS_OSX // [macOS
 static NSDictionary *RCTFormatUserNotification(NSUserNotification *notification)
 {
   NSMutableDictionary *formattedUserNotification = [NSMutableDictionary dictionary];
@@ -271,14 +272,15 @@ RCT_EXPORT_MODULE()
 }
 #endif // [macOS]
 
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
                                                       object:self
                                                     userInfo:RCTFormatLocalNotification(notification)];
 }
-#else // [macOS 
+#endif // [macOS] [visionOS]
+#if TARGET_OS_OSX // [macOS
 + (void)didReceiveUserNotification:(NSUserNotification *)notification
 {
   NSString *notificationName = notification.isRemote ? RCTRemoteNotificationReceived : kLocalNotificationReceived;
@@ -557,7 +559,7 @@ RCT_EXPORT_METHOD(getInitialNotification
                   : (RCTPromiseResolveBlock)resolve reject
                   : (__unused RCTPromiseRejectBlock)reject)
 {
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
   NSMutableDictionary<NSString *, id> *initialNotification =
       [self.bridge.launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey] mutableCopy];
 
@@ -572,7 +574,8 @@ RCT_EXPORT_METHOD(getInitialNotification
   } else {
     resolve((id)kCFNull);
   }
-#else // [macOS
+#endif // [macOS] [visionOS]
+#if TARGET_OS_OSX // [macOS
   NSUserNotification *initialNotification = self.bridge.launchOptions[NSApplicationLaunchUserNotificationKey];
   if (initialNotification) {
     resolve(RCTFormatUserNotification(initialNotification));

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -24,8 +24,6 @@ static NSString *const kRemoteNotificationRegistrationFailed = @"RemoteNotificat
 
 static NSString *const kErrorUnableToRequestPermissions = @"E_UNABLE_TO_REQUEST_PERMISSIONS";
 
-#if !TARGET_OS_UIKITFORMAC
-
 @interface RCTPushNotificationManager () <NativePushNotificationManagerIOSSpec>
 @property (nonatomic, strong) NSMutableDictionary *remoteNotificationCallbacks;
 @end
@@ -97,16 +95,10 @@ RCT_ENUM_CONVERTER(
 
 @end
 #endif // [macOS]
-#else
-@interface RCTPushNotificationManager () <NativePushNotificationManagerIOSSpec>
-@end
-#endif // TARGET_OS_UIKITFORMAC
 
 @implementation RCTPushNotificationManager
 
-#if !TARGET_OS_UIKITFORMAC
-
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
 /** DEPRECATED. UILocalNotification was deprecated in iOS 10. Please don't add new callsites. */
 static NSDictionary *RCTFormatLocalNotification(UILocalNotification *notification)
 {
@@ -198,8 +190,6 @@ static NSString *RCTFormatNotificationDateFromNSDate(NSDate *date)
   return [formatter stringFromDate:date];
 }
 
-#endif // TARGET_OS_UIKITFORMAC
-
 RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
@@ -207,7 +197,6 @@ RCT_EXPORT_MODULE()
   return dispatch_get_main_queue();
 }
 
-#if !TARGET_OS_UIKITFORMAC
 - (void)startObserving
 {
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -637,100 +626,6 @@ RCT_EXPORT_METHOD(getAuthorizationStatus : (RCTResponseSenderBlock)callback)
     callback(@[ @(settings.authorizationStatus) ]);
   }];
 }
-
-#else // TARGET_OS_UIKITFORMAC
-
-RCT_EXPORT_METHOD(onFinishRemoteNotification : (NSString *)notificationId fetchResult : (NSString *)fetchResult)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(setApplicationIconBadgeNumber : (double)number)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(getApplicationIconBadgeNumber : (RCTResponseSenderBlock)callback)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(requestPermissions
-                  : (JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions resolve
-                  : (RCTPromiseResolveBlock)resolve reject
-                  : (RCTPromiseRejectBlock)reject)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(abandonPermissions)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(checkPermissions : (RCTResponseSenderBlock)callback)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(presentLocalNotification : (JS::NativePushNotificationManagerIOS::Notification &)notification)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(scheduleLocalNotification : (JS::NativePushNotificationManagerIOS::Notification &)notification)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(cancelAllLocalNotifications)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(cancelLocalNotifications : (NSDictionary<NSString *, id> *)userInfo)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(getInitialNotification
-                  : (RCTPromiseResolveBlock)resolve reject
-                  : (__unused RCTPromiseRejectBlock)reject)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(getScheduledLocalNotifications : (RCTResponseSenderBlock)callback)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(removeAllDeliveredNotifications)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(removeDeliveredNotifications : (NSArray<NSString *> *)identifiers)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(getDeliveredNotifications : (RCTResponseSenderBlock)callback)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-RCT_EXPORT_METHOD(getAuthorizationStatus : (RCTResponseSenderBlock)callback)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
-- (NSArray<NSString *> *)supportedEvents
-{
-  return @[];
-}
-
-#endif // TARGET_OS_UIKITFORMAC
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params

--- a/packages/react-native/Libraries/Text/React-RCTText.podspec
+++ b/packages/react-native/Libraries/Text/React-RCTText.podspec
@@ -30,7 +30,10 @@ Pod::Spec.new do |s|
   s.ios.exclude_files      = "**/macOS/*" # [macOS]
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTText"
-  s.ios.framework          = ["MobileCoreServices"] # [macOS] Restrict to iOS
+  # [macOS MobileCoreServices Not available on macOS
+  s.ios.frameworks         = "MobileCoreServices" 
+  s.visionos.frameworks    = "MobileCoreServices"
+  # macOS]
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
 
   s.dependency "Yoga"

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -379,19 +379,15 @@
     if (_editMenuInteraction) {
       [_editMenuInteraction presentEditMenuWithConfiguration:config];
     }
-    return;
+  } else {
+    UIMenuController *menuController = [UIMenuController sharedMenuController];
+
+    if (menuController.isMenuVisible) {
+      return;
+    }
+
+    [menuController showMenuFromView:self rect:self.bounds];
   }
-  UIMenuController *menuController = [UIMenuController sharedMenuController];
-
-	  if (menuController.isMenuVisible) {
-		return;
-	  }
-
-	  if (!self.isFirstResponder) {
-		[self becomeFirstResponder];
-	  }
-
-  [menuController showMenuFromView:self rect:self.bounds];
 }
 #else // [macOS
 

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -373,8 +373,7 @@
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-#if !TARGET_OS_UIKITFORMAC
-  if (@available(iOS 16.0, *)) {
+  if (@available(iOS 16.0, macCatalyst 16.0, *)) {
     CGPoint location = [gesture locationInView:self];
     UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
     if (_editMenuInteraction) {
@@ -382,20 +381,17 @@
     }
     return;
   }
-  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
   UIMenuController *menuController = [UIMenuController sharedMenuController];
 
-  if (menuController.isMenuVisible) {
-    return;
-  }
+	  if (menuController.isMenuVisible) {
+		return;
+	  }
 
-  if (!self.isFirstResponder) {
-    [self becomeFirstResponder];
-  }
+	  if (!self.isFirstResponder) {
+		[self becomeFirstResponder];
+	  }
 
-  [menuController setTargetRect:self.bounds inView:self];
-  [menuController setMenuVisible:YES animated:YES];
-#endif
+  [menuController showMenuFromView:self rect:self.bounds];
 }
 #else // [macOS
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -851,6 +851,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 
 #pragma mark - Custom Input Accessory View
 
+#if TARGET_OS_IOS // [macOS] [visionOS]
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
   if ([changedProps containsObject:@"inputAccessoryViewID"] && self.inputAccessoryViewID) {
@@ -862,7 +863,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 
 - (void)setCustomInputAccessoryViewWithNativeID:(NSString *)nativeID
 {
-#if !TARGET_OS_OSX // [macOS]
   __weak RCTBaseTextInputView *weakSelf = self;
   [_bridge.uiManager rootViewForReactTag:self.reactTag
                           withCompletion:^(UIView *rootView) {
@@ -877,12 +877,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
                               }
                             }
                           }];
-#endif // [macOS]
 }
 
 - (void)setDefaultInputAccessoryView
 {
-#if !TARGET_OS_OSX // [macOS]
   UIView<RCTBackedTextInputViewProtocol> *textInputView = self.backedTextInputView;
   UIKeyboardType keyboardType = textInputView.keyboardType;
 
@@ -914,10 +912,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
     textInputView.inputAccessoryView = nil;
   }
   [self reloadInputViewsIfNecessary];
-#endif // [macOS]
 }
 
-#if !TARGET_OS_OSX // [macOS]
 - (void)reloadInputViewsIfNecessary
 {
   // We have to call `reloadInputViews` for focused text inputs to update an accessory view.
@@ -934,7 +930,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
     [self.backedTextInputView endEditing:YES];
   }
 }
-#endif // [macOS]
+#endif // [macOS] [visionOS]
 
 // [macOS
 

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.h
@@ -7,6 +7,9 @@
 
 // [macOS]
 
+#if TARGET_OS_OSX
 #define RCT_SUBCLASS_SECURETEXTFIELD 1
+#endif
 
 #include <React/RCTUITextField.h>
+

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.m
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.m
@@ -7,6 +7,8 @@
 
 // [macOS]
 
+#if TARGET_OS_OSX
 #define RCT_SUBCLASS_SECURETEXTFIELD 1
+#endif
 
 #include "../RCTUITextField.mm"

--- a/packages/react-native/React/Base/RCTConvert.m
+++ b/packages/react-native/React/Base/RCTConvert.m
@@ -542,8 +542,10 @@ RCT_ENUM_CONVERTER(
     (@{
       @"default" : @(UIBarStyleDefault),
       @"black" : @(UIBarStyleBlack),
+#if !TARGET_OS_VISION // [visionOS]
       @"blackOpaque" : @(UIBarStyleBlackOpaque),
       @"blackTranslucent" : @(UIBarStyleBlackTranslucent),
+#endif // [visionOS]
     }),
     UIBarStyleDefault,
     integerValue)

--- a/packages/react-native/React/Base/RCTKeyCommands.m
+++ b/packages/react-native/React/Base/RCTKeyCommands.m
@@ -129,7 +129,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     isKeyDown = [event _isKeyDown];
   }
 
-  BOOL interactionEnabled = !RCTSharedApplication().isIgnoringInteractionEvents;
+#if !TARGET_OS_VISION // [visionOS]
+   BOOL interactionEnabled = !RCTSharedApplication().isIgnoringInteractionEvents;
+ #else // [visionOS
+   BOOL interactionEnabled = true;
+ #endif // visionOS]
   BOOL hasFirstResponder = NO;
   if (isKeyDown && modifiedInput.length > 0 && interactionEnabled) {
     UIResponder *firstResponder = nil;

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -99,6 +99,11 @@ RCT_EXTERN RCTUIApplication *__nullable RCTSharedApplication(void); // [macOS]
 // or view controller
 RCT_EXTERN RCTUIWindow *__nullable RCTKeyWindow(void); // [macOS]
 
+#if TARGET_OS_VISION // [visionOS
+// Returns UIStatusBarManager to get it's configuration info.
+RCT_EXTERN UIStatusBarManager *__nullable RCTUIStatusBarManager(void);
+#endif // visionOS]
+
 #if !TARGET_OS_OSX // [macOS]
 // Returns the presented view controller, useful if you need
 // e.g. to present a modal view controller or alert over it

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -352,7 +352,11 @@ CGSize RCTScreenSize(void)
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     RCTUnsafeExecuteOnMainQueueSync(^{
+#if TARGET_OS_IOS // [visionOS]
       size = [UIScreen mainScreen].bounds.size;
+#else // [visionOS
+      size = RCTKeyWindow().bounds.size;
+#endif // visionOS]
     });
   });
 
@@ -619,6 +623,14 @@ RCTUIWindow *__nullable RCTKeyWindow(void) // [macOS]
   return [NSApp keyWindow];
 #endif // macOS]
 }
+
+#if TARGET_OS_VISION // [visionOS
+UIStatusBarManager *__nullable RCTUIStatusBarManager(void) {
+	NSSet *connectedScenes = RCTSharedApplication().connectedScenes;
+	UIWindowScene *windowScene = [connectedScenes anyObject];
+	return windowScene.statusBarManager;
+}
+#endif // visionOS]
 
 #if !TARGET_OS_OSX // [macOS]
 UIViewController *__nullable RCTPresentedViewController(void)

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -56,12 +56,14 @@ RCT_EXPORT_MODULE()
                                                name:RCTAccessibilityManagerDidUpdateMultiplierNotification
                                              object:[_moduleRegistry moduleForName:"AccessibilityManager"]];
 
+#if TARGET_OS_IOS // [visionOS]
   _currentInterfaceOrientation = [RCTSharedApplication() statusBarOrientation];
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceOrientationDidChange)
                                                name:UIApplicationDidChangeStatusBarOrientationNotification
                                              object:nil];
+#endif // [visionOS]
 #endif // [macOS]
 
   _currentInterfaceDimensions = [self _exportedDimensions];
@@ -90,8 +92,8 @@ RCT_EXPORT_MODULE()
 
 static BOOL RCTIsIPhoneNotched()
 {
-#if !TARGET_OS_OSX // [macOS]
   static BOOL isIPhoneNotched = NO;
+#if TARGET_OS_IOS // [macOS] [visionOS]
   static dispatch_once_t onceToken;
 
   dispatch_once(&onceToken, ^{
@@ -100,11 +102,9 @@ static BOOL RCTIsIPhoneNotched()
     // 20pt is the top safeArea value in non-notched devices
     isIPhoneNotched = RCTSharedApplication().keyWindow.safeAreaInsets.top > 20;
   });
+#endif // [macOS] [visionOS]
 
   return isIPhoneNotched;
-#else // [macOS
-  return NO;
-#endif // macOS]
 }
 
 
@@ -182,8 +182,7 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
   });
 }
 
-#if !TARGET_OS_OSX // [macOS]
-
+#if TARGET_OS_IOS // [macOS] [visionOS]
 - (void)interfaceOrientationDidChange
 {
   __weak __typeof(self) weakSelf = self;
@@ -224,7 +223,7 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 #pragma clang diagnostic pop
   }
 }
-#endif // [macOS]
+#endif // [macOS] [visionOS]
 
 - (void)interfaceFrameDidChange
 {

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -183,7 +183,11 @@ RCT_EXPORT_MODULE()
 - (UIView *)container
 {
   if (!_container) {
-    CGSize statusBarSize = RCTSharedApplication().statusBarFrame.size;
+#if !TARGET_OS_VISION // [visionOS]
+	CGSize statusBarSize = RCTSharedApplication().statusBarFrame.size;
+#else // [visionOS
+	CGSize statusBarSize = RCTUIStatusBarManager().statusBarFrame.size;
+#endif // visionOS]
     CGFloat statusBarHeight = statusBarSize.height;
     _container = [[UIView alloc] initWithFrame:CGRectMake(10, statusBarHeight, 180, RCTPerfMonitorBarHeight)];
     _container.layer.borderWidth = 2;

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -953,9 +953,15 @@ RCT_EXPORT_MODULE()
 
     if (!self->_window) {
 #if !TARGET_OS_OSX // [macOS]
+#if !TARGET_OS_VISION // [macOS]
       self->_window = [[RCTRedBoxWindow alloc] initWithFrame:[UIScreen mainScreen].bounds
                                     customButtonTitles:self->_customButtonTitles
                                   customButtonHandlers:self->_customButtonHandlers];
+#else // [visionOS
+	  self->_window = [[RCTRedBoxWindow alloc] initWithFrame:CGRectMake(0, 0, 1280, 720)
+									customButtonTitles:self->_customButtonTitles
+								  customButtonHandlers:self->_customButtonHandlers];
+#endif // visionOS]
 #else // [macOS
       self->_window = [RCTRedBoxWindow new];
 #endif // macOS]

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -68,7 +68,9 @@ static RCTUIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWith
     if (self.nativeId) {
 #if !TARGET_OS_OSX // [macOS]
       _textInput = RCTFindTextInputWithNativeId(self.window, self.nativeId);
+#if !TARGET_OS_VISION // [visionOS]
       _textInput.inputAccessoryView = _contentView;
+#endif // [visionOS]
 #else // [macOS
       _textInput = RCTFindTextInputWithNativeId(self.window.contentView, self.nativeId);
 #endif // macOS]
@@ -87,10 +89,12 @@ static RCTUIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWith
   return true;
 }
 
+#if !TARGET_OS_VISION // [visionOS]
 - (RCTUIView *)inputAccessoryView // [macOS]
 {
   return _contentView;
 }
+#endif // [visionOS]
 
 #pragma mark - RCTComponentViewProtocol
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -43,10 +43,12 @@
   [_touchHandler attachToView:self.view];
 }
 
+#if TARGET_OS_IOS // [visionOS]
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
   return [RCTSharedApplication() statusBarStyle];
 }
+#endif // [visionOS]
 
 - (void)viewDidDisappear:(BOOL)animated
 {
@@ -54,16 +56,22 @@
   _lastViewBounds = CGRectZero;
 }
 
+#if TARGET_OS_IOS // [visionOS]
 - (BOOL)prefersStatusBarHidden
 {
   return [RCTSharedApplication() isStatusBarHidden];
 }
+#endif // [visionOS]
 
 #if RCT_DEV
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
+#if !TARGET_OS_VISION // [visionOS]
   UIInterfaceOrientationMask appSupportedOrientationsMask =
       [RCTSharedApplication() supportedInterfaceOrientationsForWindow:[RCTSharedApplication() keyWindow]];
+#else // [visionOS
+  UIInterfaceOrientationMask appSupportedOrientationsMask = UIInterfaceOrientationMaskLandscape;
+#endif // visonOS]
   if (!(_supportedInterfaceOrientations & appSupportedOrientationsMask)) {
     RCTLogError(
         @"Modal was presented with 0x%x orientations mask but the application only supports 0x%x."

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -28,7 +28,7 @@ using namespace facebook::react;
 
 static const CGFloat kClippingLeeway = 44.0;
 
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
 static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(const ScrollViewProps &props)
 {
   switch (props.keyboardDismissMode) {
@@ -40,7 +40,9 @@ static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(const S
       return UIScrollViewKeyboardDismissModeInteractive;
   }
 }
+#endif // [macOS] [visionOS]
 
+#if !TARGET_OS_OSX // [macOS
 static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const ScrollViewProps &props)
 {
   switch (props.indicatorStyle) {
@@ -52,6 +54,7 @@ static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const S
       return UIScrollViewIndicatorStyleWhite;
   }
 }
+#endif // [macOS]
 
 // Once Fabric implements proper NativeAnimationDriver, this should be removed.
 // This is just a workaround to allow animations based on onScroll event.
@@ -79,7 +82,6 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
                                                       userInfo:userInfo];
   }
 }
-#endif // [macOS]
 
 @interface RCTScrollViewComponentView () <
 #if !TARGET_OS_OSX // [macOS]
@@ -329,9 +331,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(RCTUIScrollView *sc
   MAP_SCROLL_VIEW_PROP(snapToInterval);
 
   if (oldScrollViewProps.keyboardDismissMode != newScrollViewProps.keyboardDismissMode) {
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
     scrollView.keyboardDismissMode = RCTUIKeyboardDismissModeFromProps(newScrollViewProps);
-#endif // [macOS]
+#endif // [macOS] [visionOS]
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -251,7 +251,6 @@ using namespace facebook::react;
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-#if !TARGET_OS_UIKITFORMAC
   if (@available(iOS 16.0, *)) {
     CGPoint location = [gesture locationInView:self];
     UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
@@ -260,20 +259,17 @@ using namespace facebook::react;
     }
     return;
   }
-  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
   UIMenuController *menuController = [UIMenuController sharedMenuController];
 
   if (menuController.isMenuVisible) {
-    return;
+  return;
   }
 
   if (!self.isFirstResponder) {
-    [self becomeFirstResponder];
+  [self becomeFirstResponder];
   }
 
-  [menuController setTargetRect:self.bounds inView:self];
-  [menuController setMenuVisible:YES animated:YES];
-#endif
+  [menuController showMenuFromView:self rect:self.bounds];
 }
 #endif // [macOS]
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -251,25 +251,21 @@ using namespace facebook::react;
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-  if (@available(iOS 16.0, *)) {
+  if (@available(iOS 16.0, macCatalyst 16.0, *)) {
     CGPoint location = [gesture locationInView:self];
     UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
     if (_editMenuInteraction) {
       [_editMenuInteraction presentEditMenuWithConfiguration:config];
     }
-    return;
-  }
-  UIMenuController *menuController = [UIMenuController sharedMenuController];
+  } else {
+    UIMenuController *menuController = [UIMenuController sharedMenuController];
 
-  if (menuController.isMenuVisible) {
-  return;
-  }
+    if (menuController.isMenuVisible) {
+      return;
+    }
 
-  if (!self.isFirstResponder) {
-  [self becomeFirstResponder];
+    [menuController showMenuFromView:self rect:self.bounds];
   }
-
-  [menuController showMenuFromView:self rect:self.bounds];
 }
 #endif // [macOS]
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -563,6 +563,7 @@ using namespace facebook::react;
        keyboardType == UIKeyboardTypeDecimalPad || keyboardType == UIKeyboardTypeASCIICapableNumberPad) &&
       _backedTextInputView.returnKeyType == UIReturnKeyDone;
 
+#if !TARGET_OS_VISION // [visionOS]
   if ((_backedTextInputView.inputAccessoryView != nil) == shouldHaveInputAccessoryView) {
     return;
   }
@@ -581,7 +582,8 @@ using namespace facebook::react;
   } else {
     _backedTextInputView.inputAccessoryView = nil;
   }
-  
+#endif // [visionOS]
+
   if (_backedTextInputView.isFirstResponder) {
     [_backedTextInputView reloadInputViews];
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -32,9 +32,9 @@ void RCTCopyBackedTextInput(
   toTextInput.placeholder = fromTextInput.placeholder;
   toTextInput.placeholderColor = fromTextInput.placeholderColor;
   toTextInput.textContainerInset = fromTextInput.textContainerInset;
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
   toTextInput.inputAccessoryView = fromTextInput.inputAccessoryView;
-#endif // [macOS]
+#endif // [macOS] [visionOS]
   toTextInput.textInputDelegate = fromTextInput.textInputDelegate;
   toTextInput.placeholderColor = fromTextInput.placeholderColor;
   toTextInput.defaultTextAttributes = fromTextInput.defaultTextAttributes;

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -291,9 +291,11 @@ static PointerEvent CreatePointerEventFromActivePointer(
 
   if (eventType == RCTPointerEventTypeCancel) {
     event.clientPoint = RCTPointFromCGPoint(CGPointZero);
+#if !TARGET_OS_VISION // [visionOS]
     event.screenPoint =
         RCTPointFromCGPoint([rootComponentView convertPoint:CGPointZero
                                           toCoordinateSpace:rootComponentView.window.screen.coordinateSpace]);
+#endif // [visionOS]
     event.offsetPoint = RCTPointFromCGPoint([rootComponentView convertPoint:CGPointZero
                                                                      toView:activePointer.componentView]);
   } else {
@@ -386,8 +388,10 @@ static void UpdateActivePointerWithUITouch(
 
 #if !TARGET_OS_OSX // [macOS]
   activePointer.clientPoint = [uiTouch locationInView:rootComponentView];
+#if !TARGET_OS_VISION // [visionOS]
   activePointer.screenPoint = [rootComponentView convertPoint:activePointer.clientPoint
                                             toCoordinateSpace:rootComponentView.window.screen.coordinateSpace];
+#endif // [visionOS]
   activePointer.offsetPoint = [uiTouch locationInView:activePointer.componentView];
 #else // [macOS
   activePointer.offsetPoint = [activePointer.componentView convertPoint:uiTouch.locationInWindow fromView:nil];
@@ -910,9 +914,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 {
   UIView *listenerView = recognizer.view;
   CGPoint clientLocation = [recognizer locationInView:listenerView];
+#if !TARGET_OS_VISION // [visionOS]
   CGPoint screenLocation = [listenerView convertPoint:clientLocation
                                     toCoordinateSpace:listenerView.window.screen.coordinateSpace];
-
+#else // [visionOS
+  CGPoint screenLocation = CGPointZero;
+#endif // visionOS]
   UIView *targetView = [listenerView hitTest:clientLocation withEvent:nil];
   targetView = FindClosestFabricManagedTouchableView(targetView);
 

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -58,8 +58,12 @@ static void UpdateActiveTouchWithUITouch(
 #if !TARGET_OS_OSX // [macOS]
   CGPoint offsetPoint = [uiTouch locationInView:activeTouch.componentView];
   CGPoint pagePoint = [uiTouch locationInView:rootComponentView];
+#if !TARGET_OS_VISION // [visionOS]
   CGPoint screenPoint = [rootComponentView convertPoint:pagePoint
                                       toCoordinateSpace:rootComponentView.window.screen.coordinateSpace];
+#else // [visionOS
+  CGPoint screenPoint = CGPointZero;
+#endif // visionOS]
   pagePoint = CGPointMake(pagePoint.x + rootViewOriginOffset.x, pagePoint.y + rootViewOriginOffset.y);
 #else // [macOS
   CGPoint offsetPoint = [activeTouch.componentView convertPoint:uiTouch.locationInWindow fromView:nil];

--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -195,10 +195,12 @@ RCT_EXPORT_MODULE()
                                                object:[self->_bridge moduleForName:@"AccessibilityManager"
                                                              lazilyLoadIfNecessary:YES]];
   });
+#if TARGET_OS_IOS // [visionOS]
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(namedOrientationDidChange)
                                                name:UIDeviceOrientationDidChangeNotification
                                              object:nil];
+#endif // [visionOS]
   [RCTLayoutAnimation initializeStatics];
 #endif // [macOS]
 }
@@ -228,7 +230,7 @@ RCT_EXPORT_MODULE()
 }
 #endif // [macOS]
 
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
 // Names and coordinate system from html5 spec:
 // https://developer.mozilla.org/en-US/docs/Web/API/Screen.orientation
 // https://developer.mozilla.org/en-US/docs/Web/API/Screen.lockOrientation
@@ -281,7 +283,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
                                                                         body:orientationEvent];
 #pragma clang diagnostic pop
 }
-#endif // macOS]
+#endif // [macOS] [visionOS]
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -66,8 +66,11 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.module_name            = "RCTFabric"
-  s.ios.framework          = ["JavaScriptCore", "MobileCoreServices"] # [macOS] Restrict MobileCoreServices to iOS
-  s.osx.framework          = ["JavaScriptCore"] # [macOS] Restrict MobileCoreServices to iOS
+  # [macOS MobileCoreServices not available on macOS
+  s.ios.framework          = ["JavaScriptCore", "MobileCoreServices"] 
+  s.visionos.framework     = ["JavaScriptCore", "MobileCoreServices"] 
+  s.osx.framework          = ["JavaScriptCore"]
+  # macOS]
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths,
     "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" + " " + folly_flags,

--- a/packages/react-native/React/UIUtils/RCTUIUtils.m
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.m
@@ -12,24 +12,41 @@
 RCTDimensions RCTGetDimensions(CGFloat fontScale)
 {
 #if !TARGET_OS_OSX // [macOS]
+#if !TARGET_OS_VISION // [visionOS]
   UIScreen *mainScreen = UIScreen.mainScreen;
   CGSize screenSize = mainScreen.bounds.size;
+#else
+  CGSize screenSize = CGSizeZero;
+#endif
+#else // [macOS
+  NSScreen *mainScreen = NSScreen.mainScreen;
+  CGSize screenSize = mainScreen.frame.size;
+#endif // macOS]
 
+#if !TARGET_OS_OSX // [macOS]
   UIView *mainWindow = RCTKeyWindow();
   // We fallback to screen size if a key window is not found.
   CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
 #else // [macOS
-  RCTUIWindow *window = RCTKeyWindow();
-  NSSize windowSize = window ? [window frame].size : CGSizeMake(0, 0);
-  NSSize screenSize = window ? [[window screen] frame].size : CGSizeMake(0, 0);
+  NSWindow *window = RCTKeyWindow();
+  NSSize windowSize = window ? [window frame].size : CGSizeZero;
+  screenSize = window ? [[window screen] frame].size : screenSize;
   CGFloat scale = window ? [[window screen] backingScaleFactor] : 1.0; // Default scale to 1.0 if window is nil
-#endif // macOS
+#endif // macOS]
+  
   RCTDimensions result;
 #if !TARGET_OS_OSX // [macOS]
+#if !TARGET_OS_VISION // [visionOS]
   typeof(result.screen) dimsScreen = {
       .width = screenSize.width, .height = screenSize.height, .scale = mainScreen.scale, .fontScale = fontScale};
   typeof(result.window) dimsWindow = {
       .width = windowSize.width, .height = windowSize.height, .scale = mainScreen.scale, .fontScale = fontScale};
+#else // [visionOS hardcode the scale to a dummy value of 2
+  typeof(result.screen) dimsScreen = {
+	  .width = screenSize.width, .height = screenSize.height, .scale = 2, .fontScale = fontScale};
+  typeof(result.window) dimsWindow = {
+	  .width = windowSize.width, .height = windowSize.height, .scale = 2, .fontScale = fontScale};
+#endif // visionOS]
 #else // [macOS
   typeof(result.screen) dimsScreen = {
       .width = screenSize.width, 

--- a/packages/react-native/React/Views/RCTModalHostView.m
+++ b/packages/react-native/React/Views/RCTModalHostView.m
@@ -73,6 +73,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 
 - (void)notifyForOrientationChange
 {
+#if TARGET_OS_IOS // [visionOS]
   if (!_onOrientationChange) {
     return;
   }
@@ -89,6 +90,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     @"orientation" : isPortrait ? @"portrait" : @"landscape",
   };
   _onOrientationChange(eventPayload);
+#endif // [visionOS]
 }
 
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex

--- a/packages/react-native/React/Views/RCTModalHostViewController.m
+++ b/packages/react-native/React/Views/RCTModalHostViewController.m
@@ -25,8 +25,10 @@
 
   self.modalInPresentation = YES;
 
+#if TARGET_OS_IOS // [visionOS]
   _preferredStatusBarStyle = [RCTSharedApplication() statusBarStyle];
   _preferredStatusBarHidden = [RCTSharedApplication() isStatusBarHidden];
+#endif // [visionOS]
 
   return self;
 }
@@ -41,6 +43,7 @@
   }
 }
 
+#if TARGET_OS_IOS // [visionOS]
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
   return _preferredStatusBarStyle;
@@ -50,12 +53,17 @@
 {
   return _preferredStatusBarHidden;
 }
+#endif // [visionOS]
 
 #if RCT_DEV
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
+#if !TARGET_OS_VISION // [visionOS]
   UIInterfaceOrientationMask appSupportedOrientationsMask =
       [RCTSharedApplication() supportedInterfaceOrientationsForWindow:[RCTSharedApplication() keyWindow]];
+#else // [visionOS
+  UIInterfaceOrientationMask appSupportedOrientationsMask = UIInterfaceOrientationMaskAll;
+#endif // visionOS]
   if (!(_supportedInterfaceOrientations & appSupportedOrientationsMask)) {
     RCTLogError(
         @"Modal was presented with 0x%x orientations mask but the application only supports 0x%x."

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -1403,7 +1403,9 @@ RCT_SET_AND_PRESERVE_OFFSET(setCanCancelContentTouches, canCancelContentTouches,
 RCT_SET_AND_PRESERVE_OFFSET(setDecelerationRate, decelerationRate, CGFloat)
 RCT_SET_AND_PRESERVE_OFFSET(setDirectionalLockEnabled, isDirectionalLockEnabled, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setIndicatorStyle, indicatorStyle, UIScrollViewIndicatorStyle)
+#if TARGET_OS_IOS // [visionOS]
 RCT_SET_AND_PRESERVE_OFFSET(setKeyboardDismissMode, keyboardDismissMode, UIScrollViewKeyboardDismissMode)
+#endif // visionOS]
 RCT_SET_AND_PRESERVE_OFFSET(setMaximumZoomScale, maximumZoomScale, CGFloat)
 RCT_SET_AND_PRESERVE_OFFSET(setMinimumZoomScale, minimumZoomScale, CGFloat)
 #endif // [macOS]
@@ -1415,7 +1417,9 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollsToTop, scrollsToTop, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setShowsHorizontalScrollIndicator, showsHorizontalScrollIndicator, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setShowsVerticalScrollIndicator, showsVerticalScrollIndicator, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setZoomScale, zoomScale, CGFloat);
+#if !TARGET_OS_VISION // [visionOS]
 RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, scrollIndicatorInsets, UIEdgeInsets);
+#endif // [visionOS]
 
 #if !TARGET_OS_OSX // [macOS]
 - (void)setAutomaticallyAdjustsScrollIndicatorInsets:(BOOL)automaticallyAdjusts API_AVAILABLE(ios(13.0))

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.h
@@ -11,7 +11,9 @@
 #if !TARGET_OS_OSX // [macOS]
 @interface RCTConvert (UIScrollView)
 
+#if TARGET_OS_IOS // [visionOS]
 + (UIScrollViewKeyboardDismissMode)UIScrollViewKeyboardDismissMode:(id)json;
+#endif // [visionOS]
 
 @end
 #endif // [macOS]

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
@@ -12,7 +12,7 @@
 #import "RCTShadowView.h"
 #import "RCTUIManager.h"
 
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
 @implementation RCTConvert (UIScrollView)
 
 RCT_ENUM_CONVERTER(
@@ -49,7 +49,7 @@ RCT_ENUM_CONVERTER(
     integerValue)
 
 @end
-#endif // [macOS]
+#endif // [macOS] [visionOS]
 
 @implementation RCTScrollViewManager
 
@@ -72,7 +72,9 @@ RCT_EXPORT_NOT_OSX_VIEW_PROPERTY(automaticallyAdjustKeyboardInsets, BOOL) // [ma
 RCT_EXPORT_NOT_OSX_VIEW_PROPERTY(decelerationRate, CGFloat) // [macOS]
 RCT_EXPORT_NOT_OSX_VIEW_PROPERTY(directionalLockEnabled, BOOL) // [macOS]
 RCT_EXPORT_NOT_OSX_VIEW_PROPERTY(indicatorStyle, UIScrollViewIndicatorStyle) // [macOS]
+#if TARGET_OS_IOS // [visionOS]
 RCT_EXPORT_NOT_OSX_VIEW_PROPERTY(keyboardDismissMode, UIScrollViewKeyboardDismissMode) // [macOS]
+#endif // [visionOS]
 RCT_EXPORT_NOT_OSX_VIEW_PROPERTY(maximumZoomScale, CGFloat) // [macOS]
 RCT_EXPORT_NOT_OSX_VIEW_PROPERTY(minimumZoomScale, CGFloat) // [macOS]
 RCT_EXPORT_VIEW_PROPERTY(scrollEnabled, BOOL)

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -46,8 +46,12 @@ RCT_EXPORT_MODULE()
   __block NSDictionary *constants;
   RCTUnsafeExecuteOnMainQueueSync(^{
 #if !TARGET_OS_OSX // [macOS]
+#if !TARGET_OS_VISION // [visionOS]
     UIScreen *mainScreen = UIScreen.mainScreen;
     CGSize screenSize = mainScreen.bounds.size;
+#else // [visionOS
+	CGSize screenSize = CGSizeZero;
+#endif // visionOS]
 #else // [macOS
     NSScreen *mainScreen = NSScreen.mainScreen;
     CGSize screenSize = mainScreen.frame.size;

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -12,9 +12,7 @@
 #import <ReactCommon/RCTSampleTurboModule.h>
 #import <ReactCommon/SampleTurboCxxModule.h>
 
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 #import <React/RCTPushNotificationManager.h>
-#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <NativeCxxModuleExample/NativeCxxModuleExample.h>
@@ -100,8 +98,6 @@ NSString *kBundlePath = @"js/RNTesterApp.macos";
   return nullptr;
 }
 
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
-
 // Required for the remoteNotificationsRegistered event.
 - (void)application:(__unused RCTUIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
@@ -148,7 +144,6 @@ NSString *kBundlePath = @"js/RNTesterApp.macos";
   return YES;
 }
 #endif // macOS]
-#endif
 
 #pragma mark - RCTComponentViewFactoryComponentProvider
 

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -24,7 +24,7 @@
 #if BUNDLE_PATH
 NSString *kBundlePath = @"xplat/js/RKJSModules/EntryPoints/RNTesterTestBundle.js";
 #else
-#if TARGET_OS_OSX // [macOS]
+#if !TARGET_OS_OSX // [macOS]
 NSString *kBundlePath = @"js/RNTesterApp.ios";
 #else // [macOS
 NSString *kBundlePath = @"js/RNTesterApp.macos";
@@ -118,14 +118,14 @@ NSString *kBundlePath = @"js/RNTesterApp.macos";
   [RCTPushNotificationManager didReceiveRemoteNotification:notification];
 }
 
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
 // Required for the localNotificationReceived event.
 - (void)application:(__unused UIApplication *)application
     didReceiveLocalNotification:(UILocalNotification *)notification
 {
   [RCTPushNotificationManager didReceiveLocalNotification:notification];
 }
-#endif // [macOS]
+#endif // [macOS] [visionOS]
 #if TARGET_OS_OSX // [macOS
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center
         didDeliverNotification:(NSUserNotification *)notification


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

This is the last PR (for now) in a series of PRs to add visionOS support to React Native macOS

Add the actual native support for visionOS. This is done mostly with nicely placed ifdefs. Some notes:

- Amusingly, many places where we added macOS ifdefs are _also_ places we need vision ifdefs :D 
- In places where we started having nested ifdefs (`#if !TARGET_OS_OSX && !TARGET_OS_VISION`), the code inside is usually an iOS only API, and therefore the most correct ifdef to use is `#if TARGET_OS_IOS`. As such, there are a couple of places where I updated the usage. 
- Much of this is cross-referenced with the same support added in https://github.com/callstack/react-native-visionos

## Changelog:

[INTERNAL] [ADDED] - Add visionOS support

## Test Plan:

We can't test the RNTester-visionOS in CI yet (sadly), as we need an Arm64 image of macOS with the visionOS SDK to build visionOS, and Azure Pipelines doesn't seem to have that currently. Instead, let's locally verify that the scheme builds and runs. I took this screenshot with #2056 also cherry-picked because as of the time of writing, that PR hasn't landed yet. 

![Screenshot 2024-01-25 at 10 23 47 PM](https://github.com/microsoft/react-native-macos/assets/6722175/49c43cd9-519d-444b-b1ed-9316de092a98)
