### PR TITLE
fix: Port publish pipeline changes from 0.74 and 0.75 stable branches

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -138,7 +138,6 @@ extends:
              os: linux
            timeoutInMinutes: 90 # how long to run the job before automatically cancelling
            cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
-           condition: eq(variables['Build.SourceBranchName'], 'main')
            templateContext:
              outputs:
                - output: pipelineArtifact

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,5 +1,3 @@
-# It is expected that a `latestStableBranch` variable is set in the pipeline's settings:
-
 # This file defines the build steps to publish a release
 name: $(Date:yyyyMMdd).$(Rev:.r)
 
@@ -21,6 +19,9 @@ variables:
   - group: InfoSec-SecurityResults
   - name: tags
     value: production,externalfacing
+  # Remember to update this in previous stable branches when creating a new stable branch
+  - name : latestStableBranch
+    value: '0.75-stable'
 
 resources:
   repositories:

--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -29,13 +29,11 @@ steps:
     # Note, This won't do the actual `git tag` and `git push` as we're doing a dry run.
     # We do that as a separate step in `.ado/publish.yml`.
     - task: CmdLine@2
-      displayName: Prepare package for release
+      displayName: Prepare React Native macOS release
       inputs:
         script: |
-          node ./scripts/prepare-package-for-release.js -v "$RNM_PACKAGE_VERSION" --dry-run
-      env:
-        # Map the corresponding CircleCI variable since `prepare-package-for-release.js` depends on it.
-        CIRCLE_BRANCH: $(Build.SourceBranchName)
+          set -eox pipefail
+          node scripts/releases/set-rn-version.js -v $RNM_PACKAGE_VERSION --build-type "release"
 
   # Note: This won't actually publish to NPM as we've commented that bit out.
   # We do that as a separate step in `.ado/publish.yml`. 


### PR DESCRIPTION
## Summary:

We made a couple of fixes to the `0.74-stable` and `0.75-stable` branches that we should bring to our main branch, so `0.76-stable` and onwards get them. Namely:

1. Move the `latestStableBranch` variable out of the pipeline config and into YAML. Due to recent security measures, it is much harder to edit the pipeline config, so this should help maintainability. The downside is we have to remember to set this on multiple branches now every time we cut a release.
2. Use the correct script to set the React Native version across the templated files every release
3. Let the beachball publish job run on stable branches, so that virtualized-lists can publish. 

## Test Plan:

CI should pass