### PR TITLE
fix(cli): initialising in projects using Yarn v3

### DIFF
--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -185,7 +185,6 @@ async function getLatestMatchingReactNativeMacOSVersion(
   } catch (err) {
     printError(`No version of ${printPkg(MACOSPKG, versionSemVer)} found!`);
     process.exit(EXITCODE_NO_MATCHING_RNMACOS);
-    return '';
   }
 }
 
@@ -290,7 +289,7 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
       );
 
       const pkgmgr = isProjectUsingYarn(process.cwd())
-        ? `yarn add${verbose ? '' : ' -s'}`
+        ? `yarn add${verbose ? '' : ' --silent'}`
         : `npm install --save${verbose ? '' : ' --silent'}`;
       const execOptions = verbose ? {stdio: 'inherit' as 'inherit'} : {};
       execSync(`${pkgmgr} "${MACOSPKG}@${version}"`, execOptions);


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

Recently in React Native Community CLI we added bumping Yarn version in every new project created to Yarn v3 ([PR](https://github.com/react-native-community/cli/pull/2134) for more context). And In Yarn v3 flag `-s` doesn't exists anymore, so the `react-native-macos-init` tool won't work.  
![CleanShot 2024-01-09 at 17 29 31](https://github.com/microsoft/react-native-macos/assets/63900941/d8970fb7-d7e9-4377-bc7d-82407c53bebd)
I've replaced usage of `-s` with `--silent` flag. Also this change is backward compatible, since Yarn v1 support `--silent` flag. 

![CleanShot 2024-01-09 at 17 29 47](https://github.com/microsoft/react-native-macos/assets/63900941/a6287a74-1184-4f21-b581-121bed3f916a)

## Changelog:

[GENERAL] [FIXED] - Initialising `react-native-macos` in project using Yarn v3 with `react-native-macos-init`

## Test Plan:

1. Create new project with `npx react-native@latest init` and bump Yarn version to 3 (we didn't released changes with bumping version by default yet.
2. Try running `react-native-macos-init`
