### PR TITLE
Send mouseUp events for NSTabView

### DIFF
--- a/packages/react-native/React/Base/RCTTouchHandler.m
+++ b/packages/react-native/React/Base/RCTTouchHandler.m
@@ -137,6 +137,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     // Pair the mouse down events with mouse up events so our _nativeTouches cache doesn't get stale
     if ([targetView isKindOfClass:[NSControl class]]) {
       _shouldSendMouseUpOnSystemBehalf = [(NSControl*)targetView isEnabled];
+    } else if ([targetView isKindOfClass:[NSTabView class]]) {
+      // NSTabView sends click events for tab buttons but doesn't inherit from NSControl
+      _shouldSendMouseUpOnSystemBehalf = YES;
     } else if ([targetView isKindOfClass:[NSText class]]) {
       _shouldSendMouseUpOnSystemBehalf = [(NSText*)targetView isSelectable];
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix for issue #2111 (NSTabView doesn't send mouseUp event because it doesn't inherit from NSControl).

NSTabView inherits from NSView, not NSControl, so its click events aren't recorded in the _nativeTouches cache leading to mouseUp and mouseDown not firing consistently when clicking on the tab buttons.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Code for custom TabView component provided in the linked issue.
