### PR TITLE
[0.72] Use boost 1.76, not boost 1.83

### DIFF
--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
   # [macOS] Workaround for https://github.com/facebook/react-native/issues/42180
-  spec.source = { :http => 'https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.bz2',
+  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',
                   :sha256 => '6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e' }
 
   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
React Native 0.72 uses boost `1.76`, not `1.83`. Using the updated link