### PR TITLE
Add onMouseEnter and onMouseLeave to Text (cherry-picked from 0.73-stable)

### DIFF
--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -101,9 +101,20 @@ export interface TextPropsAndroid {
   android_hyphenationFrequency?: 'normal' | 'none' | 'full' | undefined;
 }
 
+// [macOS
+export interface TextPropsMacOS {
+  enableFocusRing?: boolean | undefined;
+  focusable?: boolean | undefined;
+  onMouseEnter?: ((event: MouseEvent) => void) | undefined;
+  onMouseLeave?: ((event: MouseEvent) => void) | undefined;
+  tooltip?: string | undefined;
+}
+// macOS]
+
 // https://reactnative.dev/docs/text#props
 export interface TextProps
   extends TextPropsIOS,
+    TextPropsMacOS, // [macOS]
     TextPropsAndroid,
     AccessibilityProps {
   /**

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.h
@@ -7,6 +7,7 @@
 
 #import <React/RCTComponent.h>
 #import <React/RCTEventDispatcher.h> // [macOS]
+#import <React/RCTVirtualTextView.h> // [macOS]
 
 #import <React/RCTUIKit.h> // [macOS]
 
@@ -21,6 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTextStorage:(NSTextStorage *)textStorage
           contentFrame:(CGRect)contentFrame
        descendantViews:(NSArray<RCTPlatformView *> *)descendantViews; // [macOS]
+
+// [macOS
+- (void)setTextStorage:(NSTextStorage *)textStorage
+          contentFrame:(CGRect)contentFrame
+       descendantViews:(NSArray<RCTPlatformView *> *)descendantViews
+       virtualSubviews:(NSArray<RCTVirtualTextView *> *_Nullable)virtualSubviews;
+// macOS]
 
 /**
  * (Experimental and unused for Paper) Pointer event handlers.

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -288,5 +288,19 @@ export type TextProps = $ReadOnly<{|
    * @platform macos
    */
   enableFocusRing?: ?boolean,
+
+  /**
+   * This event is called when the mouse hovers over this component.
+   *
+   * @platform macos
+   */
+  onMouseEnter?: ?(event: MouseEvent) => void,
+
+  /**
+   * This event is called when the mouse moves off of this component.
+   *
+   * @platform macos
+   */
+  onMouseLeave?: ?(event: MouseEvent) => void,
   // macOS]
 |}>;

--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -123,6 +123,8 @@ NS_ASSUME_NONNULL_END
 
 #import <AppKit/AppKit.h>
 
+#import <React/RCTComponent.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 //
@@ -403,6 +405,15 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 - (void)setNeedsDisplay;
 
+// Methods related to mouse events
+- (NSDictionary*)locationInfoFromDraggingLocation:(NSPoint)locationInWindow;
+- (NSDictionary*)locationInfoFromEvent:(NSEvent*)event;
+
+- (void)sendMouseEventWithBlock:(RCTDirectEventBlock)block
+                   locationInfo:(NSDictionary*)locationInfo
+                  modifierFlags:(NSEventModifierFlags)modifierFlags
+                 additionalData:(NSDictionary*)additionalData;
+
 // FUTURE: When Xcode 14 is no longer supported (CI is building with Xcode 15), we can remove this override since it's now declared on NSView
 @property BOOL clipsToBounds;
 @property (nonatomic, copy) NSColor *backgroundColor;
@@ -425,6 +436,24 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
  * Specifies whether focus ring should be drawn when the view has the first responder status.
  */
 @property (nonatomic, assign) BOOL enableFocusRing;
+
+// Mouse events
+@property (nonatomic, copy) RCTDirectEventBlock onMouseEnter;
+@property (nonatomic, copy) RCTDirectEventBlock onMouseLeave;
+@property (nonatomic, copy) RCTDirectEventBlock onDragEnter;
+@property (nonatomic, copy) RCTDirectEventBlock onDragLeave;
+@property (nonatomic, copy) RCTDirectEventBlock onDrop;
+
+// Focus events
+@property (nonatomic, copy) RCTBubblingEventBlock onBlur;
+@property (nonatomic, copy) RCTBubblingEventBlock onFocus;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onResponderGrant;
+@property (nonatomic, copy) RCTBubblingEventBlock onResponderMove;
+@property (nonatomic, copy) RCTBubblingEventBlock onResponderRelease;
+@property (nonatomic, copy) RCTBubblingEventBlock onResponderTerminate;
+@property (nonatomic, copy) RCTBubblingEventBlock onResponderTerminationRequest;
+@property (nonatomic, copy) RCTBubblingEventBlock onStartShouldSetResponder;
 
 @end
 

