### PR TITLE
[0.75] fix: Allow viewRegistry to accept subclasses of NSView

### DIFF
--- a/packages/react-native/React/Views/RCTShadowView.h
+++ b/packages/react-native/React/Views/RCTShadowView.h
@@ -17,7 +17,7 @@
 @class RCTRootShadowView;
 @class RCTSparseArray;
 
-typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, RCTPlatformView *> *viewRegistry); // [macOS]
+typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, __kindof RCTPlatformView *> *viewRegistry); // [macOS]
 
 /**
  * ShadowView tree mirrors RCT view tree. Every node is highly stateful.

--- a/packages/react-native/React/Views/RCTViewManager.h
+++ b/packages/react-native/React/Views/RCTViewManager.h
@@ -19,7 +19,7 @@
 @class RCTSparseArray;
 @class RCTUIManager;
 
-typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPlatformView *> *viewRegistry); // [macOS]
+typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *, __kindof RCTPlatformView *> *viewRegistry); // [macOS]
 
 @interface RCTViewManager : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Backport of #2196 to `0.75-stable`