### PR TITLE
Ensure ghost text doesn't appear when performing undos

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -1008,8 +1008,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 
 /**
  * Attempts to remove the ghost text from a provided string given our current state.
- * If `strict` mode is enabled, this method asserts if we don't find the ghost text in the expected location.
- * If disabled and we don't find the ghost text, we assume it's already been removed and just return the input string.
+ * If `strict` mode is enabled, this method assumes the ghost text exists exactly
+ * where we expect it to be, and we assert if this turns out to not be the case.
+ * If disabled, we allow for the possibility that the ghost text has already been removed,
+ * which can happen if a delegate callback is trying to remove ghost text after invoking `setAttributedText:`.
  */
 - (NSAttributedString *)removingGhostTextFromString:(NSAttributedString *)string strict:(BOOL)strict {
   if (_ghostText == nil) {

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -211,10 +211,15 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
     NSAttributedString *oldAttributedText = [self.backedTextInputView.attributedText copy];
     NSInteger oldTextLength = oldAttributedText.string.length;
 
-    [self.backedTextInputView.undoManager registerUndoWithTarget:self handler:^(RCTBaseTextInputView *strongSelf) {
-      strongSelf.attributedText = oldAttributedText;
-      [strongSelf textInputDidChange];
-    }];
+    // Ghost text changes should not be part of the undo stack
+    if (!self.backedTextInputView.ghostTextChanging) {
+      // If there was ghost text previously, we don't want it showing up if we undo
+      NSAttributedString *oldAttributedTextWithoutGhostText = [self removingGhostTextFromString:oldAttributedText strict:YES] ?: oldAttributedText;
+      [self.backedTextInputView.undoManager registerUndoWithTarget:self handler:^(RCTBaseTextInputView *strongSelf) {
+        strongSelf.attributedText = oldAttributedTextWithoutGhostText;
+        [strongSelf textInputDidChange];
+      }];
+    }
 
     self.backedTextInputView.attributedText = attributedText;
 
@@ -975,27 +980,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
   self.backedTextInputView.ghostTextChanging = YES;
 
   if (_ghostText != nil) {
-    BOOL shouldDeleteGhostText = YES;
-    NSRange ghostTextRange = NSMakeRange(_ghostTextPosition, _ghostText.length);
-    NSMutableAttributedString *attributedString = [self.attributedText mutableCopy];
+    // When setGhostText: is called after making a standard edit, the ghost text may already be gone
+    BOOL ghostTextMayAlreadyBeGone = newGhostText == nil;
+    NSAttributedString *attributedStringWithoutGhostText = [self removingGhostTextFromString:self.attributedText strict:!ghostTextMayAlreadyBeGone];
 
-    if ([attributedString length] < NSMaxRange(ghostTextRange)) {
-      RCTAssert(false, @"Ghost text not fully present in text view text");
-      shouldDeleteGhostText = NO;
-    }
-
-    NSString *actualGhostText = shouldDeleteGhostText
-      ? [[attributedString attributedSubstringFromRange:ghostTextRange] string]
-      : nil;
-
-    if (![actualGhostText isEqual:_ghostText]) {
-      RCTAssert(false, @"Ghost text does not match text view text");
-      shouldDeleteGhostText = NO;
-    }
-
-    if (shouldDeleteGhostText) {
-      [attributedString deleteCharactersInRange:ghostTextRange];
-      self.attributedText = attributedString;
+    if (attributedStringWithoutGhostText != nil) {
+      self.attributedText = attributedStringWithoutGhostText;
       [self setSelectionStart:selection.start selectionEnd:selection.end];
     }
   }
@@ -1014,6 +1004,43 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
   }
 
   self.backedTextInputView.ghostTextChanging = NO;
+}
+
+/**
+ * Attempts to remove the ghost text from a provided string given our current state.
+ * If `strict` mode is enabled, this method asserts if we don't find the ghost text in the expected location.
+ * If disabled and we don't find the ghost text, we assume it's already been removed and just return the input string.
+ */
+- (NSAttributedString *)removingGhostTextFromString:(NSAttributedString *)string strict:(BOOL)strict {
+  if (_ghostText == nil) {
+    return string;
+  }
+
+  NSRange ghostTextRange = NSMakeRange(_ghostTextPosition, _ghostText.length);
+  NSMutableAttributedString *attributedString = [string mutableCopy];
+
+  if ([attributedString length] < NSMaxRange(ghostTextRange)) {
+    if (strict) {
+      RCTAssert(false, @"Ghost text not fully present in text view text");
+      return nil;
+    } else {
+      return string;
+    }
+  }
+
+  NSString *actualGhostText = [[attributedString attributedSubstringFromRange:ghostTextRange] string];
+
+  if (![actualGhostText isEqual:_ghostText]) {
+    if (strict) {
+      RCTAssert(false, @"Ghost text does not match text view text");
+      return nil;
+    } else {
+      return string;
+    }
+  }
+
+  [attributedString deleteCharactersInRange:ghostTextRange];
+  return attributedString;
 }
 
 // macOS]

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -213,7 +213,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 
     // Ghost text changes should not be part of the undo stack
     if (!self.backedTextInputView.ghostTextChanging) {
-      // If there was ghost text previously, we don't want it showing up if we undo
+      // If there was ghost text previously, we don't want it showing up if we undo.
+      // If something goes wrong when trying to remove it, just stick with oldAttributedText.
       NSAttributedString *oldAttributedTextWithoutGhostText = [self removingGhostTextFromString:oldAttributedText strict:YES] ?: oldAttributedText;
       [self.backedTextInputView.undoManager registerUndoWithTarget:self handler:^(RCTBaseTextInputView *strongSelf) {
         strongSelf.attributedText = oldAttributedTextWithoutGhostText;
@@ -1008,8 +1009,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
 
 /**
  * Attempts to remove the ghost text from a provided string given our current state.
+ *
  * If `strict` mode is enabled, this method assumes the ghost text exists exactly
- * where we expect it to be, and we assert if this turns out to not be the case.
+ * where we expect it to be. We assert and return `nil` if we don't find the expected ghost text.
+ * It's the responsibility of the caller to make sure the result isn't `nil`.
+ *
  * If disabled, we allow for the possibility that the ghost text has already been removed,
  * which can happen if a delegate callback is trying to remove ghost text after invoking `setAttributedText:`.
  */


### PR DESCRIPTION
## Summary:

Right now, the ghost text feature is quite incompatible with undo/redo support. Since we weren't filtering out ghost text from a text input's contents when registering undoable actions, we were susceptible to a bunch of weird side effects, such as ghost text becoming editable or even crashes.

The fix here is to make sure any undoable actions ignore ghost text. Ghost text is very transient and is designed to disappear as soon as you make any sort of change, so the easiest way to do this is to just remove it directly before doing anything.

A related issue pops up where a write to `setAttributedText:` also triggers a call to set the ghost text to `nil`. Since `setAttributedText:` already gets rid of the ghost text when we ask it to, the subsequent call to `setGhostText:` may not need any action. We solve this by being more lenient in this case, assuming that if the ghost text isn't in where our internal state expects it to be, we probably already removed it.

## Test Plan:

Validated that ghost text behaves properly against the following scenarios:
* Modify the value of the text input by typing manually.
* Setting the value of the text input on the JS side.
* Moving the cursor via a mouse click or arrow keys.
* Placing ghost text either in the middle or at the end of the text.
* Cases where the ghost text immediately precedes or follows "real" text with the same value (e.g., "This is ghost(ghost) text" or "This is (ghost)ghost text").