### PR TITLE
[0.72][visionOS] Add local podspecs to override supported platforms

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/fmt/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/fmt/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++11 -fexceptions)
+add_compile_options(-std=c++20 -fexceptions)
 
 add_library(fmt STATIC src/format.cc)
 

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "glog"
   s.dependency "DoubleConversion"
+  s.dependency "fmt", "9.1.0"
   s.dependency "React-Core"
   s.dependency "React-debug"
   s.dependency "React-utils"

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
     ss.dependency "RCT-Folly", folly_version
     s.dependency "React-logger", version
     ss.dependency "DoubleConversion"
+    ss.dependency "fmt", "9.1.0"
     ss.dependency "glog"
     if using_hermes
       ss.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -39,6 +39,7 @@ Pod::Spec.new do |s|
 
   s.dependency "boost", "1.76.0"
   s.dependency "DoubleConversion"
+  s.dependency "fmt", "9.1.0"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
   s.dependency "React-jsinspector", version

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
+  s.dependency "fmt", "9.1.0"
   s.dependency "glog"
   s.dependency "RCT-Folly/Futures", folly_version
   s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -40,6 +40,7 @@ Pod::Spec.new do |s|
 
   s.dependency "boost", "1.76.0"
   s.dependency "DoubleConversion"
+  s.dependency "fmt", "9.1.0"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
 

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -40,6 +40,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
+  s.dependency "fmt", "9.1.0"
   s.dependency "glog"
 
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -152,7 +152,9 @@ def use_react_native! (
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
+  pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
   pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+  pod 'SocketRocket', :podspec => "#{prefix}/third-party-podspecs/SocketRocket.podspec", :modular_headers => true # [visionOS]
 
   run_codegen!(
     app_path,

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'boost'
   spec.dependency 'DoubleConversion'
   spec.dependency 'glog'
-  spec.dependency 'fmt' , '~> 6.2.1'
+  spec.dependency "fmt", "9.1.0"
   spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_PTHREAD=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation -faligned-new'
   spec.source_files = 'folly/String.cpp',
                       'folly/Conv.cpp',

--- a/packages/react-native/third-party-podspecs/SocketRocket.podspec
+++ b/packages/react-native/third-party-podspecs/SocketRocket.podspec
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# [visionOS] Local copy of SocketRocket.podspec with visionOS added as a platform
+
+socket_rocket_version = '0.7.0'
+
+Pod::Spec.new do |s|
+  s.name               = 'SocketRocket'
+  s.version            = socket_rocket_version
+  s.summary            = 'A conforming WebSocket (RFC 6455) client library for iOS, macOS and tvOS.'
+  s.homepage           = 'https://github.com/facebook/SocketRocket'
+  s.authors            = { 'Nikita Lutsenko' => 'nlutsenko@me.com', 'Dan Federman' => 'federman@squareup.com', 'Mike Lewis' => 'mikelikespie@gmail.com' }
+  s.license            = 'BSD'
+  s.source             = { :git => 'https://github.com/facebook/SocketRocket.git', :tag => socket_rocket_version }
+  s.requires_arc       = true
+
+  s.source_files       = 'SocketRocket/**/*.{h,m}'
+  s.public_header_files = 'SocketRocket/*.h'
+
+  s.platforms = min_supported_versions
+
+  s.ios.frameworks     = 'CFNetwork', 'Security'
+  s.osx.frameworks     = 'CoreServices', 'Security'
+  s.tvos.frameworks    = 'CFNetwork', 'Security'
+  s.visionos.frameworks = 'CFNetwork', 'Security'
+  s.libraries          = 'icucore'
+end

--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+Pod::Spec.new do |spec|
+  spec.name = "fmt"
+  spec.version = "9.1.0"
+  spec.license = { :type => "MIT" }
+  spec.homepage = "https://github.com/fmtlib/fmt"
+  spec.summary = "{fmt} is an open-source formatting library for C++. It can be used as a safe and fast alternative to (s)printf and iostreams."
+  spec.authors = "The fmt contributors"
+  spec.source = {
+    :git => "https://github.com/fmtlib/fmt.git",
+    :tag => "9.1.0"
+  }
+  spec.pod_target_xcconfig = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
+  }
+  spec.platforms = min_supported_versions
+  spec.libraries = "c++"
+  spec.public_header_files = "include/fmt/*.h"
+  spec.header_mappings_dir = "include"
+  spec.source_files = ["include/fmt/*.h", "src/format.cc"]
+end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -9,19 +9,19 @@ PODS:
     - React-Core (= 0.72.14)
     - React-jsi (= 0.72.14)
     - ReactCommon/turbomodule/core (= 0.72.14)
-  - fmt (6.2.1)
+  - fmt (9.1.0)
   - glog (0.3.5)
-  - OCMock (3.9.1)
+  - OCMock (3.9.3)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Default (= 2021.07.22.00)
   - RCT-Folly/Default (2021.07.22.00):
     - boost
     - DoubleConversion
-    - fmt (~> 6.2.1)
+    - fmt (= 9.1.0)
     - glog
   - RCTRequired (0.72.14)
   - RCTTypeSafety (0.72.14):
@@ -266,6 +266,7 @@ PODS:
   - React-cxxreact (0.72.14):
     - boost (= 1.76.0)
     - DoubleConversion
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 0.72.14)
@@ -284,10 +285,12 @@ PODS:
   - React-jsi (0.72.14):
     - boost (= 1.76.0)
     - DoubleConversion
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2021.07.22.00)
   - React-jsiexecutor (0.72.14):
     - DoubleConversion
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-cxxreact (= 0.72.14)
@@ -405,6 +408,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - ReactCommon/turbomodule/bridging (0.72.14):
     - DoubleConversion
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 0.72.14)
@@ -414,6 +418,7 @@ PODS:
     - React-perflogger (= 0.72.14)
   - ReactCommon/turbomodule/core (0.72.14):
     - DoubleConversion
