### PR TITLE
[visionOS] Add min_visionos_version_supported to ruby methods

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -29,8 +29,14 @@ def min_macos_version_supported
 end
 # macOS]
 
+# [visionOS
+def self.min_visionos_version_supported
+    return '1.0'
+end
+# visionOS]
+
 def min_supported_versions
-  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported } # [macOS]
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported, :visionos => min_visionos_version_supported } # [macOS] # [visionOS]
 end
 
 class CodegenUtilsTests < Test::Unit::TestCase

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -45,5 +45,10 @@ module Helpers
             return '10.15'
         end
         # macOS]
+        # [visionOS
+        def self.min_visionos_version_supported
+            return '1.0'
+        end
+        # visionOS]
     end
 end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -293,6 +293,7 @@ class ReactNativePodsUtils
                 target_installation_result.native_target.build_configurations.each do |config|
                     config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_ios_version_supported
                     config.build_settings["MACOSX_DEPLOYMENT_TARGET"] = Helpers::Constants.min_macos_version_supported # [macOS]
+                    config.build_settings["XROS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_visionos_version_supported # [visionOS]
                 end
             end
     end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -47,11 +47,17 @@ def min_macos_version_supported
 end
 # macOS]
 
+# [visionOS
+def min_visionos_version_supported
+  return Helpers::Constants.min_visionos_version_supported
+end
+# visionOS]
+
 # This function returns the min supported OS versions supported by React Native
 # By using this function, you won't have to manually change your Podfile
 # when we change the minimum version supported by the framework.
 def min_supported_versions
-  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported} # [macOS]
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported, :visionos => min_visionos_version_supported } # [macOS] [visionOS]
 end
 
 # This function prepares the project for React Native, before processing


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

This PR is part of a series of PRs for adding support for visionOS to the repository. See #2019 .

Add the ruby helper methods to add `visionos` to  all of our podspecs. Because RNTester doesn't yet have a scheme targetting visionOS, cocoapods won't generate the extra visionOS targets when we run `pod install`. Therefore, this change should mostly be a no-op. 

## Changelog:

[IOS] [CHANGED] - [visionOS] Add min_visionos_version_supported to ruby methods

## Test Plan:

CI should pass. 
