### PR TITLE
[0.73] Remove Xcode 12.5 workaround from template app

### DIFF
--- a/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
@@ -22,6 +22,5 @@ target 'HelloWorld-macOS' do
 
   post_install do |installer|
     react_native_post_install(installer)
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end


### PR DESCRIPTION
Closes #2015 

As of https://github.com/facebook/react-native/commit/0ab8b40fd64ad86b4598293faa0b77e71fc9d349 we no longer need the post_install script `__apply_Xcode_12_5_M1_post_install_workaround`. However, we forgot to remove it from the template app that ships with `0.73`. Let's remove it. 