--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -406,6 +406,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 - (void)setNeedsDisplay;
 
 // Methods related to mouse events
+- (BOOL)hasMouseHoverEvent;
 - (NSDictionary*)locationInfoFromDraggingLocation:(NSPoint)locationInWindow;
 - (NSDictionary*)locationInfoFromEvent:(NSEvent*)event;
 

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -12,6 +12,7 @@
 #import <React/RCTUIKit.h>
 
 #import <React/RCTAssert.h>
+#import <UIView+React.h>
 
 #import <objc/runtime.h>
 
@@ -214,6 +215,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *bezierPath)
 @private
   NSColor *_backgroundColor;
   BOOL _clipsToBounds;
+  BOOL _hasMouseOver;
   BOOL _userInteractionEnabled;
   BOOL _mouseDownCanMoveWindow;
 }
@@ -287,7 +289,140 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
 
 - (void)viewDidMoveToWindow
 {
+  // Subscribe to view bounds changed notification so that the view can be notified when a
+  // scroll event occurs either due to trackpad/gesture based scrolling or a scrollwheel event
+  // both of which would not cause the mouseExited to be invoked.
+
+  if ([self window] == nil) {
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:NSViewBoundsDidChangeNotification
+                                                  object:nil];
+  }
+  else if ([[self enclosingScrollView] contentView] != nil) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(viewBoundsChanged:)
+                                                 name:NSViewBoundsDidChangeNotification
+                                               object:[[self enclosingScrollView] contentView]];
+  }
+
+  [self reactViewDidMoveToWindow]; // [macOS] Github#1412
+
   [self didMoveToWindow];
