### PR TITLE
[0.73] Align Github version number with NPM package

### DIFF
--- a/packages/react-native/Libraries/Core/ReactNativeVersion.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersion.js
@@ -12,6 +12,6 @@
 exports.version = {
   major: 0,
   minor: 73,
-  patch: 2,
+  patch: 3,
   prerelease: null,
 };

--- a/packages/react-native/React/Base/RCTVersion.m
+++ b/packages/react-native/React/Base/RCTVersion.m
@@ -23,7 +23,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(73),
-                  RCTVersionPatch: @(2),
+                  RCTVersionPatch: @(3),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.73.2
+VERSION_NAME=0.73.3
 react.internal.publishingGroup=com.facebook.react
 
 android.useAndroidX=true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -17,6 +17,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 73,
-      "patch", 2,
+      "patch", 3,
       "prerelease", null);
 }

--- a/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -17,7 +17,7 @@ namespace facebook::react {
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 73;
-  int32_t Patch = 2;
+  int32_t Patch = 3;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.73.2",
+  "version": "0.73.3",
   "description": "React Native for macOS",
   "license": "MIT",
   "repository": {

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.73.2)
-  - FBReactNativeSpec (0.73.2):
+  - FBLazyVector (0.73.3)
+  - FBReactNativeSpec (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.2)
-    - RCTTypeSafety (= 0.73.2)
-    - React-Core (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - ReactCommon/turbomodule/core (= 0.73.2)
+    - RCTRequired (= 0.73.3)
+    - RCTTypeSafety (= 0.73.3)
+    - React-Core (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - ReactCommon/turbomodule/core (= 0.73.3)
   - fmt (6.2.1)
   - glog (0.3.5)
   - OCMock (3.9.1)
@@ -28,26 +28,26 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.73.2)
-  - RCTTypeSafety (0.73.2):
-    - FBLazyVector (= 0.73.2)
-    - RCTRequired (= 0.73.2)
-    - React-Core (= 0.73.2)
-  - React (0.73.2):
-    - React-Core (= 0.73.2)
-    - React-Core/DevSupport (= 0.73.2)
-    - React-Core/RCTWebSocket (= 0.73.2)
-    - React-RCTActionSheet (= 0.73.2)
-    - React-RCTAnimation (= 0.73.2)
-    - React-RCTBlob (= 0.73.2)
-    - React-RCTImage (= 0.73.2)
-    - React-RCTLinking (= 0.73.2)
-    - React-RCTNetwork (= 0.73.2)
-    - React-RCTSettings (= 0.73.2)
-    - React-RCTText (= 0.73.2)
-    - React-RCTVibration (= 0.73.2)
-  - React-callinvoker (0.73.2)
-  - React-Codegen (0.73.2):
+  - RCTRequired (0.73.3)
+  - RCTTypeSafety (0.73.3):
+    - FBLazyVector (= 0.73.3)
+    - RCTRequired (= 0.73.3)
+    - React-Core (= 0.73.3)
+  - React (0.73.3):
+    - React-Core (= 0.73.3)
+    - React-Core/DevSupport (= 0.73.3)
+    - React-Core/RCTWebSocket (= 0.73.3)
+    - React-RCTActionSheet (= 0.73.3)
+    - React-RCTAnimation (= 0.73.3)
+    - React-RCTBlob (= 0.73.3)
+    - React-RCTImage (= 0.73.3)
+    - React-RCTLinking (= 0.73.3)
+    - React-RCTNetwork (= 0.73.3)
+    - React-RCTSettings (= 0.73.3)
+    - React-RCTText (= 0.73.3)
+    - React-RCTVibration (= 0.73.3)
+  - React-callinvoker (0.73.3)
+  - React-Codegen (0.73.3):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -62,10 +62,10 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.73.2):
+  - React-Core (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
+    - React-Core/Default (= 0.73.3)
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -75,47 +75,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.73.2):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.73.2):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.73.2):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
-    - React-Core/RCTWebSocket (= 0.73.2)
-    - React-cxxreact
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.73.2)
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.73.2):
+  - React-Core/CoreModulesHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -128,7 +88,34 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.73.2):
+  - React-Core/Default (0.73.3):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.73.3):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core/Default (= 0.73.3)
+    - React-Core/RCTWebSocket (= 0.73.3)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.73.3)
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -141,7 +128,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.73.2):
+  - React-Core/RCTAnimationHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -154,7 +141,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.73.2):
+  - React-Core/RCTBlobHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -167,7 +154,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.73.2):
+  - React-Core/RCTImageHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -180,7 +167,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.73.2):
+  - React-Core/RCTLinkingHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -193,7 +180,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.73.2):
+  - React-Core/RCTNetworkHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -206,7 +193,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.73.2):
+  - React-Core/RCTPushNotificationHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -219,7 +206,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.73.2):
+  - React-Core/RCTSettingsHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -232,7 +219,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.73.2):
+  - React-Core/RCTTextHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core/Default
@@ -245,10 +232,10 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.73.2):
+  - React-Core/RCTVibrationHeaders (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
+    - React-Core/Default
     - React-cxxreact
     - React-jsc
     - React-jsi
@@ -258,32 +245,45 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.73.2):
+  - React-Core/RCTWebSocket (0.73.3):
+    - glog
     - RCT-Folly (= 2022.05.16.00)
