### PR TITLE
[Cherry Pick] Remove some usages of APIs deprecated in iOS & removed in visionOS

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -37,10 +37,17 @@
 
 @end
 
-@interface RCTTextView () <NSTextViewDelegate>
-@end
-
 #endif // macOS]
+
+#if !TARGET_OS_OSX // [macOS]
+@interface RCTTextView () <UIEditMenuInteractionDelegate>
+
+@property (nonatomic, nullable) UIEditMenuInteraction *editMenuInteraction API_AVAILABLE(ios(16.0));
+#else // [macOS
+@interface RCTTextView () <NSTextViewDelegate>
+#endif // macOS]
+
+@end
 
 #import <QuartzCore/QuartzCore.h>
 
@@ -351,6 +358,10 @@
 {
   _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                               action:@selector(handleLongPress:)];
+ if (@available(iOS 16.0, *)) {
+    _editMenuInteraction = [[UIEditMenuInteraction alloc] initWithDelegate:self];
+    [self addInteraction:_editMenuInteraction];
+  }
   [self addGestureRecognizer:_longPressGestureRecognizer];
 }
 
@@ -362,8 +373,16 @@
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
 #if !TARGET_OS_UIKITFORMAC
+  if (@available(iOS 16.0, *)) {
+    CGPoint location = [gesture locationInView:self];
+    UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
+    if (_editMenuInteraction) {
+      [_editMenuInteraction presentEditMenuWithConfiguration:config];
+    }
+    return;
+  }
+  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
   UIMenuController *menuController = [UIMenuController sharedMenuController];
 
   if (menuController.isMenuVisible) {

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -305,14 +305,14 @@ static CGFloat screenScale;
 void RCTComputeScreenScale(void)
 {
   dispatch_once(&onceTokenScreenScale, ^{
-    screenScale = [UIScreen mainScreen].scale;
+    screenScale = [UITraitCollection currentTraitCollection].displayScale;
   });
 }
 
 CGFloat RCTScreenScale(void)
 {
   RCTUnsafeExecuteOnMainQueueOnceSync(&onceTokenScreenScale, ^{
-    screenScale = [UIScreen mainScreen].scale;
+    screenScale = [UITraitCollection currentTraitCollection].displayScale;
   });
 
   return screenScale;

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -600,12 +600,20 @@ RCTUIWindow *__nullable RCTKeyWindow(void) // [macOS]
     return nil;
   }
 
-  // TODO: replace with a more robust solution
-  for (UIWindow *window in RCTSharedApplication().windows) {
-    if (window.keyWindow) {
-      return window;
+  for (UIScene *scene in RCTSharedApplication().connectedScenes) {
+    if (scene.activationState != UISceneActivationStateForegroundActive ||
+        ![scene isKindOfClass:[UIWindowScene class]]) {
+      continue;
+    }
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+
+    for (UIWindow *window in windowScene.windows) {
+      if (window.isKeyWindow) {
+        return window;
+      }
     }
   }
+
   return nil;
 #else // [macOS
   return [NSApp keyWindow];

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -634,12 +634,10 @@ BOOL RCTForceTouchAvailable(void)
   static BOOL forceSupported;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    forceSupported =
-        [UITraitCollection class] && [UITraitCollection instancesRespondToSelector:@selector(forceTouchCapability)];
+    forceSupported = [UITraitCollection currentTraitCollection].forceTouchCapability == UIForceTouchCapabilityAvailable;
   });
 
-  return forceSupported &&
-      (RCTKeyWindow() ?: [UIView new]).traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable;
+  return forceSupported;
 }
 #endif // [macOS]
 

