### PR TITLE
[0.75] Publish React Native macOS 0.75.0 (Take 2)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -19,6 +19,9 @@ variables:
   - group: InfoSec-SecurityResults
   - name: tags
     value: production,externalfacing
+  # Remember to update this in previous stable branches when creating a new stable branch
+  - name : latestStableBranch
+    value: '0.75-stable'
 
 resources:
   repositories:
@@ -80,10 +83,10 @@ extends:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:
                    build_type: nightly
-            #  - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
-            #    - template: .ado/templates/apple-steps-publish.yml@self
-            #      parameters:
-            #        build_type: release
+             - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
+               - template: .ado/templates/apple-steps-publish.yml@self
+                 parameters:
+                   build_type: release
              - ${{ else }}:
                - task: CmdLine@2
                  displayName: Unknown branch, skipping publish
@@ -96,6 +99,7 @@ extends:
          
              - bash: echo "##vso[task.setvariable variable=npmDistTag]latest"
                displayName: Set dist-tag to latest
+               condition: eq(variables['Build.SourceBranchName'], variables.latestStableBranch)
 
              - bash: echo "##vso[task.setvariable variable=npmDistTag]canary"
                displayName: Set dist-tag to canary

--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -29,13 +29,11 @@ steps:
     # Note, This won't do the actual `git tag` and `git push` as we're doing a dry run.
     # We do that as a separate step in `.ado/publish.yml`.
     - task: CmdLine@2
-      displayName: Prepare package for release
+      displayName: Prepare React Native macOS release
       inputs:
         script: |
-          node ./scripts/prepare-package-for-release.js -v "$RNM_PACKAGE_VERSION" --dry-run
-      env:
-        # Map the corresponding CircleCI variable since `prepare-package-for-release.js` depends on it.
-        CIRCLE_BRANCH: $(Build.SourceBranchName)
+          set -eox pipefail
+          node scripts/releases/set-rn-version.js -v $RNM_PACKAGE_VERSION --build-type "release"
 
   # Note: This won't actually publish to NPM as we've commented that bit out.
   # We do that as a separate step in `.ado/publish.yml`. 


### PR DESCRIPTION
## Summary:

We forgot to port some changes from https://github.com/microsoft/react-native-macos/commit/98dc782254a1a9b10b9c803e796453ed63601635 to `0.75-stable` which caused the publish pipeline to fail. Let's do that now. I also prepared #2180 to make sure the changes are in the main branch too. 

## Test Plan:

CI should pass.
