### PR TITLE
[0.74] Publish virtualized-lists in preparation for 0.74 release

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -137,7 +137,6 @@ extends:
              os: linux
            timeoutInMinutes: 90 # how long to run the job before automatically cancelling
            cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-           condition: eq(variables['Build.SourceBranchName'], 'main')
            templateContext:
              outputs:
                - output: pipelineArtifact

--- a/change/@react-native-mac-virtualized-lists-d397b7c8-5ac3-4deb-8d0f-58f565bd418f.json
+++ b/change/@react-native-mac-virtualized-lists-d397b7c8-5ac3-4deb-8d0f-58f565bd418f.json
@@ -3,5 +3,5 @@
   "comment": "Release virtualized-lists for React Native macOS 0.74",
   "packageName": "@react-native-mac/virtualized-lists",
   "email": "sanajmi@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@react-native-mac-virtualized-lists-d397b7c8-5ac3-4deb-8d0f-58f565bd418f.json
+++ b/change/@react-native-mac-virtualized-lists-d397b7c8-5ac3-4deb-8d0f-58f565bd418f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Release virtualized-lists for React Native macOS 0.74",
+  "packageName": "@react-native-mac/virtualized-lists",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -111,7 +111,7 @@
     "@react-native-community/cli": "13.6.9",
     "@react-native-community/cli-platform-android": "13.6.9",
     "@react-native-community/cli-platform-ios": "13.6.9",
-    "@react-native-mac/virtualized-lists": "0.74.87",
+    "@react-native-mac/virtualized-lists": "0.74.86",
     "@react-native/assets-registry": "0.74.87",
     "@react-native/codegen": "0.74.87",
     "@react-native/community-cli-plugin": "0.74.87",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-mac/virtualized-lists",
-  "version": "0.74.87",
+  "version": "0.74.86",
   "description": "Virtualized lists for React Native macOS.",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,7 +3332,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.74.87, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.74.86, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -12499,7 +12499,7 @@ __metadata:
     "@react-native-community/cli": "npm:13.6.9"
     "@react-native-community/cli-platform-android": "npm:13.6.9"
     "@react-native-community/cli-platform-ios": "npm:13.6.9"
-    "@react-native-mac/virtualized-lists": "npm:0.74.87"
+    "@react-native-mac/virtualized-lists": "npm:0.74.86"
     "@react-native/assets-registry": "npm:0.74.87"
     "@react-native/codegen": "npm:0.74.87"
     "@react-native/community-cli-plugin": "npm:0.74.87"


### PR DESCRIPTION
## Summary:

To publish React Native macOS 0.74, we need to publish `@react-native-mac/virtualized-lists` first. This change prepares us to do by doing the following:

- Updates our pipeline to allow the beachball publish job to run from non-main branches (like 0.74-stable)
- Lowers virtualized-lists by a patch version
- Adds a change file for virtualized-lists. This will add back the patch version. I also took care to make sure this doesn't cause a dependent patbumph to React Native macOS.

## Test Plan:

Manually ran `npx beachball publish` to see what the change would be, and it looked right.