-    - RCTTypeSafety (= 0.73.2)
+    - React-Core/Default (= 0.73.3)
+    - React-cxxreact
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.73.3):
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTTypeSafety (= 0.73.3)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.73.2)
-    - React-jsi (= 0.73.2)
+    - React-Core/CoreModulesHeaders (= 0.73.3)
+    - React-jsi (= 0.73.3)
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.73.2)
+    - React-RCTImage (= 0.73.3)
     - ReactCommon
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.73.2):
+  - React-cxxreact (0.73.3):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-debug (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-jsinspector (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-    - React-runtimeexecutor (= 0.73.2)
-  - React-debug (0.73.2)
-  - React-Fabric (0.73.2):
+    - React-callinvoker (= 0.73.3)
+    - React-debug (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-jsinspector (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+    - React-runtimeexecutor (= 0.73.3)
+  - React-debug (0.73.3)
+  - React-Fabric (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -293,20 +293,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.73.2)
-    - React-Fabric/attributedstring (= 0.73.2)
-    - React-Fabric/componentregistry (= 0.73.2)
-    - React-Fabric/componentregistrynative (= 0.73.2)
-    - React-Fabric/components (= 0.73.2)
-    - React-Fabric/core (= 0.73.2)
-    - React-Fabric/imagemanager (= 0.73.2)
-    - React-Fabric/leakchecker (= 0.73.2)
-    - React-Fabric/mounting (= 0.73.2)
-    - React-Fabric/scheduler (= 0.73.2)
-    - React-Fabric/telemetry (= 0.73.2)
-    - React-Fabric/templateprocessor (= 0.73.2)
-    - React-Fabric/textlayoutmanager (= 0.73.2)
-    - React-Fabric/uimanager (= 0.73.2)
+    - React-Fabric/animations (= 0.73.3)
+    - React-Fabric/attributedstring (= 0.73.3)
+    - React-Fabric/componentregistry (= 0.73.3)
+    - React-Fabric/componentregistrynative (= 0.73.3)
+    - React-Fabric/components (= 0.73.3)
+    - React-Fabric/core (= 0.73.3)
+    - React-Fabric/imagemanager (= 0.73.3)
+    - React-Fabric/leakchecker (= 0.73.3)
+    - React-Fabric/mounting (= 0.73.3)
+    - React-Fabric/scheduler (= 0.73.3)
+    - React-Fabric/telemetry (= 0.73.3)
+    - React-Fabric/templateprocessor (= 0.73.3)
+    - React-Fabric/textlayoutmanager (= 0.73.3)
+    - React-Fabric/uimanager (= 0.73.3)
     - React-graphics
     - React-jsc
     - React-jsi
@@ -316,26 +316,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.73.2):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.73.2):
+  - React-Fabric/animations (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -354,7 +335,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.73.2):
+  - React-Fabric/attributedstring (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -373,7 +354,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.73.2):
+  - React-Fabric/componentregistry (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -392,37 +373,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.73.2):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.73.2)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.2)
-    - React-Fabric/components/modal (= 0.73.2)
-    - React-Fabric/components/rncore (= 0.73.2)
-    - React-Fabric/components/root (= 0.73.2)
-    - React-Fabric/components/safeareaview (= 0.73.2)
-    - React-Fabric/components/scrollview (= 0.73.2)
-    - React-Fabric/components/text (= 0.73.2)
-    - React-Fabric/components/textinput (= 0.73.2)
-    - React-Fabric/components/unimplementedview (= 0.73.2)
-    - React-Fabric/components/view (= 0.73.2)
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.73.2):
+  - React-Fabric/componentregistrynative (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -441,7 +392,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.73.2):
+  - React-Fabric/components (0.73.3):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.73.3)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.3)
+    - React-Fabric/components/modal (= 0.73.3)
+    - React-Fabric/components/rncore (= 0.73.3)
+    - React-Fabric/components/root (= 0.73.3)
+    - React-Fabric/components/safeareaview (= 0.73.3)
+    - React-Fabric/components/scrollview (= 0.73.3)
+    - React-Fabric/components/text (= 0.73.3)
+    - React-Fabric/components/textinput (= 0.73.3)
+    - React-Fabric/components/unimplementedview (= 0.73.3)
+    - React-Fabric/components/view (= 0.73.3)
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -460,7 +441,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.73.2):
+  - React-Fabric/components/legacyviewmanagerinterop (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -479,7 +460,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.73.2):
+  - React-Fabric/components/modal (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -498,7 +479,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.73.2):
+  - React-Fabric/components/rncore (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -517,7 +498,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.73.2):
+  - React-Fabric/components/root (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -536,7 +517,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.73.2):
+  - React-Fabric/components/safeareaview (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -555,7 +536,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.73.2):
+  - React-Fabric/components/scrollview (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -574,7 +555,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.73.2):
+  - React-Fabric/components/text (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -593,7 +574,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.73.2):
+  - React-Fabric/components/textinput (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -612,7 +593,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.73.2):
+  - React-Fabric/components/unimplementedview (0.73.3):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsc
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -632,7 +632,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.73.2):
+  - React-Fabric/core (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -651,7 +651,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.73.2):
+  - React-Fabric/imagemanager (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -670,7 +670,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.73.2):
+  - React-Fabric/leakchecker (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -689,7 +689,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.73.2):
+  - React-Fabric/mounting (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -708,7 +708,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.73.2):
+  - React-Fabric/scheduler (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -727,7 +727,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.73.2):
+  - React-Fabric/telemetry (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -746,7 +746,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.73.2):
+  - React-Fabric/templateprocessor (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -765,7 +765,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.73.2):
+  - React-Fabric/textlayoutmanager (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -785,7 +785,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.73.2):
+  - React-Fabric/uimanager (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -804,30 +804,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.73.2):
+  - React-FabricImage (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired (= 0.73.2)
-    - RCTTypeSafety (= 0.73.2)
+    - RCTRequired (= 0.73.3)
+    - RCTTypeSafety (= 0.73.3)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsc
     - React-jsi
-    - React-jsiexecutor (= 0.73.2)
+    - React-jsiexecutor (= 0.73.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-graphics (0.73.2):
+  - React-graphics (0.73.3):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
+    - React-Core/Default (= 0.73.3)
     - React-utils
-  - React-ImageManager (0.73.2):
+  - React-ImageManager (0.73.3):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -836,38 +836,38 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jsc (0.73.2):
-    - React-jsc/Fabric (= 0.73.2)
-    - React-jsi (= 0.73.2)
-  - React-jsc/Fabric (0.73.2):
-    - React-jsi (= 0.73.2)
-  - React-jserrorhandler (0.73.2):
+  - React-jsc (0.73.3):
+    - React-jsc/Fabric (= 0.73.3)
+    - React-jsi (= 0.73.3)
+  - React-jsc/Fabric (0.73.3):
+    - React-jsi (= 0.73.3)
+  - React-jserrorhandler (0.73.3):
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.73.2):
+  - React-jsi (0.73.3):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-  - React-jsiexecutor (0.73.2):
+  - React-jsiexecutor (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-  - React-jsinspector (0.73.2)
-  - React-logger (0.73.2):
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+  - React-jsinspector (0.73.3)
+  - React-logger (0.73.3):
     - glog
-  - React-Mapbuffer (0.73.2):
+  - React-Mapbuffer (0.73.3):
     - glog
     - React-debug
-  - React-nativeconfig (0.73.2)
-  - React-NativeModulesApple (0.73.2):
+  - React-nativeconfig (0.73.3)
+  - React-NativeModulesApple (0.73.3):
     - glog
     - React-callinvoker
     - React-Core
@@ -877,10 +877,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.73.2)
-  - React-RCTActionSheet (0.73.2):
-    - React-Core/RCTActionSheetHeaders (= 0.73.2)
-  - React-RCTAnimation (0.73.2):
+  - React-perflogger (0.73.3)
+  - React-RCTActionSheet (0.73.3):
+    - React-Core/RCTActionSheetHeaders (= 0.73.3)
+  - React-RCTAnimation (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -888,7 +888,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.73.2):
+  - React-RCTAppDelegate (0.73.3):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -902,7 +902,7 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon
-  - React-RCTBlob (0.73.2):
+  - React-RCTBlob (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTBlobHeaders
@@ -911,7 +911,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.73.2):
+  - React-RCTFabric (0.73.3):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-Core
@@ -929,7 +929,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.73.2):
+  - React-RCTImage (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -938,14 +938,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.73.2):
+  - React-RCTLinking (0.73.3):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.73.2)
-    - React-jsi (= 0.73.2)
+    - React-Core/RCTLinkingHeaders (= 0.73.3)
+    - React-jsi (= 0.73.3)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.73.2)
-  - React-RCTNetwork (0.73.2):
+    - ReactCommon/turbomodule/core (= 0.73.3)
+  - React-RCTNetwork (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -953,14 +953,14 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTPushNotification (0.73.2):
+  - React-RCTPushNotification (0.73.3):
     - RCTTypeSafety
     - React-Codegen
     - React-Core/RCTPushNotificationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.73.2):