+}
+
+- (void)viewBoundsChanged:(NSNotification*)__unused inNotif
+{
+  // When an enclosing scrollview is scrolled using the scrollWheel or trackpad,
+  // the mouseExited: event does not get called on the view where mouseEntered: was previously called.
+  // This creates an unnatural pairing of mouse enter and exit events and can cause problems.
+  // We therefore explicitly check for this here and handle them by calling the appropriate callbacks.
+
+  if (!_hasMouseOver && self.onMouseEnter)
+  {
+    NSPoint locationInWindow = [[self window] mouseLocationOutsideOfEventStream];
+    NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
+
+    if (NSPointInRect(locationInView, [self bounds]))
+    {
+      _hasMouseOver = YES;
+
+      [self sendMouseEventWithBlock:self.onMouseEnter
+                       locationInfo:[self locationInfoFromDraggingLocation:locationInWindow]
+                      modifierFlags:0
+                     additionalData:nil];
+    }
+  }
+  else if (_hasMouseOver && self.onMouseLeave)
+  {
+    NSPoint locationInWindow = [[self window] mouseLocationOutsideOfEventStream];
+    NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
+
+    if (!NSPointInRect(locationInView, [self bounds]))
+    {
+      _hasMouseOver = NO;
+
+      [self sendMouseEventWithBlock:self.onMouseLeave
+                       locationInfo:[self locationInfoFromDraggingLocation:locationInWindow]
+                      modifierFlags:0
+                     additionalData:nil];
+    }
+  }
+}
+
+- (NSDictionary*)locationInfoFromDraggingLocation:(NSPoint)locationInWindow
+{
+  NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
+
+  return @{@"screenX": @(locationInWindow.x),
+           @"screenY": @(locationInWindow.y),
+           @"clientX": @(locationInView.x),
+           @"clientY": @(locationInView.y)
+           };
+}
+
+- (NSDictionary*)locationInfoFromEvent:(NSEvent*)event
+{
+  NSPoint locationInWindow = event.locationInWindow;
+  NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
+
+  return @{@"screenX": @(locationInWindow.x),
+           @"screenY": @(locationInWindow.y),
+           @"clientX": @(locationInView.x),
+           @"clientY": @(locationInView.y)
+           };
+}
+
+- (void)mouseEntered:(NSEvent *)event
+{
+  _hasMouseOver = YES;
+  [self sendMouseEventWithBlock:self.onMouseEnter
+                   locationInfo:[self locationInfoFromEvent:event]
+                  modifierFlags:event.modifierFlags
+                 additionalData:nil];
+}
+
+- (void)mouseExited:(NSEvent *)event
+{
+  _hasMouseOver = NO;
+  [self sendMouseEventWithBlock:self.onMouseLeave
+                   locationInfo:[self locationInfoFromEvent:event]
+                  modifierFlags:event.modifierFlags
+                 additionalData:nil];
+}
+
+- (void)sendMouseEventWithBlock:(RCTDirectEventBlock)block
+                   locationInfo:(NSDictionary*)locationInfo
+                  modifierFlags:(NSEventModifierFlags)modifierFlags
+                 additionalData:(NSDictionary*)additionalData
+{
+  if (block == nil) {
+    return;
+  }
+
+  NSMutableDictionary *body = [NSMutableDictionary new];
+
+  if (modifierFlags & NSEventModifierFlagShift) {
+    body[@"shiftKey"] = @YES;
+  }
+  if (modifierFlags & NSEventModifierFlagControl) {
+    body[@"ctrlKey"] = @YES;
+  }
+  if (modifierFlags & NSEventModifierFlagOption) {
+    body[@"altKey"] = @YES;
+  }
+  if (modifierFlags & NSEventModifierFlagCommand) {
+    body[@"metaKey"] = @YES;
+  }
+
+  if (locationInfo) {
+    [body addEntriesFromDictionary:locationInfo];
+  }
+
+  if (additionalData) {
+    [body addEntriesFromDictionary:additionalData];
+  }
+
+  block(body);
 }
 
 - (BOOL)mouseDownCanMoveWindow{

--- a/packages/react-native/React/Views/RCTShadowView.h
+++ b/packages/react-native/React/Views/RCTShadowView.h
@@ -241,6 +241,13 @@ typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, RCTPlatformView *> *vie
  */
 - (CGRect)measureLayoutRelativeToAncestor:(RCTShadowView *)ancestor;
 
+// [macOS
+/**
+ * Returns the closest ancestor shared by this shadow view and another specified shadow view.
+ */
+- (RCTShadowView *)ancestorSharedWithShadowView:(RCTShadowView *)shadowView;
+// macOS]
+
 /**
  * Checks if the current shadow view is a descendant of the provided `ancestor`
  */

--- a/packages/react-native/React/Views/RCTShadowView.m
+++ b/packages/react-native/React/Views/RCTShadowView.m
@@ -182,6 +182,25 @@ static void RCTProcessMetaPropsBorder(const YGValue metaProps[META_PROP_COUNT], 
   return (CGRect){offset, self.layoutMetrics.frame.size};
 }
 
+// [macOS
+- (RCTShadowView *)ancestorSharedWithShadowView:(RCTShadowView *)shadowView
+{
+  // TODO: Can this be optimized by climbing up both hierarchies at the same time?
+  NSMutableSet<RCTShadowView *> *selfSuperviews = [NSMutableSet set];
+  for (RCTShadowView *view = self; view != nil; view = [view reactSuperview]) {
+    [selfSuperviews addObject:view];
+  }
+
+  for (RCTShadowView *candidateView = shadowView; candidateView != nil; candidateView = [candidateView reactSuperview]) {
+    if ([selfSuperviews containsObject:candidateView]) {
+      return candidateView;
+    }
+  }
+
+  return nil;
+}
+// macOS]
+
 - (BOOL)viewIsDescendantOf:(RCTShadowView *)ancestor
 {
   RCTShadowView *shadowView = self;

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -167,12 +167,6 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 // that we can set through JS and the getter for `allowsVibrancy` can read in RCTView.
 @property (nonatomic, assign) BOOL allowsVibrancyInternal;
 
-@property (nonatomic, copy) RCTDirectEventBlock onMouseEnter;
-@property (nonatomic, copy) RCTDirectEventBlock onMouseLeave;
-@property (nonatomic, copy) RCTDirectEventBlock onDragEnter;
-@property (nonatomic, copy) RCTDirectEventBlock onDragLeave;
-@property (nonatomic, copy) RCTDirectEventBlock onDrop;
-
 // Keyboarding events
 // NOTE does not properly work with single line text inputs (most key downs). This is because those are
 // presumably handled by the window's field editor. To make it work, we'd need to look into providing

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -136,7 +136,6 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
   RCTUIColor *_backgroundColor; // [macOS]
   id<RCTEventDispatcherProtocol> _eventDispatcher; // [macOS]
 #if TARGET_OS_OSX // [macOS
-  NSTrackingArea *_trackingArea;
   BOOL _mouseDownCanMoveWindow;
 #endif // macOS]
   NSMutableDictionary<NSString *, NSDictionary *> *accessibilityActionsNameMap;
@@ -1464,28 +1463,6 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 - (BOOL)acceptsFirstResponder
 {
 	return [self focusable] || [super acceptsFirstResponder];
-}
-
-- (void)updateTrackingAreas
-{
-  BOOL hasMouseHoverEvent = self.onMouseEnter || self.onMouseLeave;
-  BOOL wouldRecreateIdenticalTrackingArea = hasMouseHoverEvent && _trackingArea && NSEqualRects(self.bounds, [_trackingArea rect]);
-
-  if (!wouldRecreateIdenticalTrackingArea) {
-    if (_trackingArea) {
-      [self removeTrackingArea:_trackingArea];
-    }
-
-    if (hasMouseHoverEvent) {
-      _trackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds
-                                                   options:NSTrackingActiveAlways|NSTrackingMouseEnteredAndExited
-                                                     owner:self
-                                                  userInfo:nil];
-      [self addTrackingArea:_trackingArea];
-    }
-  }
-
-  [super updateTrackingAreas];
 }
 
 - (BOOL)mouseDownCanMoveWindow{

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -137,7 +137,6 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
   id<RCTEventDispatcherProtocol> _eventDispatcher; // [macOS]
 #if TARGET_OS_OSX // [macOS
   NSTrackingArea *_trackingArea;
-  BOOL _hasMouseOver;
   BOOL _mouseDownCanMoveWindow;
 #endif // macOS]
   NSMutableDictionary<NSString *, NSDictionary *> *accessibilityActionsNameMap;
@@ -778,67 +777,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     [self setShadow:shadow];
 }
 
-- (void)viewDidMoveToWindow
-{
-  // Subscribe to view bounds changed notification so that the view can be notified when a
-  // scroll event occurs either due to trackpad/gesture based scrolling or a scrollwheel event
-  // both of which would not cause the mouseExited to be invoked.
 
-  if ([self window] == nil) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                    name:NSViewBoundsDidChangeNotification
-                                                  object:nil];
-  }
-  else if ([[self enclosingScrollView] contentView] != nil) {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(viewBoundsChanged:)
-                                                 name:NSViewBoundsDidChangeNotification
-                                               object:[[self enclosingScrollView] contentView]];
-  }
-
-  [self reactViewDidMoveToWindow]; // [macOS] Github#1412
-
-  [super viewDidMoveToWindow];
-}
-
-- (void)viewBoundsChanged:(NSNotification*)__unused inNotif
-{
-  // When an enclosing scrollview is scrolled using the scrollWheel or trackpad,
-  // the mouseExited: event does not get called on the view where mouseEntered: was previously called.
-  // This creates an unnatural pairing of mouse enter and exit events and can cause problems.
-  // We therefore explicitly check for this here and handle them by calling the appropriate callbacks.
-
-  if (!_hasMouseOver && self.onMouseEnter)
-  {
-    NSPoint locationInWindow = [[self window] mouseLocationOutsideOfEventStream];
-    NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
-
-    if (NSPointInRect(locationInView, [self bounds]))
-    {
-      _hasMouseOver = YES;
-
-      [self sendMouseEventWithBlock:self.onMouseEnter
-                       locationInfo:[self locationInfoFromDraggingLocation:locationInWindow]
-                      modifierFlags:0
-                     additionalData:nil];
-    }
-  }
-  else if (_hasMouseOver && self.onMouseLeave)
-  {
-    NSPoint locationInWindow = [[self window] mouseLocationOutsideOfEventStream];
-    NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
-
-    if (!NSPointInRect(locationInView, [self bounds]))
-    {
-      _hasMouseOver = NO;
-
-      [self sendMouseEventWithBlock:self.onMouseLeave
-                       locationInfo:[self locationInfoFromDraggingLocation:locationInWindow]
-                      modifierFlags:0
-                     additionalData:nil];
-    }
-  }
-}
 #endif // macOS]
 
 #pragma mark - Statics for dealing with layoutGuides
