### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,6 @@ If you are making a new change then one of the following should be done:
 **Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
 -->
 
-#### Please select one of the following
-- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
-- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
-- [ ] I am making a fix / change for the macOS implementation of react-native
-- [ ] I am making a change required for Microsoft usage of react-native
-
 ## Summary:
 
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
-# :warning: Make sure you are targeting microsoft/react-native-macos for your PR :warning:
-(then delete these lines)
-
 <!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->
 
 <!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.
@@ -20,18 +17,6 @@ If you are making a new change then one of the following should be done:
 ## Summary:
 
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
-
-## Changelog:
-
-<!-- Help reviewers and the release process by writing your own changelog entry.
-
-Pick one each for the category and type tags:
-
-[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message
-
-For more details, see:
-https://reactnative.dev/contributing/changelogs-in-pull-requests
--->
 
 ## Test Plan:
 


### PR DESCRIPTION
## Summary:

Our pull request template has a section for a changelog, which is currently unused because we don't (and can't) use the same tool for changelog generation as upstream. Instead, we use the Github built in changelog generator, which mostly takes PR titles. Let's just remove that section from our template. 

## Test Plan:

Not really applicable. 