### PR TITLE
fix(CI): Fix `verify react-native-macos-init` job

### DIFF
--- a/.ado/jobs/build-test-rntester.yml
+++ b/.ado/jobs/build-test-rntester.yml
@@ -103,7 +103,7 @@ jobs:
               displayName: Download visionOS SDDK
               inputs:
                 script: |
-                  set -eox
+                  set -eox pipefail
                   # https://github.com/actions/runner-images/issues/10559
                   sudo xcodebuild -runFirstLaunch
                   sudo xcrun simctl list

--- a/.ado/jobs/test-react-native-macos-init.yml
+++ b/.ado/jobs/test-react-native-macos-init.yml
@@ -17,6 +17,7 @@ jobs:
         displayName: yarn install react-native-macos-init
         inputs:
           script: |
+            set -eox pipefail
             cd packages/react-native-macos-init
             yarn install
 
@@ -24,6 +25,7 @@ jobs:
         displayName: Build react-native-macos-init
         inputs:
           script: |
+            set -eox pipefail
             cd packages/react-native-macos-init
             yarn build
 
@@ -35,12 +37,15 @@ jobs:
       - task: CmdLine@2
         displayName: yarn install (local react-native-macos)
         inputs:
-          script: yarn install --immutable
+          script:  |
+            set -eox pipefail
+            yarn install --immutable
 
       - task: CmdLine@2
         displayName: yarn install (local react-native-macos-init)
         inputs:
           script: |
+            set -eox pipefail
             cd packages/react-native-macos-init
             yarn install --immutable
 
@@ -48,29 +53,40 @@ jobs:
         displayName: yarn build (local react-native-macos-init)
         inputs:
           script: |
+            set -eox pipefail
             cd packages/react-native-macos-init
             yarn build
 
       - task: CmdLine@2
         displayName: Init new project
         inputs:
-          script: npx --yes react-native@0.71.5 init testcli --template react-native@0.71.5 --skip-install
+          script: |
+            set -eox pipefail
+            npx --yes @react-native-community/cli init testcli --version 0.75 --skip-install
           workingDirectory: $(Agent.BuildDirectory)
 
       - task: CmdLine@2
-        displayName: yarn install (local react-native-macos-init)
+        displayName: yarn install (testcli)
         inputs:
-          script: yarn install --immutable
+          script: |
+            set -eox pipefail
+            yarn install --mode=update-lockfile
+            # `update-lockfile` skips the linking step, so we need to run `yarn install` again
+            yarn install
           workingDirectory: $(Agent.BuildDirectory)/testcli
 
       - task: CmdLine@2
         displayName: Apply macos template
         inputs:
-          script: npx react-native-macos-init --version latest --overwrite --prerelease
+          script: |
+            set -eox pipefail
+            npx react-native-macos-init --version latest --overwrite --prerelease
           workingDirectory: $(Agent.BuildDirectory)/testcli
 
       - task: CmdLine@2
         displayName: Run macos [test]
         inputs:
-          script: npx react-native run-macos
+          script: |
+            set -eox pipefail
+            npx react-native run-macos
           workingDirectory: $(Agent.BuildDirectory)/testcli

--- a/.ado/jobs/test-react-native-macos-init.yml
+++ b/.ado/jobs/test-react-native-macos-init.yml
@@ -13,6 +13,20 @@ jobs:
 
       - template: /.ado/templates/apple-tools-setup.yml@self
 
+      - task: CmdLine@2
+        displayName: yarn install react-native-macos-init
+        inputs:
+          script: |
+            cd packages/react-native-macos-init
+            yarn install
+
+      - task: CmdLine@2
+        displayName: Build react-native-macos-init
+        inputs:
+          script: |
+            cd packages/react-native-macos-init
+            yarn build
+
       - template: /.ado/templates/verdaccio-init.yml@self
 
       - template: /.ado/templates/verdaccio-publish.yml@self

--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos-init",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CLI to add react-native-macos to an existing react-native project",
   "main": "index.js",
   "repository": "https://github.com/microsoft/react-native-macos",


### PR DESCRIPTION
## Summary:

Fix a couple of issues with the `verify react-native-macos-init` job:
- `react-native-macos-init` is listed as 2.1.1 in our repository, but is 2.1.2 in NPM, which caused failures
- Use RN 0.75 as the template
- Update the scripts to have `set -eox pipefail` for better debugging
- Fix an issue with `yarn install`, presumably due to updating to Yarn 3 

## Test Plan:

CI should pass
