### PR TITLE
fix: Allow viewRegistry to accept subclasses of NSView

### DIFF
--- a/packages/react-native/React/Views/RCTShadowView.h
+++ b/packages/react-native/React/Views/RCTShadowView.h
@@ -17,7 +17,7 @@
 @class RCTRootShadowView;
 @class RCTSparseArray;
 
-typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, RCTPlatformView *> *viewRegistry); // [macOS]
+typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, __kindof RCTPlatformView *> *viewRegistry); // [macOS]
 
 /**
  * ShadowView tree mirrors RCT view tree. Every node is highly stateful.

--- a/packages/react-native/React/Views/RCTViewManager.h
+++ b/packages/react-native/React/Views/RCTViewManager.h
@@ -19,7 +19,7 @@
 @class RCTSparseArray;
 @class RCTUIManager;
 
-typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPlatformView *> *viewRegistry); // [macOS]
+typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *, __kindof RCTPlatformView *> *viewRegistry); // [macOS]
 
 @interface RCTViewManager : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
## Summary:

In React Native macOS, we have two "shim" classes to help make the iOS codebase of React Native compatible with macOS
- `RCTPlatformView`:a typedef of `NSView` on macOS, and `UIView` on iOS / visionOS)
- `RCTUIView`: A subclass of `NSView` with extra methods and properties to be closer to the iOS `UIView`

Additionally, in React Native's old architecture, there is this line that we forked as follows in 0.73 and earlier versions:

React Native:

>typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *, **UIView** *> *viewRegistry);

React Native macOS:
> typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *,
**RCTUIView***> *viewRegistry); // [macOS]`

In React Native macOS 0.74+, I changed the definition as follows, thinking the widening of scope to a superclass would be a non breaking change:
> typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *,
**RCTPlatformView***> *viewRegistry); // [macOS]`


Turns out I was wrong, and this broke libraries like Reanimated and React Native Gesture Handler. The fix is simple, add a `__kindof` in front of the type!
> typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *,
**__kindof RCTPlatformView***> *viewRegistry); // [macOS]`


## Test Plan:

Tested this in my branch where I'm adding macOS support to react-native-webgpu (https://github.com/wcandillon/react-native-webgpu/pull/123), and reanimated + gesture gesture handler compile successfully. 

