### PR TITLE
Sync `react-native-macos-init` vesrion with NPM registry using beachball

### DIFF
--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos-init",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CLI to add react-native-macos to an existing react-native project",
   "main": "index.js",
   "repository": "https://github.com/microsoft/react-native-macos",


### PR DESCRIPTION
## Summary:

Fix a version mismatch from a previous failed beachball publish. 
