### PR TITLE
fix: Properly import `npm-registry-fetch` in `react-native-macos-init`

### DIFF
--- a/change/react-native-macos-init-f8ea158b-582a-420c-8fb7-8a1f75eb2cbe.json
+++ b/change/react-native-macos-init-f8ea158b-582a-420c-8fb7-8a1f75eb2cbe.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update for Yarn 3+",
+  "comment": "fix: Properly import `npm-registry-fetch` in `react-native-macos-init`",
   "packageName": "react-native-macos-init",
   "email": "sanajmi@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -13,8 +13,7 @@ import * as validUrl from 'valid-url';
 import * as prompts from 'prompts';
 import * as findUp from 'find-up';
 import * as chalk from 'chalk';
-// @ts-ignore
-import npmFetch from 'npm-registry';
+import * as npmFetch from 'npm-registry-fetch';
 
 const npmConfReg = execSync('npm config get registry').toString().trim();
 const NPM_REGISTRY_URL = validUrl.isUri(npmConfReg)


### PR DESCRIPTION
## Summary:

Back in #1754 , we switched `react-native-macos-init` from using `npm-registry` to `npm-registry-fetch`. But we never replaced the import.. so let's fix that now. 

## Test Plan:

Tested using `yarn link` with a newly initialized project, and got it to work. 