+    - fmt (= 9.1.0)
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 0.72.14)
@@ -432,6 +437,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../react-native/React/FBReactNativeSpec`)
+  - fmt (from `../react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../react-native/third-party-podspecs/glog.podspec`)
   - OCMock (~> 3.9.1)
   - RCT-Folly (from `../react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -471,13 +477,12 @@ DEPENDENCIES:
   - ReactCommon-Samples (from `../react-native/ReactCommon/react/nativemodule/samples`)
   - ReactCommon/turbomodule/core (from `../react-native/ReactCommon`)
   - ScreenshotManager (from `NativeModuleExample`)
+  - SocketRocket (from `../react-native/third-party-podspecs/SocketRocket.podspec`)
   - Yoga (from `../react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   trunk:
-    - fmt
     - OCMock
-    - SocketRocket
 
 EXTERNAL SOURCES:
   boost:
@@ -488,6 +493,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
     :path: "../react-native/React/FBReactNativeSpec"
+  fmt:
+    :podspec: "../react-native/third-party-podspecs/fmt.podspec"
   glog:
     :podspec: "../react-native/third-party-podspecs/glog.podspec"
   RCT-Folly:
@@ -562,6 +569,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/react/nativemodule/samples"
   ScreenshotManager:
     :path: NativeModuleExample
+  SocketRocket:
+    :podspec: "../react-native/third-party-podspecs/SocketRocket.podspec"
   Yoga:
     :path: "../react-native/ReactCommon/yoga"
 
@@ -570,10 +579,10 @@ SPEC CHECKSUMS:
   DoubleConversion: acaf5db79676d2e9119015819153f0f99191de12
   FBLazyVector: 288049ecff3e9d4dbc45472ad9806ee7107d6f25
   FBReactNativeSpec: f92472dd3d7d7a61592f899d2c2dad34a34a33fd
-  fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
+  fmt: 5b727a448676142428a33049f421fa92202a0a46
   glog: 6df0a3d6e2750a50609471fd1a01fd2948d405b5
-  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
-  RCT-Folly: d4068a27d2141b203d46e675446351fcc3fe6b8d
+  OCMock: 300b1b1b9155cb6378660b981c2557448830bdc6
+  RCT-Folly: 7c4e3756fb6c3658e361d9bc03dc1bdb141f9216
   RCTRequired: 54ff765a2616c96e325b2ffc619b9cb5fa43112d
   RCTTypeSafety: 93648de41301fffd43492aebad61e9b627c08432
   React: c622bf9e7f72d875b783e6343bbceaaf22947d67
@@ -581,11 +590,11 @@ SPEC CHECKSUMS:
   React-Codegen: 884870dbc2d6760983f552857ddca39b3934836d
   React-Core: ec5221e3765fabd167a8d814f01dc50a18fd2cfc
   React-CoreModules: 36f02e348091fd0049b5fc3ae6471ea9d39de611
-  React-cxxreact: 1602814de180db73416ea51c79bcdb7b9ad8e4a9
+  React-cxxreact: 699ecb34a0767d430a6c7091f962ded866c3529a
   React-debug: 03f67152cc6e6c8076ffafd47293a25b7dcf675a
   React-jsc: 509dba8de93247c6479b9bb235b29a14a2df5306
-  React-jsi: e62fd46e5ff8c7a24f092ea99c7a0024d0360590
-  React-jsiexecutor: de9b97a1743ce44e1e4315b4067d0b4f43dc16f6
+  React-jsi: 1676dd387bdd1be50cca299c4636df7fa8b007cb
+  React-jsiexecutor: e6cbb7f2bf955a586041ddbd235f64bbb84f2ca2
   React-jsinspector: 6b49486408e655a5e29dfaff0fcffcdb20a0573e
   React-logger: fab7d1a4a3468a8a900b715155d30080e04001e1
   React-NativeModulesApple: e15208341807161e632353b30b42776badfede99
@@ -606,10 +615,10 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: d7e529ca7df51132f6f87e9e5e1412e291ee4ce6
   React-runtimescheduler: 1923caf10ec6307dac48cd192bc8c6d93480dbb8
   React-utils: de8d9d4a6b209b4b00b3cdf5140f06bc7e636fd9
-  ReactCommon: dc1738ce1b8030f242151ecf45af8acc62cdcf1f
+  ReactCommon: b08f02351da5586be3f0008ba2c8d58d7f445101
   ReactCommon-Samples: a3ca42d47f6ab4c55f9e9d59b3f2ceb18b120dc4
   ScreenshotManager: 84f13d11f296b960bbafd9897ba52588a42dd5ca
-  SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
+  SocketRocket: 68865697074ea9021e801d3aa9f466c52e656ca5
   Yoga: 8c3ef397bb03ad9761b37e4f9abc6e6157abdbf7
 
 PODFILE CHECKSUM: 23258155130fc3ae417bc5bb12e76438f3b9a394

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -1351,6 +1351,8 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;
@@ -1437,6 +1439,8 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Backport of #2047 to 0.72-stable. This PR also cherry-picks https://github.com/facebook/react-native/commit/bb9ed0e9061288e56796fe6fe6a69541c3e09c90 to override `fmt` and then downgrades `fmt` to `6.2.1`, the version that was already used on this branch.