### PR TITLE
[visionOS] Link Accelerate Framework on visionOS

### DIFF
--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -51,8 +51,11 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
-  s.ios.framework              = ["Accelerate", "UIKit"] # [macOS] Restrict UIKit to iOS
-  s.osx.framework              = ["Accelerate"] # [macOS]
+  # [macOS Restrict UIKit to iOS and visionOS
+  s.ios.framework              = ["Accelerate", "UIKit"] 
+  s.visionos.framework         = ["Accelerate", "UIKit"]
+  s.osx.framework              = ["Accelerate"]
+  # macOS]
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-Codegen", version


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary:

While working on https://github.com/microsoft/react-native-test-app/pull/1803 , I ran into this issue where we don't link the system framework `accelerate` on visionOS. Let's make that fix.

## Changelog:

[VISIONOS [FIXED] - Link Accelerate Framework on visionOS

## Test Plan:

CI should pass. Local build of visionOS (since that's not on CI yet) should also pass.
