### PR TITLE
[0.75] fix: local-cli is missing from published package

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -44,6 +44,7 @@
     "jest",
     "Libraries",
     "LICENSE",
+    "local-cli",
     "React-Core.podspec",
     "react-native.config.js",
     "React.podspec",


### PR DESCRIPTION
## Summary:

Cherry pick #2182 to `0.75-stable`

## Test Plan:

CI should pass. 
