### PR TITLE
[CI] Only echo `RNM_PACKAGE_VERSION` after it has been set

### DIFF
--- a/.ado/templates/apple-job-publish.yml
+++ b/.ado/templates/apple-job-publish.yml
@@ -20,8 +20,8 @@ steps:
       displayName: Set next package version
       inputs:
         script: |
-          echo "Next package version: $RNM_PACKAGE_VERSION"
           echo "##vso[task.setvariable variable=RNM_PACKAGE_VERSION]$(node .ado/get-next-semver-version.js)"
+          echo "Next package version: $RNM_PACKAGE_VERSION"
 
     # Note, This won't do the actual `git tag` and `git push` as we're doing a dry run.
     # We do that as a separate step in `.ado/publish.yml`.


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

Fix a nit from #2021 - we were printing a variable before using it.

## Changelog:

[INTERNAL] [CHANGED] - Only echo `RNM_PACKAGE_VERSION` after it has been set

## Test Plan:

CI should pass