--- a/packages/react-native/React/CoreModules/RCTAlertController.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertController.mm
@@ -23,17 +23,7 @@
 - (UIWindow *)alertWindow
 {
   if (_alertWindow == nil) {
-    _alertWindow = [self getUIWindowFromScene];
-
-    if (_alertWindow == nil) {
-      UIWindow *keyWindow = RCTSharedApplication().keyWindow;
-      if (keyWindow) {
-        _alertWindow = [[UIWindow alloc] initWithFrame:keyWindow.bounds];
-      } else {
-        // keyWindow is nil, so we cannot create and initialize _alertWindow
-        NSLog(@"Unable to create alert window: keyWindow is nil");
-      }
-    }
+    _alertWindow = [[UIWindow alloc] initWithWindowScene:RCTKeyWindow().windowScene];
 
     if (_alertWindow) {
       _alertWindow.rootViewController = [UIViewController new];
@@ -66,18 +56,6 @@
   _alertWindow.windowScene = nil;
 
   _alertWindow = nil;
-}
-
-- (UIWindow *)getUIWindowFromScene
-{
-  for (UIScene *scene in RCTSharedApplication().connectedScenes) {
-    if (scene.activationState == UISceneActivationStateForegroundActive &&
-        [scene isKindOfClass:[UIWindowScene class]]) {
-      return [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
-    }
-  }
-
-  return nil;
 }
 #endif // [macOS]
 

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -122,13 +122,11 @@ RCT_EXPORT_MODULE()
     self->_showDate = [NSDate date];
     if (!self->_window && !RCTRunningInTestEnvironment()) {
 #if !TARGET_OS_OSX // [macOS]
-      CGSize screenSize = [UIScreen mainScreen].bounds.size;
-
       UIWindow *window = RCTSharedApplication().keyWindow;
-      self->_window =
-          [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, window.safeAreaInsets.top + 10)];
-      self->_label =
-          [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top - 10, screenSize.width, 20)];
+      CGFloat windowWidth = window.bounds.size.width;
+
+      self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, windowWidth, window.safeAreaInsets.top + 10)];
+      self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top - 10, windowWidth, 20)];
       [self->_window addSubview:self->_label];
 
       self->_window.windowLevel = UIWindowLevelStatusBar + 1;

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -120,12 +120,14 @@ RCT_EXPORT_MODULE()
 
   dispatch_async(dispatch_get_main_queue(), ^{
     self->_showDate = [NSDate date];
+
     if (!self->_window && !RCTRunningInTestEnvironment()) {
 #if !TARGET_OS_OSX // [macOS]
-      UIWindow *window = RCTSharedApplication().keyWindow;
+      UIWindow *window = RCTKeyWindow();
       CGFloat windowWidth = window.bounds.size.width;
 
-      self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, windowWidth, window.safeAreaInsets.top + 10)];
+      self->_window = [[UIWindow alloc] initWithWindowScene:window.windowScene];
+      self->_window.frame = CGRectMake(0, 0, windowWidth, window.safeAreaInsets.top + 10);
       self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top - 10, windowWidth, 20)];
       [self->_window addSubview:self->_label];
 
@@ -162,12 +164,10 @@ RCT_EXPORT_MODULE()
 
     self->_window.backgroundColor = backgroundColor;
     self->_window.hidden = NO;
-
-    UIWindowScene *scene = (UIWindowScene *)RCTSharedApplication().connectedScenes.anyObject;
-    self->_window.windowScene = scene;
 #else // [macOS
     self->_label.stringValue = message;
     self->_label.textColor = color;
+
     self->_label.backgroundColor = backgroundColor;
     [self->_window orderFront:nil];
 #endif // macOS]

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -27,6 +27,14 @@
 
 using namespace facebook::react;
 
