### PR TITLE
Servusdei2018 patch 1

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -37,7 +37,7 @@ import useAndroidRippleForView, {
   type RippleConfig,
 } from './useAndroidRippleForView';
 import * as React from 'react';
-import {useImperativeHandle, useMemo, useRef, useState} from 'react';
+import {useMemo, useRef, useState} from 'react';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-import type {Spec as FabricUIManagerSpec} from '../ReactNative/FabricUIManager';
 import type {
   LayoutAnimationConfig as LayoutAnimationConfig_,
   LayoutAnimationProperty,

--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -235,8 +235,7 @@ export abstract class FlatListComponent<
 
   getScrollableNode: () => any;
 
-  // TODO: use `unknown` instead of `any` for Typescript >= 3.0
-  setNativeProps: (props: {[key: string]: any}) => void;
+  setNativeProps: (props: {[key: string]: unknown}) => void;
 }
 
 export class FlatList<ItemT = any> extends FlatListComponent<

--- a/scripts/__tests__/publish-npm-test.js
+++ b/scripts/__tests__/publish-npm-test.js
@@ -92,7 +92,9 @@ describe('publish-npm', () => {
       execMock
         .mockReturnValueOnce({stdout: '0.81.0-rc.1\n', code: 0})
         .mockReturnValueOnce({code: 0});
+      /* [macOS We skip Android Artifact and NPM Publish on React Native macOS
       const expectedVersion = '0.82.0-nightly-20230420-currentco';
+      macOS] */
 
       publishNpm('nightly');
 

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -18,9 +18,9 @@ const {
   generateAndroidArtifacts,
   publishAndroidArtifactsToMaven,
 } = require('./release-utils');
-macOS] */
-const fs = require('fs');
+
 const path = require('path');
+macOS] */
 const yargs = require('yargs');
 
 /**
@@ -63,7 +63,7 @@ if (require.main === module) {
 }
 
 function publishNpm(buildType) {
-  const {version, tag} = getNpmInfo(buildType);
+  const {version} = getNpmInfo(buildType);
 
   // Here we update the react-native package and template package with the right versions
   // For releases, CircleCI job `prepare_package_for_release` handles this


### PR DESCRIPTION
resolves 1 TODO, 6 linter warnings

## Summary:

- The argument type of `FlatListComponent.setNativeProps` was changed from `any` to `unknown` to promote safer type handling
- A few unused variables/imports were removed

## Test Plan:

`yarn lint` passes successfully