### PR TITLE
chore(cli): deprecate `--configuration` option in `run-macos` 

### DIFF
--- a/packages/react-native/local-cli/runMacOS/runMacOS.js
+++ b/packages/react-native/local-cli/runMacOS/runMacOS.js
@@ -9,6 +9,7 @@
 /**
  * @typedef {{
  *   configuration: string;
+ *   mode: string;
  *   packager: boolean;
  *   port: number;
  *   projectPath: string;
@@ -47,6 +48,13 @@ function runMacOS(_, _ctx, args) {
     );
   }
 
+  if (args.configuration) {
+    logger.warn(
+      'Argument --configuration has been deprecated and will be removed in a future release, please use --mode instead.',
+    );
+    args.mode = args.configuration;
+  }
+
   process.chdir(args.projectPath);
 
   const xcodeProject = findXcodeProject(fs.readdirSync('.'));
@@ -78,11 +86,7 @@ function runMacOS(_, _ctx, args) {
 async function run(xcodeProject, scheme, args) {
   await buildProject(xcodeProject, scheme, args);
 
-  const buildSettings = getBuildSettings(
-    xcodeProject,
-    args.configuration,
-    scheme,
-  );
+  const buildSettings = getBuildSettings(xcodeProject, args.mode, scheme);
   const appPath = path.join(
     buildSettings.TARGET_BUILD_DIR,
     buildSettings.FULL_PRODUCT_NAME,
@@ -127,7 +131,7 @@ function buildProject(xcodeProject, scheme, args) {
       xcodeProject.isWorkspace ? '-workspace' : '-project',
       xcodeProject.name,
       '-configuration',
-      args.configuration,
+      args.mode,
       '-scheme',
       scheme,
     ];
@@ -278,8 +282,14 @@ module.exports = {
   options: [
     {
       name: '--configuration [string]',
-      description: 'Explicitly set the scheme configuration to use',
+      description:
+        '[Deprecated] Explicitly set the scheme configuration to use',
       default: 'Debug',
+    },
+    {
+      name: '--mode [string]',
+      description:
+        'Explicitly set the scheme configuration to use. This option is case sensitive.',
     },
     {
       name: '--scheme [string]',

--- a/packages/react-native/local-cli/runMacOS/runMacOS.js
+++ b/packages/react-native/local-cli/runMacOS/runMacOS.js
@@ -52,7 +52,10 @@ function runMacOS(_, _ctx, args) {
     logger.warn(
       'Argument --configuration has been deprecated and will be removed in a future release, please use --mode instead.',
     );
-    args.mode = args.configuration;
+
+    if (!args.mode) {
+      args.mode = args.configuration;
+    }
   }
 
   process.chdir(args.projectPath);
@@ -289,11 +292,12 @@ module.exports = {
     {
       name: '--mode [string]',
       description:
-        'Explicitly set the scheme configuration to use. This option is case sensitive.',
+        'Explicitly set the scheme configuration to use, corresponds to `--configuration` in `xcodebuild` command, e.g. Debug, Release.',
     },
     {
       name: '--scheme [string]',
-      description: 'Explicitly set Xcode scheme to use',
+      description:
+        'Explicitly set Xcode scheme to use, corresponds to `--scheme` in `xcodebuild` command.',
     },
     {
       name: '--project-path [string]',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

In future we would like to replace custom implementation of `run-macos` with the one that is inside created [`cli-platform-app`](https://github.com/react-native-community/cli/tree/main/packages/cli-platform-apple) package inside https://github.com/react-native-community/cli. To unify implementations between all Apple's OOT platforms.  To avoid creating _many_ breaking changes I'm deprecating old options that are under different name in new implementation. 

## Changelog:

[GENERAL] [DEPRECATED] - Deprecate `--configuration` option from `run-macos` command.



## Test Plan:

1. Setup CLI locally.
2. Run `run-macos --configuration` -> you should see the warning.
3. Run `run-macos --project-path` -> you should also see the warning.
