### PR TITLE
Set build settings required for Swift in the template project

### DIFF
--- a/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld.xcodeproj/project.pbxproj
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld.xcodeproj/project.pbxproj
@@ -347,6 +347,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				INFOPLIST_FILE = "HelloWorld-macos/Info.plist";
@@ -360,6 +361,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = HelloWorld;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -367,6 +370,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = "HelloWorld-macos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -379,6 +383,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = HelloWorld;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

As of Expo SDK50 it's possible to use Expo modules in `react-native-macos` projects. During `pod install` and a build phase script, `expo-modules-autolinking` generates a Swift file called `ExpoModulesProvider.swift` and adds it programmatically to the pbxproj using CocoaPods tooling.
The problem is that the template project doesn't have `SWIFT_VERSION` build setting, which causes the below error when building:

> Value for SWIFT_VERSION cannot be empty.

If we manually add a Swift file through Xcode, it automatically adds `SWIFT_VERSION`, `SWIFT_OPTIMIZATION_LEVEL` and `CLANG_ENABLE_MODULES` build settings to the target. These settings are already present in the target for iOS.

To made these changes, I simply manually added a dummy Swift file to the HelloWorld project and let Xcode update these settings.

## Changelog:

[IOS] [CHANGED] - Set build settings required for Swift in the template project

## Test Plan:

The newly generated project builds as expected (i.e. without the issue mentioned above) after applying this change and integrating it with Expo modules.
