### PR TITLE
[Cherry Pick] Refactor RCTPushNotificationManager to use `UNNotification`

### DIFF
--- a/packages/react-native/Libraries/PushNotificationIOS/NativePushNotificationManagerIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/NativePushNotificationManagerIOS.js
@@ -20,14 +20,34 @@ type Permissions = {|
 
 type Notification = {|
   +alertTitle?: ?string,
-  // Actual type: string | number
-  +fireDate?: ?number,
   +alertBody?: ?string,
   +userInfo?: ?Object,
+  /**
+   * Identifier for the notification category. See the [Apple documentation](https://developer.apple.com/documentation/usernotifications/declaring_your_actionable_notification_types)
+   * for more details.
+   */
   +category?: ?string,
-  // Actual type: 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute'
-  +repeatInterval?: ?string,
+  /**
+   * Actual type: string | number
+   *
+   * Schedule notifications using EITHER `fireDate` or `fireIntervalSeconds`.
+   * If both are specified, `fireDate` takes precedence.
+   * If you use `presentLocalNotification`, both will be ignored
+   * and the notification will be shown immediately.
+   */
+  +fireDate?: ?number,
+  /**
+   * Seconds from now to display the notification.
+   *
+   * Schedule notifications using EITHER `fireDate` or `fireIntervalSeconds`.
+   * If both are specified, `fireDate` takes precedence.
+   * If you use `presentLocalNotification`, both will be ignored
+   * and the notification will be shown immediately.
+   */
+  +fireIntervalSeconds?: ?number,
+  /** Badge count to display on the app icon. */
   +applicationIconBadgeNumber?: ?number,
+  /** Whether to silence the notification sound. */
   +isSilent?: ?boolean,
   /**
    * Custom notification sound to play. Write-only: soundName will be null when
@@ -37,6 +57,8 @@ type Notification = {|
   +soundName?: ?string,
   /** DEPRECATED. This was used for iOS's legacy UILocalNotification. */
   +alertAction?: ?string,
+  /** DEPRECATED. Use `fireDate` or `fireIntervalSeconds` instead. */
+  +repeatInterval?: ?string,
 |};
 
 export interface Spec extends TurboModule {

--- a/packages/react-native/Libraries/PushNotificationIOS/NativePushNotificationManagerIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/NativePushNotificationManagerIOS.js
@@ -23,14 +23,20 @@ type Notification = {|
   // Actual type: string | number
   +fireDate?: ?number,
   +alertBody?: ?string,
-  +alertAction?: ?string,
   +userInfo?: ?Object,
   +category?: ?string,
   // Actual type: 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute'
   +repeatInterval?: ?string,
   +applicationIconBadgeNumber?: ?number,
   +isSilent?: ?boolean,
+  /**
+   * Custom notification sound to play. Write-only: soundName will be null when
+   * accessing already created notifications using getScheduledLocalNotifications
+   * or getDeliveredNotifications.
+   */
   +soundName?: ?string,
+  /** DEPRECATED. This was used for iOS's legacy UILocalNotification. */
+  +alertAction?: ?string,
 |};
 
 export interface Spec extends TurboModule {

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -16,9 +16,6 @@ typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 #endif // [macOS]
 
 #if !TARGET_OS_UIKITFORMAC
-#if !TARGET_OS_OSX // [macOS]
-+ (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
-#endif // [macOS]
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
 #if !TARGET_OS_OSX // [macOS]

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -401,33 +401,19 @@ RCT_EXPORT_METHOD(requestPermissions
   // Add a listener to make sure that startObserving has been called
   [self addListener:@"remoteNotificationsRegistered"];
 
-#if !TARGET_OS_OSX // [macOS
-  UIUserNotificationType types = UIUserNotificationTypeNone;
+  UNAuthorizationOptions options = UNAuthorizationOptionNone;
 
   if (permissions.alert()) {
-    types |= UIUserNotificationTypeAlert;
+    options |= UNAuthorizationOptionAlert;
   }
   if (permissions.badge()) {
-    types |= UIUserNotificationTypeBadge;
+    options |= UNAuthorizationOptionBadge;
   }
   if (permissions.sound()) {
-    types |= UIUserNotificationTypeSound;
+    options |= UNAuthorizationOptionSound;
   }
-#else
-    NSRemoteNotificationType types = NSRemoteNotificationTypeNone;
-
-    if (permissions.alert()) {
-      types |= NSRemoteNotificationTypeAlert;
-    }
-    if (permissions.badge()) {
-      types |= NSRemoteNotificationTypeBadge;
-    }
-    if (permissions.sound()) {
-      types |= NSRemoteNotificationTypeSound;
-    }
-#endif // macOS]
   [UNUserNotificationCenter.currentNotificationCenter
-      requestAuthorizationWithOptions:types
+      requestAuthorizationWithOptions:options
                     completionHandler:^(BOOL granted, NSError *_Nullable error) {
                       if (error != NULL) {
                         reject(@"-1", @"Error - Push authorization request failed.", error);

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -235,12 +235,6 @@ RCT_EXPORT_MODULE()
   ];
 }
 
-#if !TARGET_OS_OSX // [macOS]
-+ (void)didRegisterUserNotificationSettings:(__unused UIUserNotificationSettings *)notificationSettings
-{
-}
-#endif // [macOS]
-
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
   NSMutableString *hexString = [NSMutableString string];

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -102,15 +102,6 @@ NSString *kBundlePath = @"js/RNTesterApp.macos";
 
 #if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 
-#if !TARGET_OS_OSX // [macOS]
-// Required to register for notifications
-- (void)application:(__unused UIApplication *)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
-{
-  [RCTPushNotificationManager didRegisterUserNotificationSettings:notificationSettings];
-}
-#endif // [macOS]
-
 // Required for the remoteNotificationsRegistered event.
 - (void)application:(__unused RCTUIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

This change is part of a series of cherry-picks intended to bring visionOS support to React Native macOS. Thes

Prior to these commits, `RCTPushNotificationManager used [UILocalNotification](https://developer.apple.com/documentation/uikit/uilocalnotification) on iOS, and we ifdef'ed macOS to use to use [NSUserNotification](https://developer.apple.com/documentation/foundation/nsusernotification). Both are deprecated and replaced with the cross-apple-platform [UNNotification](https://developer.apple.com/documentation/usernotifications/unnotification) API. Let's cherry pick these changes to make adding visionOS support easier.

Notably excluded from these PRs was properly supporting remote notification on macOS. I didn't see an obvious equivalent for that, and I don't think we supported it before either. I'll leave that as a future task. 

## Test Plan:

RNTester actually doesn't have a test page for PushNotificationManager, so I don't have a good way to test this. I'll leave the build passing as a good sign
