### PR TITLE
[0.73] fix(macOS): Don't use iOS deployment target for macOS

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -340,10 +340,12 @@ class ReactNativePodsUtils
                         config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] :
                         Helpers::Constants.min_ios_version_supported
                     config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = [Helpers::Constants.min_ios_version_supported.to_f, old_iphone_deploy_target.to_f].max.to_s
+                    #  [macOS
                     old_macos_deploy_target = config.build_settings["MACOSX_DEPLOYMENT_TARGET"] ?
                         config.build_settings["MACOSX_DEPLOYMENT_TARGET"] :
                         Helpers::Constants.min_macos_version_supported
                     config.build_settings["MACOSX_DEPLOYMENT_TARGET"] = [Helpers::Constants.min_macos_version_supported.to_f, old_macos_deploy_target.to_f].max.to_s
+                    # macOS]
                 end
             end
     end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -47,15 +47,11 @@ def min_macos_version_supported
 end
 # macOS]
 
-def min_supported_versions
-return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported } # [macOS]
-end
-
 # This function returns the min supported OS versions supported by React Native
 # By using this function, you won't have to manually change your Podfile
 # when we change the minimum version supported by the framework.
 def min_supported_versions
-  return  { :ios => min_ios_version_supported, :osx => '10.15'} # [macOS]
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported} # [macOS]
 end
 
 # This function prepares the project for React Native, before processing


### PR DESCRIPTION
Backport of #2042 to `0.73-stable