@@ -1549,24 +1488,6 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
   [super updateTrackingAreas];
 }
 
-- (void)mouseEntered:(NSEvent *)event
-{
-  _hasMouseOver = YES;
-  [self sendMouseEventWithBlock:self.onMouseEnter
-                   locationInfo:[self locationInfoFromEvent:event]
-                  modifierFlags:event.modifierFlags
-                 additionalData:nil];
-}
-
-- (void)mouseExited:(NSEvent *)event
-{
-  _hasMouseOver = NO;
-  [self sendMouseEventWithBlock:self.onMouseLeave
-                   locationInfo:[self locationInfoFromEvent:event]
-                  modifierFlags:event.modifierFlags
-                 additionalData:nil];
-}
-
 - (BOOL)mouseDownCanMoveWindow{
 	return _mouseDownCanMoveWindow;
 }
@@ -1577,53 +1498,6 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
 
 - (BOOL)allowsVibrancy {
   return _allowsVibrancyInternal;
-}
-
-- (NSDictionary*)locationInfoFromEvent:(NSEvent*)event
-{
-  NSPoint locationInWindow = event.locationInWindow;
-  NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
-
-  return @{@"screenX": @(locationInWindow.x),
-           @"screenY": @(locationInWindow.y),
-           @"clientX": @(locationInView.x),
-           @"clientY": @(locationInView.y)
-           };
-}
-
-- (void)sendMouseEventWithBlock:(RCTDirectEventBlock)block
-                   locationInfo:(NSDictionary*)locationInfo
-                  modifierFlags:(NSEventModifierFlags)modifierFlags
-                 additionalData:(NSDictionary*)additionalData
-{
-  if (block == nil) {
-    return;
-  }
-  
-  NSMutableDictionary *body = [NSMutableDictionary new];
-  
-  if (modifierFlags & NSEventModifierFlagShift) {
-    body[@"shiftKey"] = @YES;
-  }
-  if (modifierFlags & NSEventModifierFlagControl) {
-    body[@"ctrlKey"] = @YES;
-  }
-  if (modifierFlags & NSEventModifierFlagOption) {
-    body[@"altKey"] = @YES;
-  }
-  if (modifierFlags & NSEventModifierFlagCommand) {
-    body[@"metaKey"] = @YES;
-  }
-
-  if (locationInfo) {
-    [body addEntriesFromDictionary:locationInfo];
-  }
-
-  if (additionalData) {
-    [body addEntriesFromDictionary:additionalData];
-  }
-
-  block(body);
 }
 
 - (NSDictionary*)dataTransferInfoFromPasteboard:(NSPasteboard*)pasteboard
