### PR TITLE
[0.72] Backport changes to help set platform versions in podspecs

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
+++ b/packages/react-native/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/actionsheetios"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -60,7 +60,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/actionsheetios"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files            = "**/*.{c,h,m,mm,S,cpp}"
 

--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{h,m,mm}"

--- a/packages/react-native/Libraries/FBLazyVector/FBLazyVector.podspec
+++ b/packages/react-native/Libraries/FBLazyVector/FBLazyVector.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "FBLazyVector"

--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/image"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/linking"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{h,m,mm}"

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/pushnotificationios"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/packages/react-native/Libraries/RCTRequired/RCTRequired.podspec
+++ b/packages/react-native/Libraries/RCTRequired/RCTRequired.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "RCTRequired"

--- a/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
+++ b/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/settings"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/packages/react-native/Libraries/Text/React-RCTText.podspec
+++ b/packages/react-native/Libraries/Text/React-RCTText.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/text"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{h,m}"
   s.ios.exclude_files      = "**/macOS/*" # [macOS]

--- a/packages/react-native/Libraries/TypeSafety/RCTTypeSafety.podspec
+++ b/packages/react-native/Libraries/TypeSafety/RCTTypeSafety.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "RCTTypeSafety"

--- a/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
+++ b/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/vibration"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -67,7 +67,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.resource_bundle        = { "AccessibilityResources" => ["React/AccessibilityResources/*.lproj"]}
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/packages/react-native/React.podspec
+++ b/packages/react-native/React.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.cocoapods_version      = ">= 1.10.1"

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{c,m,mm,cpp}"

--- a/packages/react-native/React/FBReactNativeSpec/FBReactNativeSpec.podspec
+++ b/packages/react-native/React/FBReactNativeSpec/FBReactNativeSpec.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   # This podspec is used to trigger the codegen, and built files are generated in a different location.

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -52,7 +52,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "Fabric/**/*.{c,h,m,mm,S,cpp}"
   s.exclude_files          = "**/tests/*",

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "dummyFile.cpp"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",

--- a/packages/react-native/ReactCommon/React-rncore.podspec
+++ b/packages/react-native/ReactCommon/React-rncore.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "dummyFile.cpp"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.header_dir             = "ReactCommon" # Use global header_dir for all subspecs for use_frameworks! compatibility
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/packages/react-native/ReactCommon/callinvoker/React-callinvoker.podspec
+++ b/packages/react-native/ReactCommon/callinvoker/React-callinvoker.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "ReactCommon"

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package['license']
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :osx => "10.14", :ios => "12.4" }
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "executor/*.{cpp,h}",
                              "inspector/*.{cpp,h}",

--- a/packages/react-native/ReactCommon/jsc/React-jsc.podspec
+++ b/packages/react-native/ReactCommon/jsc/React-jsc.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "JSCRuntime.{cpp,h}"
   s.exclude_files          = "**/test/*"

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
 
   s.header_dir    = "jsi"

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files         = "jsireact/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/packages/react-native/ReactCommon/jsinspector/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector/React-jsinspector.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = 'jsinspector'

--- a/packages/react-native/ReactCommon/logger/React-logger.podspec
+++ b/packages/react-native/ReactCommon/logger/React-logger.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => min_ios_version_supported, :osx => '10.15' } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "react/debug"

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.homepage               = "https://reactnative.dev/"
     s.license                = package["license"]
     s.author                 = "Meta Platforms, Inc. and its affiliates"
-    s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+    s.platforms              = min_supported_versions
     s.source                 = source
     s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
     s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers\"",

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = source_files

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = source_files

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => min_ios_version_supported, :osx => '10.15' } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => min_ios_version_supported, :osx => '10.15' } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h,mm}"
   s.compiler_flags         = folly_compiler_flags

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "reactperflogger"

--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "ReactCommon"

--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |spec|
   ]
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  spec.platforms = min_supported_versions
 
   # Set this environment variable when *not* using the `:path` option to install the pod.
   # E.g. when publishing this spec to a spec repo.

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -15,12 +15,16 @@ require_relative "./test_utils/CodegenUtilsMock.rb"
 require_relative "./test_utils/CodegenScriptPhaseExtractorMock.rb"
 require_relative "./test_utils/FileUtilsMock.rb"
 
-# mocking the min_ios_version_supported function
+# mocking the min_supported_versions function
 # as it is not possible to require the original react_native_pod
 # without incurring in circular deps
 # TODO: move `min_ios_version_supported` to utils.rb
 def min_ios_version_supported
     return '12.4'
+end
+
+def min_supported_versions
+  return  { :ios => min_ios_version_supported }
 end
 
 class CodegenUtilsTests < Test::Unit::TestCase
@@ -535,8 +539,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
           'source' => { :git => '' },
           'header_mappings_dir' => './',
           'platforms' => {
-            'ios' => '12.4',
-            'osx' => '10.15',
+            :ios => '13.4',
           },
           'source_files' => "**/*.{h,mm,cpp}",
           'pod_target_xcconfig' => {

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -23,8 +23,14 @@ def min_ios_version_supported
     return '12.4'
 end
 
+# [macOS
+def min_macos_version_supported
+    return '10.15'
+end
+# macOS]
+
 def min_supported_versions
-  return  { :ios => min_ios_version_supported }
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported } # [macOS]
 end
 
 class CodegenUtilsTests < Test::Unit::TestCase

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -112,10 +112,7 @@ class CodegenUtils
           'compiler_flags'  => "#{folly_compiler_flags} #{boost_compiler_flags} -Wno-nullability-completeness -std=c++17",
           'source' => { :git => '' },
           'header_mappings_dir' => './',
