### PR TITLE
[RNTester] Correctly specify React Native dependency

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -13,8 +13,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "start": "react-native start",
-    "android": "react-native run-android --mode HermesDebug",
+    "start": "react-native-macos start",
+    "android": "react-native-macos run-android --mode HermesDebug",
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",
@@ -25,11 +25,9 @@
   "dependencies": {
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",
-    "nullthrows": "^1.1.1"
-  },
-  "peerDependencies": {
+    "nullthrows": "^1.1.1",
     "react": "18.2.0",
-    "react-native": "*"
+    "react-native-macos": "workspace:*"
   },
   "codegenConfig": {
     "name": "AppSpecs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,9 +3645,8 @@ __metadata:
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
     nullthrows: "npm:^1.1.1"
-  peerDependencies:
-    react: 18.2.0
-    react-native: "*"
+    react: "npm:18.2.0"
+    react-native-macos: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -12469,7 +12468,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@workspace:packages/react-native":
+"react-native-macos@workspace:*, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

After #2030 landed, running `yarn start` (an alias of `react-native start`)  in `packages/rn-tester` leads to this error:
> command not found: react-native

This seems to be because Yarn 4 is much stricter about only using declared dependencies as compared to Yarn 1, and RNTester's package.json only specifies react-native as a peer dependency (a `"*"` at that!):
```
...
  "peerDependencies": {
    "react": "18.2.0",
    "react-native": "*"
  },
...
``` 

What we want is tell RNTester ( a private package that will never be published) to use the workspace copy of react-native, rather than download from NPM. Luckily, modern package managers have the `workspace:*` syntax for exactly that! Let's update our package.json. I also had to specify `react-native-macos` as the dependency instead of react-native.

This fix won't work upstream in React Native, where yarn 1 doesn't support `workspace:*`, and the version needs to update for every nightly / stable release. I have prepared a separate fix there: https://github.com/facebook/react-native/pull/42756

## Changelog:

[INTERNAL] [FIXED] - Fix running `react-native start` in rn-tester with yarn 4

## Test Plan:

CI should pass. 
