### PR TITLE
Prevent spurious onBlur/onEndEditing events in `<TextInput>` elements with placeholder text

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -93,7 +93,9 @@
 #endif
   RCTBackedTextFieldDelegateAdapter *_textInputDelegateAdapter;
   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
-  BOOL _isUpdatingPlaceholderText; // [macOS]
+#if TARGET_OS_OSX // [macOS
+  BOOL _isUpdatingPlaceholderText;
+#endif // macOS]
 }
 
 #if TARGET_OS_OSX // [macOS
@@ -117,7 +119,9 @@
 
     _textInputDelegateAdapter = [[RCTBackedTextFieldDelegateAdapter alloc] initWithTextField:self];
     _scrollEnabled = YES;
-    _isUpdatingPlaceholderText = NO; // [macOS]
+#if TARGET_OS_OSX // [macOS
+    _isUpdatingPlaceholderText = NO;
+#endif // macOS]
   }
 
   return self;
@@ -495,13 +499,11 @@
 {
   [super textDidEndEditing:notification];
 
-  // [macOS
   // On macOS, setting placeholderAttributedString causes AppKit to call textDidEndEditing.
   // We don't want this to propagate or else we get unexpected onBlur/onEndEditing events.
   if (_isUpdatingPlaceholderText) {
     return;
   }
-  // macOS]
 
   id<RCTUITextFieldDelegate> delegate = self.delegate;
   if ([delegate respondsToSelector:@selector(textFieldEndEditing:)]) {


### PR DESCRIPTION
## Summary:

While working on #2159, I noticed that a single-line `<TextInput>` with a placeholder causes spurious `onBlur` and `onEndEditing` events. For some strange reason, setting `placeholderAttributedString` on macOS causes the `NSTextDelegate` to call `textDidEndEditing`. This PR blocks these events from reaching the JS side.

## Test Plan:

Validated in RNTester that `onBlur` and `onEndEditing` don't get called unexpectedly when dealing with a `<TextInput>` with placeholder text.