-          'platforms' => {
-            'ios' => min_ios_version_supported,
-            'osx' => '10.15'
-          },
+          'platforms' => min_supported_versions,
           'source_files' => "**/*.{h,mm,cpp}",
           'pod_target_xcconfig' => {
             "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -40,5 +40,10 @@ module Helpers
         def self.min_ios_version_supported
             return '12.4'
         end
+        # [macOS
+        def self.min_macos_version_supported
+            return '10.15'
+        end
+        # macOS]
     end
 end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -247,7 +247,7 @@ class ReactNativePodsUtils
         end
     end
 
-    def self.updateIphoneOSDeploymentTarget(installer)
+    def self.updateOSDeploymentTarget(installer)
         pod_to_update = Set.new([
             "boost",
             "CocoaAsyncSocket",

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -274,6 +274,7 @@ class ReactNativePodsUtils
                 end
                 target_installation_result.native_target.build_configurations.each do |config|
                     config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_ios_version_supported
+                    config.build_settings["MACOSX_DEPLOYMENT_TARGET"] = Helpers::Constants.min_macos_version_supported # [macOS]
                 end
             end
     end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -247,7 +247,7 @@ def react_native_post_install(
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
   ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: fabric_enabled)
   ReactNativePodsUtils.apply_xcode_15_patch(installer)
-  ReactNativePodsUtils.updateIphoneOSDeploymentTarget(installer)
+  ReactNativePodsUtils.updateOSDeploymentTarget(installer)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   is_new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == "1"

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -35,12 +35,15 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
+def min_ios_version_supported
+  return Helpers::Constants.min_ios_version_supported
+end
 
 # This function returns the min supported OS versions supported by React Native
 # By using this function, you won't have to manually change your Podfile
 # when we change the minimum version supported by the framework.
-def min_ios_version_supported
-  return Helpers::Constants.min_ios_version_supported
+def min_supported_versions
+  return  { :ios => min_ios_version_supported }
 end
 
 # This function prepares the project for React Native, before processing

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -39,11 +39,17 @@ def min_ios_version_supported
   return Helpers::Constants.min_ios_version_supported
 end
 
+# [macOS
+def min_macos_version_supported
+  return  Helpers::Constants.min_macos_version_supported
+end
+# macOS]
+
 # This function returns the min supported OS versions supported by React Native
 # By using this function, you won't have to manually change your Podfile
 # when we change the minimum version supported by the framework.
 def min_supported_versions
-  return  { :ios => min_ios_version_supported }
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported } # [macOS]
 end
 
 # This function prepares the project for React Native, before processing

--- a/packages/react-native/third-party-podspecs/DoubleConversion.podspec
+++ b/packages/react-native/third-party-podspecs/DoubleConversion.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |spec|
   spec.user_target_xcconfig = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/DoubleConversion\"" }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  spec.platforms = min_supported_versions
 
 end

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -152,5 +152,5 @@ Pod::Spec.new do |spec|
 
   # Folly has issues when compiled with iOS 10 set as deployment target
   # See https://github.com/facebook/folly/issues/1470 for details
-  spec.platforms = { :ios => "9.0", :osx => "10.15" } # [macOS]
+  spec.platforms = min_supported_versions
 end

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => '11.0', :osx => "10.15" } # [macOS]
+  spec.platforms = min_supported_versions
   spec.requires_arc = false
 
   spec.module_name = 'boost'

--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -33,6 +33,6 @@ Pod::Spec.new do |spec|
                                "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  spec.platforms = min_supported_versions
 
 end

--- a/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
+++ b/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.description     = "my-native-view"
   s.homepage        = "https://github.com/sota000/my-native-view.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms       = min_supported_versions
   s.compiler_flags  = boost_compiler_flags + ' -Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/my-native-view.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.podspec
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.description     = "NativeCxxModuleExample"
   s.homepage        = "https://github.com/facebook/react-native.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "12.4", :osx => "10.15" } # [macos]
+  s.platforms       = min_supported_versions
   s.compiler_flags  = '-Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/react-native.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
+++ b/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.description     = "ScreenshotManager"
   s.homepage        = "https://github.com/facebook/react-native.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms       = min_supported_versions
   s.compiler_flags  = '-Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/react-native.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4", :osx => "10.15" } # [macOS]
+  s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{h,m,mm}"


### PR DESCRIPTION
This change is a back port of #2042 to `0.72-stable`.

 In order to do so, I also had to back port https://github.com/facebook/react-native/commit/1b78da8b43d011834924d59b4493b854ddee4302 and https://github.com/facebook/react-native/commit/8fa1127c359563141f0cf62d5e3a3baac9f923f4 (both changes I made upstream to make it easier to add new platforms to React Native pod specs for React Native macOS 0.73+)