### PR TITLE
Remove dangling semicolons from RCT macros

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -244,7 +244,7 @@ RCT_EXTERN_C_END
  */
 #define RCT_REMAP_METHOD(js_name, method)       \
   _RCT_EXTERN_REMAP_METHOD(js_name, method, NO) \
-  -(void)method RCT_DYNAMIC;
+  -(void)method RCT_DYNAMIC
 
 /**
  * Similar to RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD but lets you set
@@ -256,7 +256,7 @@ RCT_EXTERN_C_END
  */
 #define RCT_REMAP_BLOCKING_SYNCHRONOUS_METHOD(js_name, returnType, method) \
   _RCT_EXTERN_REMAP_METHOD(js_name, method, YES)                           \
-  -(returnType)method RCT_DYNAMIC;
+  -(returnType)method RCT_DYNAMIC
 
 /**
  * Use this macro in a private Objective-C implementation file to automatically


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary:

Internally, we enabled `-Wsemicolon-before-method-body` which exposed that React Native has a dangling semicolon after some of its macros. This leads to a bunch of code that looks like this to suppress the warning:

```objective-c
// ADO ~~: RCT macros have bad semicolons
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wsemicolon-before-method-body"
RCT_EXPORT_METHOD(logError
				  : (NSString *)error)
#pragma clang diagnostic pop
{
```
This is fixed upstream with https://github.com/facebook/react-native/commit/cf4963feb3acd22755e768bc22c20e3136049999 . Let's pick part of the fix so we can remove  the macro supression internally. 

## Test Plan:

CI should pass