@@ -1702,17 +1576,6 @@ setBorderColor() setBorderColor(Top) setBorderColor(Right) setBorderColor(Bottom
   return @{@"dataTransfer": @{@"files": files,
                               @"items": items,
                               @"types": types}};
-}
-
-- (NSDictionary*)locationInfoFromDraggingLocation:(NSPoint)locationInWindow
-{
-  NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
-
-  return @{@"screenX": @(locationInWindow.x),
-           @"screenY": @(locationInWindow.y),
-           @"clientX": @(locationInView.x),
-           @"clientY": @(locationInView.y)
-           };
 }
 
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1346,7 +1346,7 @@ const examples = [
   {
     title: 'Mouse hover events on nested Text elements',
     render: function (): React.Node {
-      function mouseProps(name) {
+      function mouseProps(name: string) {
         return {
           onMouseEnter: () => console.log(`Enter ${name}`),
           onMouseLeave: () => console.log(`Leave ${name}`),

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1344,6 +1344,27 @@ const examples = [
   },
   // [macOS
   {
+    title: 'Mouse hover events on nested Text elements',
+    render: function (): React.Node {
+      function mouseProps(name) {
+        return {
+          onMouseEnter: () => console.log(`Enter ${name}`),
+          onMouseLeave: () => console.log(`Leave ${name}`),
+        };
+      }
+
+      return (
+        <Text {...mouseProps('outer')}>
+          This is some text with{' '}
+          <Text style={{color: 'red'}} {...mouseProps('inner')}>
+            a nested element
+          </Text>{' '}
+          that tracks mouse hover events
+        </Text>
+      )
+    }
+  },
+  {
     title: 'Text components inheriting color from parent',
     render: function (): React.Node {
       return (

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1361,8 +1361,8 @@ const examples = [
           </Text>{' '}
           that tracks mouse hover events
         </Text>
-      )
-    }
+      );
+    },
   },
   {
     title: 'Text components inheriting color from parent',


### PR DESCRIPTION
## Summary:

This mainly brings over #2137 and #2143 from 0.73-stable into the main branch. We also add an example in RNTester and do some housekeeping on our TypeScript types.

Commit descriptions:
* Move various Mac-specific props from `RCTView` to its parent class `RCTUIView`. Theoretically these can be used for any sort of view, not just `<View>`. They're still "opt-in" from the JS side, so there won't be any side effects for other views that don't care about these properties.
* Hooks up `onMouseEnter` and `onMouseLeave` to `<Text>` views.

## Test Plan:

Validated the new test case in RNTester as well as in other external test apps.
