### PR TITLE
[0.75] fix(): Remove flipper config from the Podfile template

### DIFF
--- a/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/Podfile
@@ -14,8 +14,6 @@ target 'HelloWorld-macOS' do
     :path => '../node_modules/react-native-macos',
     :hermes_enabled => false,
     :fabric_enabled => ENV['RCT_NEW_ARCH_ENABLED'] == '1',
-    # Flipper is not compatible w/ macOS
-    :flipper_configuration => FlipperConfiguration.disabled,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )


### PR DESCRIPTION
## Summary:

We've discussed this on #2195, this is for the `0.75` version

When building a new project with React Native MacOS, it would fail with this error:

```
Couldn't install Pods. Updating the Pods project and trying again...
Command `pod install` failed.
└─ Cause: Invalid `Podfile` file: uninitialized constant Pod::Podfile::FlipperConfiguration.

 #  from /Users/moru/Documents/Work/test_project/macos/Podfile:18
 #  -------------------------------------------
 #      # Flipper is not compatible w/ macOS
 >      :flipper_configuration => FlipperConfiguration.disabled,
 #      # An absolute path to your application root.
 #  -------------------------------------------
```

As, for example, here: https://github.com/microsoft/react-native-macos/issues/2164

The ongoing solution was to remove that line from the Podfile, I'm sending this PR to edit the template so that line is removed by default.

## Test Plan:

I'm probably going to need some help here, not quite sure how I can create a project against my local version of react-native-macos to test this one, but I'm sure that with this line removed (and as many other issues point) the project compiles and this error is avoided.

