### PR TITLE
Bump minimum macOS requirement to 11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Follow the [Getting Started guide](https://reactnative.dev/docs/getting-started)
 
 ## Requirements
 
-You can run React Native for macOS apps on Mac devices with versions Catalina (10.15) or newer.
+You can run React Native for macOS apps on Mac devices with versions Catalina (11) or newer.
 
 For a full and detailed list of the system requirements and how to set up your development platform, see our [System Requirements](https://microsoft.github.io/react-native-windows/docs/rnm-dependencies) documentation on our website.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Follow the [Getting Started guide](https://reactnative.dev/docs/getting-started)
 
 ## Requirements
 
-You can run React Native for macOS apps on Mac devices with versions Catalina (11) or newer.
+You can run React Native for macOS apps on Mac devices with versions Big Sur (11) or newer.
 
 For a full and detailed list of the system requirements and how to set up your development platform, see our [System Requirements](https://microsoft.github.io/react-native-windows/docs/rnm-dependencies) documentation on our website.
 

--- a/packages/react-native/Libraries/Text/RCTTextAttributes.mm
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.mm
@@ -20,11 +20,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
 // [macOS
 + (RCTUIColor *)defaultForegroundColor
 {
-  if (@available(iOS 13.0, *)) {
-    return [RCTUIColor labelColor];
-  } else {
-    return [RCTUIColor blackColor];
-  }
+  return [RCTUIColor labelColor];
 }
 // macOS]
 
@@ -141,7 +137,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   }
 
   if (_lineBreakStrategy != NSLineBreakStrategyNone) {
-    if (@available(iOS 14.0, macOS 11.0, *)) { // [macOS]
+    if (@available(iOS 14.0, *)) {
       paragraphStyle.lineBreakStrategy = _lineBreakStrategy;
       isParagraphStyleUsed = YES;
     }

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -966,16 +966,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)decoder)
   NSMutableDictionary<NSAttributedStringKey, id> *textAttributes =
       [backedTextInputView.defaultTextAttributes mutableCopy] ?: [NSMutableDictionary new];
 
-  if (@available(iOS 13.0, *)) {
-    [textAttributes setValue:backedTextInputView.placeholderColor ?: [RCTUIColor placeholderTextColor]
-                      forKey:NSForegroundColorAttributeName];
-  } else {
-    if (backedTextInputView.placeholderColor) {
-      [textAttributes setValue:backedTextInputView.placeholderColor forKey:NSForegroundColorAttributeName];
-    } else {
-      [textAttributes removeObjectForKey:NSForegroundColorAttributeName];
-    }
-  }
+  [textAttributes setValue:backedTextInputView.placeholderColor ?: [RCTUIColor placeholderTextColor]
+                    forKey:NSForegroundColorAttributeName];
 
   return textAttributes;
 }

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -417,18 +417,8 @@
   NSMutableDictionary<NSAttributedStringKey, id> *textAttributes =
       [_defaultTextAttributes mutableCopy] ?: [NSMutableDictionary new];
 
-  // [macOS
-  if (@available(iOS 13.0, *)) {
     [textAttributes setValue:self.placeholderColor ?: [RCTUIColor placeholderTextColor]
-                      forKey:NSForegroundColorAttributeName];
-  } else {
-  // macOS]
-    if (self.placeholderColor) {
-      [textAttributes setValue:self.placeholderColor forKey:NSForegroundColorAttributeName];
-    } else {
-      [textAttributes removeObjectForKey:NSForegroundColorAttributeName];
-    }
-  }
+                      forKey:NSForegroundColorAttributeName]; // [macOS]
 
   return textAttributes;
 }

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -377,7 +377,7 @@ RCT_ENUM_CONVERTER(
 
 + (NSLineBreakStrategy)NSLineBreakStrategy:(id)json RCT_DYNAMIC
 {
-  if (@available(iOS 14.0, macOS 11.0, *)) { // [macOS]
+  if (@available(iOS 14.0, *)) {
     static NSDictionary *mapping;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -886,11 +886,7 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
   
   switch (activityIndicatorViewStyle) {
     case UIActivityIndicatorViewStyleLarge:
-	  if (@available(macOS 11.0, *)) {
-		self.controlSize = NSControlSizeLarge;
-	  } else {
-		self.controlSize = NSControlSizeRegular;
-	  }
+		  self.controlSize = NSControlSizeLarge;
       break;
     case UIActivityIndicatorViewStyleMedium:
       self.controlSize = NSControlSizeRegular;

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -886,7 +886,7 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
   
   switch (activityIndicatorViewStyle) {
     case UIActivityIndicatorViewStyleLarge:
-		  self.controlSize = NSControlSizeLarge;
+      self.controlSize = NSControlSizeLarge;
       break;
     case UIActivityIndicatorViewStyleMedium:
       self.controlSize = NSControlSizeRegular;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
@@ -49,13 +49,13 @@ inline static NSLineBreakStrategy RCTNSLineBreakStrategyFromLineBreakStrategy(
     case facebook::react::LineBreakStrategy::PushOut:
       return NSLineBreakStrategyPushOut;
     case facebook::react::LineBreakStrategy::HangulWordPriority:
-      if (@available(iOS 14.0, macOS 11.0, *)) { // [macOS]
+      if (@available(iOS 14.0, *)) {
         return NSLineBreakStrategyHangulWordPriority;
       } else {
         return NSLineBreakStrategyNone;
       }
     case facebook::react::LineBreakStrategy::Standard:
-      if (@available(iOS 14.0, macOS 11.0, *)) { // [macOS]
+      if (@available(iOS 14.0, *)) {
         return NSLineBreakStrategyStandard;
       } else {
         return NSLineBreakStrategyNone;

--- a/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld.xcodeproj/project.pbxproj
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				INFOPLIST_FILE = "HelloWorld-macos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -374,7 +374,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = "HelloWorld-macos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
@@ -4,7 +4,7 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 prepare_react_native_project!
 
 target 'HelloWorld-macOS' do
-  platform :macos, '10.15'
+  platform :macos, '11.0'
   use_native_modules!
 
   # Flags change depending on the env values.

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -26,7 +26,7 @@ end
 
 # [macOS
 def min_macos_version_supported
-    return '10.15'
+    return '11.0'
 end
 # macOS]
 
@@ -524,7 +524,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
           'header_mappings_dir' => './',
           'platforms' => {
             :ios => '13.4',
-            'osx' => '10.15',
+            :osx => '11.0',
           },
           'source_files' => "**/*.{h,mm,cpp}",
           'pod_target_xcconfig' => {

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -42,7 +42,7 @@ module Helpers
         end
         # [macOS
         def self.min_macos_version_supported
-            return '10.15'
+            return '11.0'
         end
         # macOS]
         # [visionOS

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1416,64 +1416,64 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 0686b6af8cbd638c784fea5afb789be66699823c
   DoubleConversion: 5b92c4507c560bb62e7aa1acdf2785ea3ff08b3b
-  FBLazyVector: 62aaa61b7b69d531a3ffd60fdbad3bb0384008b1
+  FBLazyVector: 72a1af78f96be17bb7f09b9f45ed37364bff0f11
   fmt: 03574da4b7ba40de39da59677ca66610ce8c4a02
   glog: 3a72874c0322c7caf24931d3a2777cb7a3090529
-  MyNativeView: e5442ab418e407beec1e41ac9d6fbf676e29165d
-  NativeCxxModuleExample: ddf252a14ad2a48c5b546c82d56b250771f449b8
+  MyNativeView: dbeb70b5843b3eb0cc61da828f2b5ad91f256f0a
+  NativeCxxModuleExample: 04447d359be38a6e2c97563c3cf8c4506dec7d35
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
   RCT-Folly: b84ed447eb92e8adbb6101ae195ce6506481b22c
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: e849327aae4cd21bead62676b4589612c8c1958e
-  RCTTypeSafety: 7fbef1bc878c2aa2af95867c3aabacb5fd36a9ad
-  React: 1ccf276435a49f064a816ba5debcf496ad3a2143
-  React-callinvoker: cb7f02cd7cbf7f787d25f56cdebbb6292388ebff
-  React-Codegen: 956c1b0bb3de8d8663a16b4b484684ca7eaea0f1
-  React-Core: c03507ab2dfd9b7c3ce757b55e2f0050414af284
-  React-CoreModules: b76b4fb3dd522d3a98f3b248c33213075e3162c5
-  React-cxxreact: c2c393635f4bcc6d6c3bd87b532bee9dac1d50ad
-  React-debug: 39b29f0fad45920e54a96caecd330c36b899f2ed
-  React-Fabric: b132b508e092647bdbcb8ff330893f184a932abd
-  React-FabricImage: 3b1ec6f6be8b23b66398a20240e8dfa575d685d8
-  React-featureflags: ca35757ebcfdb8916c5273da6faa05a2648ab53f
-  React-graphics: d286502f8f8faaebcb50dcc26b6a1f547c97b511
-  React-ImageManager: a01b0edb8644ab8379af2e252e458064b7482012
-  React-jsc: 49683dc2f8d13a63c7ae3ceca0a5c7f5e8b4158e
-  React-jserrorhandler: 1f2571a6ab3e7d89fdd0e45437b83eb49ccc86f4
-  React-jsi: f9d8c14d006fe511af7d8e77692dfd1e156d49bc
-  React-jsiexecutor: 963edf21d57714773a0626123913c571efa049a8
-  React-jsinspector: 41f653e7ab5f4cdd89ab7bbf4221304a7f02bc89
-  React-jsitracing: 7ceb073994282bf1869677aefdf2aeaa1292f96d
-  React-logger: 1f014355650dd821879e6c8c9605670e42bb0d82
-  React-Mapbuffer: 870df4678792a8897f39f1f05f16e7705a280ec9
-  React-nativeconfig: 45737e7d0acd7b524c7c204b54c0b0cfd9a641a2
-  React-NativeModulesApple: 1b291ae265c574457d5e81a4933960ceb0711301
-  React-perflogger: b30e5b9f834231caf928254d5fb3e2ac5a23a110
-  React-RCTActionSheet: cd6934d167f4e0c6f7263386d6970f8d27ea6127
-  React-RCTAnimation: 6206907baf7092210bb99b1224549312ff85165f
-  React-RCTAppDelegate: f315dde99ccdb4bc1ad33afb11be404c49dd6870
-  React-RCTBlob: 14e49f3ae9029d8d08ed524d32b3e1093cacdfad
-  React-RCTFabric: e966c9b8206113cde98f1b7e76f2dce3b2ab4b89
-  React-RCTImage: acab25a65c58305ac07ab4126c18cb4408623f8c
-  React-RCTLinking: 5c4b48cd3f58b7fe7400fdeaccb21a446ba55671
-  React-RCTNetwork: 0a23f947331d688f260c2d4e668503e07d7f2a81
-  React-RCTPushNotification: e2aba6102b33b77d87eb4153e66d6dd880092cf3
-  React-RCTSettings: 5a489bf650385a6664ad79438a8d01ea8407fbe6
-  React-RCTTest: 4a551521303472b84e8c1039adfc117fe7c3208b
-  React-RCTText: f3fc4a0d3b46aac22e0812cf28a3f8b296b4745b
-  React-RCTVibration: 84d825d147b6d32503cb1f2b5fff2ff44c1b535b
-  React-rendererdebug: 5e44408adb547b3d64aa897b8485531f926a68d6
-  React-rncore: 5dbd45235dbca06325f1fb341667b274239037e6
-  React-RuntimeApple: a9257b6ba8a66a8ca179babf1e2525ba3a3d8052
-  React-RuntimeCore: bfe5858bfee9486caf8e99b8f641bad8af0ccdbe
-  React-runtimeexecutor: 180b804c53ae1b8d6d91438ebc3e4d744ce24c76
-  React-runtimescheduler: 24a20945ad382574e03438ffae1c54b40952d4c9
-  React-utils: 2c5bc038d20c7b8c7dd188a57cf938aa49b420e8
-  ReactCommon: 9e369ddf2218e3d7bd288273f52ee4041a999822
-  ReactCommon-Samples: 1e9b9317898692cb043c326efd5b82c911f461f6
-  ScreenshotManager: e2b9810347f641b9164aa485cb5fa7f3ab04184f
+  RCTRequired: 947bb3d95e81b7f455e7d21fadccae045ace44c8
+  RCTTypeSafety: 04522c029ca02b94b9a5ced84e481407784e2518
+  React: bcba92706da375e3bab01b8bf2cd7a03c9a6d492
+  React-callinvoker: 73a0314c6c73bea7726ad152fbb197299a672c4a
+  React-Codegen: aa91263047f0b8281c21c4274d906c19a678752a
+  React-Core: c9dd52c7a764f6517da7e70726c3d8347cf5ea36
+  React-CoreModules: 30b99c899dd437fc33717f54a315a90c7de5acef
+  React-cxxreact: 75acb705d7ee3952bf50ff162b0329145b8e6e17
+  React-debug: 8a155137cb354399dc47ea629378452ebcca30ba
+  React-Fabric: 791be1d3b4cc215da5d59880d5dd5b8ab1edd887
+  React-FabricImage: 1733ea5728180895805262a6a9692de58746cbe8
+  React-featureflags: 77e466e8a5b0bffe61ade63656e5174fbec1540b
+  React-graphics: 8aa09f819a50fc48f00e3e4bc81976c657e25390
+  React-ImageManager: 35dcabe4369af91695d35110d0d980e4405df79b
+  React-jsc: ab9e46e64ab624bc485150e2f39c694655521dd1
+  React-jserrorhandler: cbc27e35a62f79b7516fbda9d4980fb4c2669242
+  React-jsi: 60ddbec9351b82a25825f71e627c31e3cc69cd4d
+  React-jsiexecutor: fa06bd0e24a19f0db0b86f418b0df6555ff82f18
+  React-jsinspector: 73960826ed1f650623efcf8643ea48d581ed5e8a
+  React-jsitracing: 66c9255224465dcd664166f20a51949d6ea7718e
+  React-logger: c63b0786a02292dad542bde7d309dfc6f8a41a14
+  React-Mapbuffer: 180ebeae4f9ae2cfbc9335b2d0d0b832a5eaf935
+  React-nativeconfig: 86a1a372e8667f6e6848c9940e7d1b22ec115be6
+  React-NativeModulesApple: 84ad4e3758df196a50d918b50101cf547ebd3f25
+  React-perflogger: ef40dac0be11cf06fad56ca6f192afcec2894bb7
+  React-RCTActionSheet: ae42d3a41111a581d7dc24c08d0bb7c9e6d7e61f
+  React-RCTAnimation: 1ebe94c784acc8d53019a981d5a2d47fc4b380a4
+  React-RCTAppDelegate: 366f931a03a0f5060d5d6a22b90308c9f2221ac7
+  React-RCTBlob: fd9e2443247012adc3e0d92d5a05a847f5610f34
+  React-RCTFabric: af2f70bb5dc75c842463d7e8ab3d20eb408a73cd
+  React-RCTImage: 9975826df57993beb68aaff1cb952def4d0c56f6
+  React-RCTLinking: 75e8ba3211a5c8379586a950c0a3b40b1e7c96ae
+  React-RCTNetwork: 6c6af8205ceb8f77ee6c5a317e3784ecbc5d4032
+  React-RCTPushNotification: ed7858e0c76a4efd7f2c7b41f21d8b0fe4c9138b
+  React-RCTSettings: a29e54974bc625f407a8d5bf5061e91f16014cad
+  React-RCTTest: ca635c987cc5d1acbf77b27e741000fd56710c66
+  React-RCTText: ba0310f70fbf58a304e4aa7a8b2fcd1297801c76
+  React-RCTVibration: 9b603e1cc58a78f56c097780505022fbcfcf58d9
+  React-rendererdebug: d52bc944ab2861280ec6b624b53a2464826f2c1a
+  React-rncore: e1b9720d8e55726338eceaf1b997b8bad2c00363
+  React-RuntimeApple: a8bd2847c1a0f11450dc309491b444fd27ad5cf3
+  React-RuntimeCore: dcfe44e5c497bf93281654e389df7d9ab92c26bc
+  React-runtimeexecutor: 5f5916bad3c4b04f7cf9ffaf03fe3d13baed1666
+  React-runtimescheduler: 7533ee76b94b8103ee6fd37c477a333a191d2599
+  React-utils: e5643c2a170a20dcb7e55a73e675e4ba1a115fad
+  ReactCommon: 97f4037f2a764a0b81536bb1af894f3ce590cb48
+  ReactCommon-Samples: 9e9bef893d81435d19be1c20578def93eacb96c0
+  ScreenshotManager: 5d9f436f343dfab6ce7ccec6a345efd9fb8b1eb0
   SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
-  Yoga: 4b2d9dab52760b8b084fc882c7c9c3d5612ad82b
+  Yoga: 96b661fdf1db3f04bc8261808ca63f28c885562a
 
 PODFILE CHECKSUM: 8d41baa96deb5f6497f9f0824d3df78cb740d7a8
 


### PR DESCRIPTION
## Summary:

Bump the minimum macOS requirement to 11.0. This aligns closer to our internal company organization policy of only supporting N-2 releases for macOS. We are still supporting N-3 here, but I figured let's bump one version at a time.  

## Test Plan:

Ci should pass
