### PR TITLE
[0.74] Update Publish CI job to publish `0.74.0`

### DIFF
--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -29,13 +29,12 @@ steps:
     # Note, This won't do the actual `git tag` and `git push` as we're doing a dry run.
     # We do that as a separate step in `.ado/publish.yml`.
     - task: CmdLine@2
-      displayName: Prepare package for release
+      displayName: Set React Native macOS version
       inputs:
         script: |
-          node ./scripts/prepare-package-for-release.js -v "$RNM_PACKAGE_VERSION" --dry-run
-      env:
-        # Map the corresponding CircleCI variable since `prepare-package-for-release.js` depends on it.
-        CIRCLE_BRANCH: $(Build.SourceBranchName)
+          set -eox pipefail
+          $RNM_PACKAGE_VERSION = $(node .ado/get-next-semver-version.js)
+          node scripts/releases/set-rn-version.js -v RNM_PACKAGE_VERSION --build-type "release"
 
   # Note: This won't actually publish to NPM as we've commented that bit out.
   # We do that as a separate step in `.ado/publish.yml`. 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -111,7 +111,7 @@
     "@react-native-community/cli": "13.6.9",
     "@react-native-community/cli-platform-android": "13.6.9",
     "@react-native-community/cli-platform-ios": "13.6.9",
-    "@react-native-mac/virtualized-lists": "0.74.86",
+    "@react-native-mac/virtualized-lists": "0.74.87",
     "@react-native/assets-registry": "0.74.87",
     "@react-native/codegen": "0.74.87",
     "@react-native/community-cli-plugin": "0.74.87",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,7 +3332,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.74.86, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.74.87, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -12499,7 +12499,7 @@ __metadata:
     "@react-native-community/cli": "npm:13.6.9"
     "@react-native-community/cli-platform-android": "npm:13.6.9"
     "@react-native-community/cli-platform-ios": "npm:13.6.9"
-    "@react-native-mac/virtualized-lists": "npm:0.74.86"
+    "@react-native-mac/virtualized-lists": "npm:0.74.87"
     "@react-native/assets-registry": "npm:0.74.87"
     "@react-native/codegen": "npm:0.74.87"
     "@react-native/community-cli-plugin": "npm:0.74.87"


### PR DESCRIPTION
Updates our CI to release React Native macOS 0.74.0, assuming all goes well.

## Summary:

First, we need to manually bump RNM's dependency on `@react-native-mac/virtualized-lists` to `0.74.87`. https://github.com/microsoft/react-native-macos/pull/2158 didn't do this because we set `"dependentChangeType": "none"` in the change file. 

Second, we need to update our publish job, since some of the scripts we relied on have changed between 0.73 and 0.74. Specifically, it seems `prepare-package-for-release.js` has been replaced with a direct call to `set-rn-version.js`. I figured this out by looking at the changes in https://github.com/facebook/react-native/commit/bb4d13e80c8030e98a96eec12ec1244b930662b7 and by looking at the [CircleCI job "prepare-release"](https://github.com/microsoft/react-native-macos/blob/9cf3a4a4d331d5626df27d1b7b401db6e762b8c9/.circleci/configurations/jobs.yml#L1101). I am also taking advantage of a [change we made for RNM ](https://github.com/microsoft/react-native-macos/commit/a4ac549b42bd881afa4e3f1d0f5c7451876d51e7#diff-2e9633eddd1f97496b45ed24d38ebab24408e37541aafae60acb3542e2ba258b) to add a `-ready` prefix when we want `get-next-semver-version.js` to know we want `0.74.0` and not `0.74.1`.

## Test Plan:

Locally ran the modified bash script in our CI pipeline, and it seemed to do the right thing (just bump package versions to 0.74.0)