### PR TITLE
[0.73][Cherry Pick] Fix Hermes version mismatch (#2014)

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -10,7 +10,10 @@ react_native_path = File.join(__dir__, "..", "..")
 
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
-version = package['version']
+# [macOS
+rn_version = package['version']
+version = findLastestVersionWithArtifact(rn_version) || rn_version
+# macOS]
 
 source_type = hermes_source_type(version, react_native_path)
 source = podspec_source(source_type, version, react_native_path)


### PR DESCRIPTION
Backport of https://github.com/microsoft/react-native-macos/pull/2014 to 0.73-stable