### PR TITLE
[0.75] Publish React Native macOS 0.75.0

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -80,10 +80,10 @@ extends:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:
                    build_type: nightly
-            #  - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
-            #    - template: .ado/templates/apple-steps-publish.yml@self
-            #      parameters:
-            #        build_type: release
+             - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
+               - template: .ado/templates/apple-steps-publish.yml@self
+                 parameters:
+                   build_type: release
              - ${{ else }}:
                - task: CmdLine@2
                  displayName: Unknown branch, skipping publish

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -113,7 +113,7 @@
     "@react-native-community/cli": "14.0.0",
     "@react-native-community/cli-platform-android": "14.0.0",
     "@react-native-community/cli-platform-ios": "14.0.0",
-    "@react-native-mac/virtualized-lists": "0.74.99",
+    "@react-native-mac/virtualized-lists": "0.75.0",
     "@react-native/assets-registry": "0.75.2",
     "@react-native/codegen": "0.75.2",
     "@react-native/community-cli-plugin": "0.75.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,7 +3299,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.74.99, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.75.0, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -12736,7 +12736,7 @@ __metadata:
     "@react-native-community/cli": "npm:14.0.0"
     "@react-native-community/cli-platform-android": "npm:14.0.0"
     "@react-native-community/cli-platform-ios": "npm:14.0.0"
-    "@react-native-mac/virtualized-lists": "npm:0.74.99"
+    "@react-native-mac/virtualized-lists": "npm:0.75.0"
     "@react-native/assets-registry": "npm:0.75.2"
     "@react-native/codegen": "npm:0.75.2"
     "@react-native/community-cli-plugin": "npm:0.75.2"


### PR DESCRIPTION
## Summary:

Uncomment the bit of the publish job that will start publishing on the 0.75-stable branch

## Test Plan:

CI should pass
