### PR TITLE
fix: `local-cli` is missing from published package

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -44,6 +44,7 @@
     "jest",
     "Libraries",
     "LICENSE",
+    "local-cli",
     "React-Core.podspec",
     "react-native.config.js",
     "React.podspec",


### PR DESCRIPTION
## Summary:

`local-cli` is missing in published packages, making `run-macos` unavailable:

```
% yarn react-native run-macos
error: unknown command 'run-macos'
(Did you mean run-ios?)
```

This needs to be cherry-picked to [0.75-stable](https://github.com/microsoft/react-native-macos/tree/0.75-stable)

## Test Plan:

n/a