### PR TITLE
[visionOS] Add local podspecs to override supported platforms

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -163,6 +163,7 @@ def use_react_native! (
   pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
   pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
   pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+  pod 'SocketRocket', :podspec => "#{prefix}/third-party-podspecs/SocketRocket.podspec", :modular_headers => true # [visionOS]
 
   run_codegen!(
     app_path,

--- a/packages/react-native/third-party-podspecs/SocketRocket.podspec
+++ b/packages/react-native/third-party-podspecs/SocketRocket.podspec
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# [visionOS] Local copy of SocketRocket.podspec with visionOS added as a platform
+
+socket_rocket_version = '0.7.0'
+
+Pod::Spec.new do |s|
+  s.name               = 'SocketRocket'
+  s.version            = socket_rocket_version
+  s.summary            = 'A conforming WebSocket (RFC 6455) client library for iOS, macOS and tvOS.'
+  s.homepage           = 'https://github.com/facebook/SocketRocket'
+  s.authors            = { 'Nikita Lutsenko' => 'nlutsenko@me.com', 'Dan Federman' => 'federman@squareup.com', 'Mike Lewis' => 'mikelikespie@gmail.com' }
+  s.license            = 'BSD'
+  s.source             = { :git => 'https://github.com/facebook/SocketRocket.git', :tag => socket_rocket_version }
+  s.requires_arc       = true
+
+  s.source_files       = 'SocketRocket/**/*.{h,m}'
+  s.public_header_files = 'SocketRocket/*.h'
+
+  s.platforms = min_supported_versions
+
+  s.ios.frameworks     = 'CFNetwork', 'Security'
+  s.osx.frameworks     = 'CoreServices', 'Security'
+  s.tvos.frameworks    = 'CFNetwork', 'Security'
+  s.visionos.frameworks = 'CFNetwork', 'Security'
+  s.libraries          = 'icucore'
+end


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

This PR is part of a series of PRs for adding support for visionOS to the repository. See #2019 .

The way cocoapods works, the platforms a pod targets must be specified in its' pod spec, otherwise the generated Xcodeproj target won't output that platform's static library. AKA, if Pod A targets `{:iOS => 13.4, :osx => 10.15}`, then  targets that output `libA-iOS.a` and `libA-macOS.a` will be generated, but not targets that output `libA-visionOS.a`.  For most pod dependencies of react native, we set the platforms using `min_supported_versions` helper method, which we can override to return as many platforms as we want. However, there are a few pods where we don't control the podspec because we're getting it from the cocoapods registry. Without updating the pod in its own repo, we wouldn't be able to override the platforms, even if we're perfectly able to compile for said platform.  In our case, that would be:

- `main`:
  - SocketRocket
- `0.73` and `0.72`:
  - SocketRocket
  - fmt
  
Rather than wait for those repos to update (SocketRocket has been [taking a while](https://github.com/facebookincubator/SocketRocket/pull/669)), we can instead make local podspecs, stick in the folder `third_party_podspecs`, and reference them in our ruby methods. Let's do that.

We don't need to add `fmt.podspec`  for `main` because https://github.com/facebook/react-native/commit/bb9ed0e9061288e56796fe6fe6a69541c3e09c90 already did so. For the back ports to `0.73-stable` and `0.72-stable`, I will cherry-pick that change with the caveat it is newer than the version of `fmt` used on those branches before. I tried to downgrade to 6.2.1... but then it failed to build. This is a library for formatting print statements and iostream, which should be relatively safe to upgrade.

## Changelog:

[IOS] [CHANGED] - Add local podspecs to override supported platforms

## Test Plan:

CI should pass.
