### PR TITLE
Add getRectForCharRange to RCTTextView

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.h
@@ -22,7 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
           contentFrame:(CGRect)contentFrame
        descendantViews:(NSArray<RCTPlatformView *> *)descendantViews; // [macOS]
 
-- (NSRect)getRectForCharRange:(NSRange)charRange; // [macOS]
+#if TARGET_OS_OSX // [macOS
+- (NSRect)getRectForCharRange:(NSRange)charRange;
+#endif // macOS]
 
 /**
  * (Experimental and unused for Paper) Pointer event handlers.

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
           contentFrame:(CGRect)contentFrame
        descendantViews:(NSArray<RCTPlatformView *> *)descendantViews; // [macOS]
 
+- (NSRect)getRectForCharRange:(NSRange)charRange; // [macOS]
+
 /**
  * (Experimental and unused for Paper) Pointer event handlers.
  */

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -207,6 +207,20 @@
   [self setNeedsDisplay];
 }
 
+- (NSRect)getRectForCharRange:(NSRange)charRange // [macOS
+{
+    if (_textStorage) {
+        NSLayoutManager *layoutManager = _textStorage.layoutManagers.firstObject;
+        NSTextContainer *textContainer = layoutManager.textContainers.firstObject;
+        if (layoutManager && textContainer) {
+            NSRange glyphRange = [layoutManager glyphRangeForCharacterRange:charRange actualCharacterRange:nullptr];
+            return [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
+        }
+    }
+    
+    return {0, 0, 0, 0};
+} // macOS]
+
 - (void)drawRect:(CGRect)rect
 {
   [super drawRect:rect];

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -207,7 +207,8 @@
   [self setNeedsDisplay];
 }
 
-- (NSRect)getRectForCharRange:(NSRange)charRange // [macOS
+#if TARGET_OS_OSX // [macOS
+- (NSRect)getRectForCharRange:(NSRange)charRange
 {
     if (_textStorage) {
         NSLayoutManager *layoutManager = _textStorage.layoutManagers.firstObject;
@@ -219,7 +220,8 @@
     }
     
     return {0, 0, 0, 0};
-} // macOS]
+}
+#endif // macOS]
 
 - (void)drawRect:(CGRect)rect
 {


### PR DESCRIPTION
## Summary:

Add a function to return the bounding rect of a character range in the string hosted by RCTTextView.  Having such a function will enable referencing nested text runs for relative positioning of transient UI: callouts, tooltips, etc.