+  - React-RCTSettings (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -968,31 +968,31 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTTest (0.73.2):
+  - React-RCTTest (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core (= 0.73.2)
-    - React-CoreModules (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - ReactCommon/turbomodule/core (= 0.73.2)
-  - React-RCTText (0.73.2):
-    - React-Core/RCTTextHeaders (= 0.73.2)
+    - React-Core (= 0.73.3)
+    - React-CoreModules (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - ReactCommon/turbomodule/core (= 0.73.3)
+  - React-RCTText (0.73.3):
+    - React-Core/RCTTextHeaders (= 0.73.3)
     - Yoga
-  - React-RCTVibration (0.73.2):
+  - React-RCTVibration (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.73.2):
+  - React-rendererdebug (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - React-rncore (0.73.2)
-  - React-runtimeexecutor (0.73.2):
-    - React-jsi (= 0.73.2)
-  - React-runtimescheduler (0.73.2):
+  - React-rncore (0.73.3)
+  - React-runtimeexecutor (0.73.3):
+    - React-jsi (= 0.73.3)
+  - React-runtimescheduler (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-callinvoker
@@ -1003,14 +1003,14 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.73.2):
+  - React-utils (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - ReactCommon (0.73.2):
-    - React-logger (= 0.73.2)
-    - ReactCommon/turbomodule (= 0.73.2)
-  - ReactCommon-Samples (0.73.2):
+  - ReactCommon (0.73.3):
+    - React-logger (= 0.73.3)
+    - ReactCommon/turbomodule (= 0.73.3)
+  - ReactCommon-Samples (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - RCT-Folly
@@ -1021,38 +1021,38 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - ReactCommon/turbomodule (0.73.2):
+  - ReactCommon/turbomodule (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-    - ReactCommon/turbomodule/bridging (= 0.73.2)
-    - ReactCommon/turbomodule/core (= 0.73.2)
-  - ReactCommon/turbomodule/bridging (0.73.2):
+    - React-callinvoker (= 0.73.3)
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+    - ReactCommon/turbomodule/bridging (= 0.73.3)
+    - ReactCommon/turbomodule/core (= 0.73.3)
+  - ReactCommon/turbomodule/bridging (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-  - ReactCommon/turbomodule/core (0.73.2):
+    - React-callinvoker (= 0.73.3)
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+  - ReactCommon/turbomodule/core (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
+    - React-callinvoker (= 0.73.3)
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
   - ScreenshotManager (0.0.1):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1227,60 +1227,60 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1401ba01f443d1a21a7994aa5f7233c101321909
-  DoubleConversion: 56bb181dd9093360c7cd027b592155b7f33eeb61
-  FBLazyVector: 6120861222df54e12758f3761dd3ea4bba1e5c0f
-  FBReactNativeSpec: 8f2ec719b81fb39d12d0ea822752dc250e2af7b7
+  boost: cb0a22b9555beefea9c9c238246ed969157e8b16
+  DoubleConversion: ca54355f8932558971f6643521d62b9bc8231cee
+  FBLazyVector: a10da92176810ccd3396c42e0ec2d09c4e35e863
+  FBReactNativeSpec: 45952c52b84421714b83ee7519b1e4a2f5fc961e
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 905b36b53c03b6e3afad8c8868237e84df8e17c4
+  glog: 3a72874c0322c7caf24931d3a2777cb7a3090529
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   RCT-Folly: 270f9eebb5a7d757382d0438ea993e4d7aa85932
-  RCTRequired: 47fe8eedbbc5a1869b4b6327daa196c740fbd644
-  RCTTypeSafety: 1b7ac43d753fa2957f693e129d7000f2f9df76a6
-  React: f31616608f535bc2ab3fbb4218652be9efb6525f
-  React-callinvoker: 6c4e7816d197acd4e7b9116f8867d051fc157505
-  React-Codegen: 4fe3e615947fa328c77c8f22e99b82dc20bf579b
-  React-Core: 468e6a29c0071e5328e20648d2d9f966bcdb1c4f
-  React-CoreModules: da7b30d1aa1a3adf2db84de30285813e4c274b0a
-  React-cxxreact: 4ed7f466cc6c5c0255ad912c2f9b1412887d929b
-  React-debug: a168c355d6cc67a030758c49cd959dc756e07659
-  React-Fabric: ccc19e9af98afc981a7a89487f1564fd94e9cffa
-  React-FabricImage: 21610d12a9a96740c4698c932784b47db485b2f9
-  React-graphics: 98b39c32c6e979bbd168042ef4dc74e5e606e315
-  React-ImageManager: 10348a52a28df045d7891e1dcb18a908f3a4483f
-  React-jsc: 5ffa8108e8bd4c4365a247815fbb57f56c851e14
-  React-jserrorhandler: 5ff3013534cca02b6df8eadcf8f5ab75a17012f9
-  React-jsi: 23181346bad1f74f4fa16fcb12e10dfb07ce7606
-  React-jsiexecutor: 11d5dd3f0a154f6b529dd8dff6365d7daa887c03
-  React-jsinspector: db49a17ff06c11d42dba469fe9068052b67e437e
-  React-logger: 9d30b2beae0a4a0f698a14f6674ffeb81cd1ea5e
-  React-Mapbuffer: 5ee42c5a4d1ee1945cb84b0cac843ac7fe137f83
-  React-nativeconfig: 64fa40e70fc32a3fd674c9f790a09e0d922b3e27
-  React-NativeModulesApple: 7d26a25a0e613f598affd9310b913309435173ed
-  React-perflogger: 42da8c03de5033b47cb4913d8feed18a413ca1dc
-  React-RCTActionSheet: c01d9d247b36d226372212700706202a317b5fbe
-  React-RCTAnimation: b7f6f69e0d1c90d4b576cd40748b781ad2734ba2
-  React-RCTAppDelegate: a03737a6228782fab346b2078185cae4d19f7222
-  React-RCTBlob: cbe915fcf8e37cda8a60aac542f35354c7b0ee28
-  React-RCTFabric: d276e1fb308213d7a5350992718306a3c0b89ab4
-  React-RCTImage: a561d460d7d8fe5fa35ae8430e66fc6b15ca0c02
-  React-RCTLinking: e621fa6b06ce5f221a1c3dba85db783ff48433c1
-  React-RCTNetwork: 49d1cb3eac9af078bf08f2a1f6f5c131787e3f6e
-  React-RCTPushNotification: a015d68f234d4050b4b308e3152a1c847479ff4a
-  React-RCTSettings: c105b52800d0d1ecf463e3683914a422bb6e968d
-  React-RCTTest: 965616ae238c9c21e00aadb284c8e9e56930a31c
-  React-RCTText: 11aa7539c1ec6b3b4ae9b1d36642dc040b7894b3
-  React-RCTVibration: 960727a748678759886e496f585bc21eba3fb44e
-  React-rendererdebug: ef3f88bc7020ef48a706157779257e0e2dd900ac
-  React-rncore: d20c5bbc2a3f1bbd64d9953e9201d1a6b69e4873
-  React-runtimeexecutor: e8913520fa4bddd8afec441724fc9ab5f6f92989
-  React-runtimescheduler: ba4b5adaf8396250b73c880574a866617236c259
-  React-utils: a59446d0f4d3dc0f0c231211236dbfc9584207fe
-  ReactCommon: 7c8bee1aa36c2858b5db198445976713db53efa3
-  ReactCommon-Samples: 8fb64df6e41dbf10c66ec1bb7889d133a19265f6
+  RCTRequired: 66cd51261ccf1f0e8b39528c9bb142245f8972bb
+  RCTTypeSafety: db4a2a91c47dad212d95b1c00c06eeda5243809f
+  React: 51d16a1e4895efe0b13800528906e7f9d6cdfea2
+  React-callinvoker: 847a0be1dfe98f1036d110e4554c0d39286b6ff7
+  React-Codegen: b9186997c9a7ea20a4db76e3ae5748d30b4d1a51
+  React-Core: 7d9f10480e30dc9db72ff78f885e1131d06d2220
+  React-CoreModules: fbe51120804d7e1f2d0a702dd5b3dfe04f2deb6d
+  React-cxxreact: 7e4462d3286037fa1df56b8a59bd2a6ed6593427
+  React-debug: abaea2ec50b896e878736c76bd4410f31f595e10
+  React-Fabric: 16bed94248504b5b6575c09a003b228c837f64da
+  React-FabricImage: 36f3e3c54c8bb92b61bb62e9cb85b8e8006d1833
+  React-graphics: 141485b1c11e85b9b592d86669b471eccdecc5c9
+  React-ImageManager: c1c32cb13bf1a200a86d388e1f5a289d7a953bf2
+  React-jsc: 6f23ade7ed5cc964b01ea6e4f9d1ea86ef2dea08
+  React-jserrorhandler: 74275394616a899e8306a4dac08905eafa20379d
+  React-jsi: 25d70d453d05c6337d1acacdcbcabdd4c545ae5a
+  React-jsiexecutor: ab421d702d9b57180d59cd3ccf5a7307dabc0768
+  React-jsinspector: 7ed29cdb213e291eb7538060e0692234cb19239a
+  React-logger: a1f09151bfa40d990e33ecd109b9ff7d8aa48edb
+  React-Mapbuffer: 31f640178d172ca36e8f0489bc6ee8a2ffdbb307
+  React-nativeconfig: eb3d0bd8f153c2d79b0c4799e160f6872f0bbf29
+  React-NativeModulesApple: 9172b6e735dcbd9f5af58c264549483803c16f6f
+  React-perflogger: 307c30c4d952e8e9054950a9a972e3e18bf56fd7
+  React-RCTActionSheet: b92626c6d0ff14555ae7ccdb0bcc0ae41757f1ed
+  React-RCTAnimation: 02b87b6ac57c385ab27061716ab1214d1993260b
+  React-RCTAppDelegate: e68653cddfe9a5b37802dcd340726a8988eb8e9d
+  React-RCTBlob: bd56333b0f8bdfa2c2432e768b4afdb3e2d1aab7
+  React-RCTFabric: 0b755f99813d6e244394b2026da8eced06d7c3f8
+  React-RCTImage: ae05ca661ab6fbbe4bac2445e88e173f57d7d94f
+  React-RCTLinking: 69734a83865f1d5fad8f8430ddc695b77bf711f3
+  React-RCTNetwork: 199c51aff39adb64eae530587b9229c49f181058
+  React-RCTPushNotification: 25321d99d2e6e0957ecf88b03717c5f1119f749f
+  React-RCTSettings: 4751657034196e7be275fcd111e87208c438afad
+  React-RCTTest: f85885dc9291c2274ee59a20f19d90d5bc9060b7
+  React-RCTText: babcd6aea501e9d84ccba5da738db5470550c7aa
+  React-RCTVibration: e32e496cb7b055c1702605619e4c5e6b959d515c
+  React-rendererdebug: f937477268c39d79b34f50993fc9b7fd26fe2e27
+  React-rncore: b22212e5aa8806b4c11823dad5ed1e10336fc042
+  React-runtimeexecutor: c0ad0dae9c7ab89ca2efc5ce8e276256116683ba
+  React-runtimescheduler: 9f2dc7e366355842b5c1e7cbf88f079d7badbb04
+  React-utils: d5b0db03c144015f9abd6328a6b42a6822ef75ec
+  ReactCommon: 47af596c530f0d73b4f5daaa9b620b635229101c
+  ReactCommon-Samples: 35ea113931bbba2c3aa67a1a91afb883ac4cdd46
   ScreenshotManager: b7521db0bb38052cee55c7fa9811ce55081f4055
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 88c1183f66254fdae21331e195458e5b57514832
+  Yoga: d4e9bd5c8ca091fa23fcd867af874875deffdc17
 
 PODFILE CHECKSUM: cfeda206bf8917b64b065521c6c7f81321a8f25b
 


### PR DESCRIPTION
React Native macOS 0.73.3 is published in CI, but our local repo only has 0.73.2, presumably because of a CI pipeline issue. Let's realign and fix by running `node scripts/prepare-package-for-release -d -v 0.73.3` and committing the result.