### PR TITLE
[0.75] Let beachball publish run on stable branches

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -137,7 +137,6 @@ extends:
              os: linux
            timeoutInMinutes: 90 # how long to run the job before automatically cancelling
            cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-           condition: eq(variables['Build.SourceBranchName'], 'main')
            templateContext:
              outputs:
                - output: pipelineArtifact


### PR DESCRIPTION
I missed a line to remove a check to let beachball publish run on stable branches. We previously did the same change in `0.74-stable` with https://github.com/microsoft/react-native-macos/pull/2158 