### PR TITLE
Implement `[RCTUITextField selectedRange]`

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -121,6 +121,12 @@
   return self;
 }
 
+#if TARGET_OS_OSX
+- (NSRange)selectedRange {
+  return [[self currentEditor] selectedRange];
+}
+#endif
+
 - (void)_textDidChange
 {
   _textWasPasted = NO;


### PR DESCRIPTION
## Summary:

We have a crash internally due to the following error:
> uncaught ObjC exception, reason: -[RCTUITextField selectedRange]: unrecognized selector sent to instance 0x347fc2d70

This reproes when you move focus programmatically (I.E: through JS with `ref.current.focus()`) to a TextInput with 2-Set Korean text already typed. For some reason, that exact code path means that Appkit calls the selector on our TextInput (backed by RCTUITextField in natively) and we crash on the uncaught exception. 

Fix is to implement the selector. 

## Test Plan:

CI should pass. Locally, no longer get an `unrecognized selector` exception.
