### PR TITLE
[visionOS] Followup fixes

### DIFF
--- a/packages/react-native/Libraries/Text/React-RCTText.podspec
+++ b/packages/react-native/Libraries/Text/React-RCTText.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "**/*.{h,m,mm}"
   s.ios.exclude_files      = "**/macOS/*" # [macOS]
+  s.visionos.exclude_files = "**/macOS/*" # [visionOS]
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTText"
   # [macOS MobileCoreServices Not available on macOS

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -68,17 +68,18 @@ RCT_EXPORT_MODULE()
 
   _currentInterfaceDimensions = [self _exportedDimensions];
 
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceOrientationDidChange)
                                                name:UIApplicationDidBecomeActiveNotification
                                              object:nil];
+#endif // [macOS] [visionOS]
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceFrameDidChange)
                                                name:RCTUserInterfaceStyleDidChangeNotification
                                              object:nil];
-#endif // [macOS]
+
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceFrameDidChange)
                                                name:RCTRootViewFrameDidChangeNotification


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

Some followup fixes to #2019 :

- Exclude `RCTUISecureTextField` from visionOS. This is a macOS specific file
- Fix a mismatching ifdef, where some code inside `#if !TARGET_OS_OSX` called code only defined in `#if TARGET_OS_IOS`. This is not needed to be back ported to 0.73 and 0.72 as their corresponding PRs already had this fix.

## Test Plan:

CI should pass
