### PR TITLE
[react-native-macos-init] Push change files for a new version

### DIFF
--- a/change/react-native-macos-init-27af1077-e8dd-498f-9813-622bd400487c.json
+++ b/change/react-native-macos-init-27af1077-e8dd-498f-9813-622bd400487c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update for Yarn 3+",
+  "packageName": "react-native-macos-init",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Let's try to publish a new version of react-native-macos-init, to pick up https://github.com/microsoft/react-native-macos/commit/b15e16827f5cfc2afb46bfe0d6d95f77ca7f4d9e