### PR TITLE
Backport getRectForCharRange to 0.73-stable

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.h
@@ -22,6 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
           contentFrame:(CGRect)contentFrame
        descendantViews:(NSArray<RCTPlatformView *> *)descendantViews; // [macOS]
 
+#if TARGET_OS_OSX // [macOS
+- (NSRect)getRectForCharRange:(NSRange)charRange;
+#endif // macOS]
+
 /**
  * (Experimental and unused for Paper) Pointer event handlers.
  */

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -207,6 +207,22 @@
   [self setNeedsDisplay];
 }
 
+#if TARGET_OS_OSX // [macOS
+- (NSRect)getRectForCharRange:(NSRange)charRange
+{
+    if (_textStorage) {
+        NSLayoutManager *layoutManager = _textStorage.layoutManagers.firstObject;
+        NSTextContainer *textContainer = layoutManager.textContainers.firstObject;
+        if (layoutManager && textContainer) {
+            NSRange glyphRange = [layoutManager glyphRangeForCharacterRange:charRange actualCharacterRange:nullptr];
+            return [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
+        }
+    }
+    
+    return {0, 0, 0, 0};
+}
+#endif // macOS]
+
 - (void)drawRect:(CGRect)rect
 {
   [super drawRect:rect];


### PR DESCRIPTION
See primary PR https://github.com/microsoft/react-native-macos/pull/2140



## Summary:

Add a function to return the bounding rect of a character range in the string hosted by RCTTextView. Having such a function will enable referencing nested text runs for relative positioning of transient UI: callouts, tooltips, etc.
