### PR TITLE
[0.73][Hotfix] Pick up RCTDeviceInfo fix from upstream

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -98,6 +98,9 @@ RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {
+  if (_invalidated) {
+    return;
+  }
   _invalidated = YES;
   [self _cleanupObservers];
 }
@@ -120,10 +123,7 @@ RCT_EXPORT_MODULE()
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTWindowFrameDidChangeNotification object:nil];
 
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(invalidate)
-                                               name:RCTBridgeWillInvalidateModulesNotification
-                                             object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTBridgeWillInvalidateModulesNotification object:nil];
 }
 
 static BOOL RCTIsIPhoneNotched()


### PR DESCRIPTION


## Summary:

Pick up https://github.com/facebook/react-native/commit/44159e35ce21910a7c1f0f66807f43512b442b3c#diff-4608929083e7d44679638b322e0f5297664b0106fd1ddaf39a3039af0fd3e89f from upstream to fix a potential hang we're seeing internally.

## Test Plan:

CI should pass