+#if !TARGET_OS_OSX // [macOS]
+@interface RCTParagraphComponentView () <UIEditMenuInteractionDelegate>
+
+@property (nonatomic, nullable) UIEditMenuInteraction *editMenuInteraction API_AVAILABLE(ios(16.0));
+
+@end
+#endif // [macOS]
+
 @implementation RCTParagraphComponentView {
   ParagraphShadowNode::ConcreteState::Shared _state;
   ParagraphAttributes _paragraphAttributes;
@@ -223,19 +231,36 @@ using namespace facebook::react;
 {
   _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                               action:@selector(handleLongPress:)];
+
+  if (@available(iOS 16.0, *)) {
+    _editMenuInteraction = [[UIEditMenuInteraction alloc] initWithDelegate:self];
+    [self addInteraction:_editMenuInteraction];
+  }
   [self addGestureRecognizer:_longPressGestureRecognizer];
 }
 
 - (void)disableContextMenu
 {
   [self removeGestureRecognizer:_longPressGestureRecognizer];
+  if (@available(iOS 16.0, *)) {
+    [self removeInteraction:_editMenuInteraction];
+    _editMenuInteraction = nil;
+  }
   _longPressGestureRecognizer = nil;
 }
 
 - (void)handleLongPress:(UILongPressGestureRecognizer *)gesture
 {
-  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
 #if !TARGET_OS_UIKITFORMAC
+  if (@available(iOS 16.0, *)) {
+    CGPoint location = [gesture locationInView:self];
+    UIEditMenuConfiguration *config = [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:location];
+    if (_editMenuInteraction) {
+      [_editMenuInteraction presentEditMenuWithConfiguration:config];
+    }
+    return;
+  }
+  // TODO: Adopt showMenuFromRect (necessary for UIKitForMac)
   UIMenuController *menuController = [UIMenuController sharedMenuController];
 
   if (menuController.isMenuVisible) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -263,7 +263,7 @@ using namespace facebook::react;
   if (oldViewProps.shouldRasterize != newViewProps.shouldRasterize) {
     self.layer.shouldRasterize = newViewProps.shouldRasterize;
 #if !TARGET_OS_OSX // [macOS]
-    self.layer.rasterizationScale = newViewProps.shouldRasterize ? [UIScreen mainScreen].scale : 1.0;
+    self.layer.rasterizationScale = newViewProps.shouldRasterize ? self.traitCollection.displayScale : 1.0;
 #else // [macOS
     self.layer.rasterizationScale = 1.0;
 #endif // macOS]

--- a/packages/react-native/React/UIUtils/RCTUIUtils.m
+++ b/packages/react-native/React/UIUtils/RCTUIUtils.m
@@ -15,8 +15,7 @@ RCTDimensions RCTGetDimensions(CGFloat fontScale)
   UIScreen *mainScreen = UIScreen.mainScreen;
   CGSize screenSize = mainScreen.bounds.size;
 
-  UIView *mainWindow;
-  mainWindow = RCTKeyWindow();
+  UIView *mainWindow = RCTKeyWindow();
   // We fallback to screen size if a key window is not found.
   CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
 #else // [macOS

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -277,7 +277,7 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 {
   view.layer.shouldRasterize = json ? [RCTConvert BOOL:json] : defaultView.layer.shouldRasterize;
   view.layer.rasterizationScale =
-      view.layer.shouldRasterize ? [UIScreen mainScreen].scale : defaultView.layer.rasterizationScale;
+      view.layer.shouldRasterize ? view.traitCollection.displayScale : defaultView.layer.rasterizationScale;
 }
 #endif // [macOS]
 

--- a/packages/rn-tester/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/packages/rn-tester/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -238,14 +238,15 @@ typedef NS_ENUM(NSInteger, FBTestSnapshotFileNameType) {
   if (0 < identifier.length) {
     fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
   }
-  CGFloat scale; // [macOS
-#if !TARGET_OS_OSX
-  scale = [[UIScreen mainScreen] scale];
-#else
-  scale = [[NSScreen mainScreen] backingScaleFactor];
-#endif
-  if (scale > 1.0) { // macOS]
+#if !TARGET_OS_OSX // [macOS]
+  UITraitCollection *currentTraitCollection = [UITraitCollection currentTraitCollection];
+  if (currentTraitCollection.displayScale > 1.0) {
+    fileName = [fileName stringByAppendingFormat:@"@%.fx", currentTraitCollection.displayScale];
+#else // [macOS
+  CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
+  if (scale > 1.0) {
     fileName = [fileName stringByAppendingFormat:@"@%.fx", scale];
+#endif // macOS]
   }
   fileName = [fileName stringByAppendingPathExtension:@"png"];
   return fileName;

--- a/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Compare.m
+++ b/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Compare.m
@@ -45,14 +45,13 @@
       (CGBitmapInfo)kCGImageAlphaPremultipliedLast);
 
 #if !TARGET_OS_OSX // [macOS]
-  CGFloat scaleFactor = [UIScreen mainScreen].scale;
+  CGFloat scaleFactor = [UITraitCollection currentTraitCollection].displayScale;
 #else // [macOS
   // The compareWithImage: method is used for integration test snapshot image comparison.
   // The _snapshotView: method that creates snapshot images that are *not* scaled for the screen.
   // By not using the screen scale factor in this method the test results are machine independent.
   CGFloat scaleFactor = 1;
 #endif // macOS]
-
   CGContextScaleCTM(referenceImageContext, scaleFactor, scaleFactor);
   CGContextScaleCTM(imageContext, scaleFactor, scaleFactor);
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

Cherry pick several commits that will help make adding visionOS support easier. These will be back ported to `0.73-stable` and `0.72-stable`.

Specific commits:
 - https://github.com/facebook/react-native/commit/e08a1973f67d85acc157111c749c43572469e4c2 Refactors deprecated uses of `UIMenuController` which is no longer available on visionOS
 - https://github.com/facebook/react-native/commit/ace81ff7d81b2eb547ad93b8000c5906dfefd9d3 Removes `[UIScreen mainScreen]` usage
 - https://github.com/facebook/react-native/commit/88e39136037ac338179579e6c48504c068a6618b Removes more `[UIScreen mainScreen]` usage
 - https://github.com/facebook/react-native/commit/90fb73e83caf087659b6b3173edd457b4f1d1987 Optimise a call to `RCTKeyWindow`
 - https://github.com/facebook/react-native/commit/782e9eace974baefba7d8978739f11fe1ea70dc9 Fefactor RCTKeyWindow to be more resilient and work in multi-window apps

## Test Plan:

CI should pass