### PR TITLE
[0.73][CI] Set and use `CIRCLE_TAG` in Azure pipelines publish job

### DIFF
--- a/.ado/templates/apple-job-publish.yml
+++ b/.ado/templates/apple-job-publish.yml
@@ -16,20 +16,22 @@ steps:
           echo "Set latest to: $LATEST"
       condition: eq(variables['Build.SourceBranchName'], variables.latestStableBranch)
 
+    - task: CmdLine@2
+      displayName: Set next package version
+      inputs:
+        script: |
+          echo "Next package version: $RNM_PACKAGE_VERSION"
+          echo "##vso[task.setvariable variable=RNM_PACKAGE_VERSION]$(node .ado/get-next-semver-version.js)
+
     # Note, This won't do the actual `git tag` and `git push` as we're doing a dry run.
     # We do that as a separate step in `.ado/publish.yml`.
     - task: CmdLine@2
       displayName: Prepare package for release
       inputs:
         script: |
-          VERSION=$(node .ado/get-next-semver-version.js)
-          if [[ -z "$VERSION" ]]; then
-            VERSION=$(grep '"version"' package.json | cut -d '"' -f 4 | head -1)
-            echo "Using the version from the package.json: $VERSION"
-          fi
-          node ./scripts/prepare-package-for-release.js -v "$VERSION" --dry-run
+          node ./scripts/prepare-package-for-release.js -v "$RNM_PACKAGE_VERSION" --dry-run
       env:
-        # Map the corresponding variable since `prepare-package-for-release.js` depends on it.
+        # Map the corresponding CircleCI variable since `prepare-package-for-release.js` depends on it.
         CIRCLE_BRANCH: $(Build.SourceBranchName)
 
   # Note: This won't actually publish to NPM as we've commented that bit out.
@@ -39,3 +41,6 @@ steps:
     inputs:
       script: |
         node ./scripts/publish-npm.js -t ${{ parameters.build_type }}
+    env:
+      # Map the corresponding CircleCI variable since `publish-npm.js` depends on it.
+      CIRCLE_TAG: $(RNM_PACKAGE_VERSION)

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -16,23 +16,6 @@ const {
   getCurrentCommit,
   isTaggedLatest,
 } = require('./scm-utils');
-const path = require('path'); // [macOS]
-const fs = require('fs'); // [macOS]
-
-// [macOS] Function to get our version from package.json instead of the CircleCI build tag.
-function getPkgJsonVersion() {
-  const RN_PACKAGE_DIRECTORY = path.resolve(
-    __dirname,
-    '..',
-    'packages',
-    'react-native',
-  );
-  const pkgJsonPath = path.resolve(RN_PACKAGE_DIRECTORY, 'package.json');
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-  const pkgJsonVersion = pkgJson.version;
-  return pkgJsonVersion;
-}
-// macOS]
 
 // Get `next` version from npm and +1 on the minor for `main` version
 function getMainVersion() {
@@ -65,7 +48,7 @@ function getNpmInfo(buildType) {
   }
 
   const {version, major, minor, prerelease} = parseVersion(
-    getPkgJsonVersion(), // [macOS] We can't use the CircleCI build tag, so we use the version argument instead.
+    process.env.CIRCLE_TAG,
     buildType,
   );
 


### PR DESCRIPTION
Backport of #2021 to `0.73-stable`