### PR TITLE
[visionOS] Implement isVision interfaceIdiom

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -69,6 +69,10 @@ const Platform: PlatformType = {
     // $FlowFixMe[object-this-reference]
     return this.constants.uiMode === 'tv';
   },
+  // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean {
+    return false;
+  },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     'android' in spec
       ? // $FlowFixMe[incompatible-return]

--- a/packages/react-native/Libraries/Utilities/Platform.d.ts
+++ b/packages/react-native/Libraries/Utilities/Platform.d.ts
@@ -55,6 +55,7 @@ interface PlatformIOSStatic extends PlatformStatic {
   OS: 'ios';
   isPad: boolean;
   isTV: boolean;
+  isVision: boolean;
   isMacCatalyst?: boolean | undefined;
   Version: string;
 }

--- a/packages/react-native/Libraries/Utilities/Platform.flow.js
+++ b/packages/react-native/Libraries/Utilities/Platform.flow.js
@@ -42,6 +42,8 @@ type IOSPlatform = {
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean,
+  // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
   get isDisableAnimations(): boolean,

--- a/packages/react-native/Libraries/Utilities/Platform.flow.js
+++ b/packages/react-native/Libraries/Utilities/Platform.flow.js
@@ -80,6 +80,8 @@ type AndroidPlatform = {
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean,
+  // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
   get isDisableAnimations(): boolean,

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -58,6 +58,11 @@ const Platform: PlatformType = {
     return this.constants.interfaceIdiom === 'tv';
   },
   // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean {
+    // $FlowFixMe[object-this-reference]
+    return this.constants.interfaceIdiom === 'vision';
+  },
+  // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean {
     if (__DEV__) {
       // $FlowFixMe[object-this-reference]

--- a/packages/react-native/Libraries/Utilities/Platform.macos.js
+++ b/packages/react-native/Libraries/Utilities/Platform.macos.js
@@ -52,6 +52,10 @@ const Platform = {
     return false;
   },
   // $FlowFixMe[unsafe-getters-setters]
+  get isVision(): boolean {
+    return false;
+  },
+  // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean {
     if (__DEV__) {
       // $FlowFixMe[object-this-reference]

--- a/packages/react-native/React/CoreModules/RCTPlatform.mm
+++ b/packages/react-native/React/CoreModules/RCTPlatform.mm
@@ -30,6 +30,10 @@ static NSString *interfaceIdiom(UIUserInterfaceIdiom idiom)
       return @"tv";
     case UIUserInterfaceIdiomCarPlay:
       return @"carplay";
+#if TARGET_OS_VISION
+    case UIUserInterfaceIdiomVision:
+      return @"vision";
+#endif
     default:
       return @"unknown";
   }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

Cherry pick a couple of changes to introduce the `isVision` API so that we can write visionOS specific JS. This is a cherry pick of two commits already upstream, plus an extra one to add the method to `Platform.macos.js`,

## Changelog:

[VISIONOS] [ADDED] - Implement isVision interfaceIdiom

## Test Plan:

CI should pass
