### PR TITLE
fix(macOS): Don't use iOS deployment target for macOS

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -292,7 +292,7 @@ class ReactNativePodsUtils
                 end
                 target_installation_result.native_target.build_configurations.each do |config|
                     config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_ios_version_supported
-                    config.build_settings["MACOSX_DEPLOYMENT_TARGET"] = Helpers::Constants.min_ios_version_supported # [macOS]
+                    config.build_settings["MACOSX_DEPLOYMENT_TARGET"] = Helpers::Constants.min_macos_version_supported # [macOS]
                 end
             end
     end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -47,15 +47,11 @@ def min_macos_version_supported
 end
 # macOS]
 
-def min_supported_versions
-return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported } # [macOS]
-end
-
 # This function returns the min supported OS versions supported by React Native
 # By using this function, you won't have to manually change your Podfile
 # when we change the minimum version supported by the framework.
 def min_supported_versions
-  return  { :ios => min_ios_version_supported, :osx => '10.15'} # [macOS]
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported} # [macOS]
 end
 
 # This function prepares the project for React Native, before processing

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		AC73FCE829B1316D0003586F /* RNTesterIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7C1241922BEC44B00DA25C0 /* RNTesterIntegrationTests.m */; };
 		AC73FCE929B131700003586F /* RCTLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB215E22B2F3EC005AC45F /* RCTLoggingTests.m */; };
 		AC73FCEB29B131770003586F /* RCTUIManagerScenarioTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB215F22B2F3EC005AC45F /* RCTUIManagerScenarioTests.m */; };
-		AC73FCEC29B1317A0003586F /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		AC73FCED29B1317D0003586F /* RNTesterTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB215D22B2F3EC005AC45F /* RNTesterTestModule.m */; };
 		AC73FCEE29B131870003586F /* RCTAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB20C622B2BAA5005AC45F /* RCTAllocationTests.m */; };
 		AC73FCEF29B1318B0003586F /* RCTAnimationUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7DB20B222B2BAA4005AC45F /* RCTAnimationUtilsTests.m */; };
@@ -58,7 +57,6 @@
 		ACDBF0D529B2BF0A00EEBD9E /* RNTesterUnitTestsBundle.js in Resources */ = {isa = PBXBuildFile; fileRef = E7DB20B322B2BAA4005AC45F /* RNTesterUnitTestsBundle.js */; };
 		BE29745FA46255D106CB15ED /* libPods-RNTester.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77955ECD532E128A8C49AC35 /* libPods-RNTester.a */; };
 		CD10C7A5290BD4EB0033E1ED /* RCTEventEmitterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD10C7A4290BD4EB0033E1ED /* RCTEventEmitterTests.m */; };
-		DD6FAB12C0152128DD2DA1BE /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		E62F11832A5C6580000BF1C8 /* FlexibleSizeExampleView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27F441E81BEBE5030039B79C /* FlexibleSizeExampleView.mm */; };
 		E62F11842A5C6584000BF1C8 /* UpdatePropertiesExampleView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 272E6B3C1BEA849E001FCF37 /* UpdatePropertiesExampleView.mm */; };
 		E7C1241A22BEC44B00DA25C0 /* RNTesterIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7C1241922BEC44B00DA25C0 /* RNTesterIntegrationTests.m */; };
@@ -242,7 +240,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD6FAB12C0152128DD2DA1BE /* BuildFile in Frameworks */,
 				BE29745FA46255D106CB15ED /* libPods-RNTester.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1049,7 +1046,6 @@
 				AC73FCE929B131700003586F /* RCTLoggingTests.m in Sources */,
 				AC73FCEB29B131770003586F /* RCTUIManagerScenarioTests.m in Sources */,
 				AC73FCED29B1317D0003586F /* RNTesterTestModule.m in Sources */,
-				AC73FCEC29B1317A0003586F /* BuildFile in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

This PR aims to reduce the number of changes needed to add visionOS support, see: https://github.com/microsoft/react-native-macos/pull/2019

Fix two issues:

1. Fix some typos where we were using the iOS deployment target for macOS, and had duplicated the definition of the `min_supported_versions` helper method (😵‍💫)
2. Delete some stale pbxproj entries that don't do anything. These show up every now and then, and I didn't feel it was worth a separate PR to fix up.

## Changelog:

[GENERAL] [FIXED] - Fix some typos and merge errors 

## Test Plan:

CI should pass.
