### PR TITLE
[0.72][visionOS] Add min_visionos_version_supported to ruby methods

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -29,8 +29,14 @@ def min_macos_version_supported
 end
 # macOS]
 
+# [visionOS
+def self.min_visionos_version_supported
+    return '1.0'
+end
+# visionOS]
+
 def min_supported_versions
-  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported } # [macOS]
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported, :visionos => min_visionos_version_supported } # [macOS] # [visionOS]
 end
 
 class CodegenUtilsTests < Test::Unit::TestCase

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -45,5 +45,10 @@ module Helpers
             return '10.15'
         end
         # macOS]
+        # [visionOS
+        def self.min_visionos_version_supported
+            return '1.0'
+        end
+        # visionOS]
     end
 end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -275,6 +275,7 @@ class ReactNativePodsUtils
                 target_installation_result.native_target.build_configurations.each do |config|
                     config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_ios_version_supported
                     config.build_settings["MACOSX_DEPLOYMENT_TARGET"] = Helpers::Constants.min_macos_version_supported # [macOS]
+                    config.build_settings["XROS_DEPLOYMENT_TARGET"] = Helpers::Constants.min_visionos_version_supported # [visionOS]
                 end
             end
     end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -45,11 +45,17 @@ def min_macos_version_supported
 end
 # macOS]
 
+# [visionOS
+def min_visionos_version_supported
+  return Helpers::Constants.min_visionos_version_supported
+end
+# visionOS]
+
 # This function returns the min supported OS versions supported by React Native
 # By using this function, you won't have to manually change your Podfile
 # when we change the minimum version supported by the framework.
 def min_supported_versions
-  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported } # [macOS]
+  return  { :ios => min_ios_version_supported, :osx => min_macos_version_supported, :visionos => min_visionos_version_supported } # [macOS] [visionOS]
 end
 
 # This function prepares the project for React Native, before processing


### PR DESCRIPTION
Backport of #2050 to `0.72-stable`