### PR TITLE
fix: Properly clean up RCTDevLoadingView on hide

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -138,7 +138,7 @@ RCT_EXPORT_MODULE()
       self->_label.font = [UIFont monospacedDigitSystemFontOfSize:12.0 weight:UIFontWeightRegular];
       self->_label.textAlignment = NSTextAlignmentCenter;
 #else // [macOS
-      self->_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
+      self->_window = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
                                                  styleMask:NSWindowStyleMaskBorderless
                                                    backing:NSBackingStoreBuffered
                                                      defer:YES];
@@ -214,6 +214,8 @@ RCT_EXPORT_METHOD(hide)
         }];
 #else // [macOS]
     [RCTKeyWindow() endSheet:self->_window];
+    self->_window = nil;
+    self->_hiding = false;
 #endif // macOS]
   });
 }


### PR DESCRIPTION
## Summary:

Fixes #2183 

This PR fixes two issues with RCTDevLoadingView:

- In the macOS implementation of `RCTDevLoadingView`, we forgot to do some cleanup of instance variables on `hide`, which was causing the loading view to stick around. 

- The NSWindow that RCTDevLoadingView used would return false for `canBecomeKeyWindow`. Somewhere internal to Appkit, `makeKeyWindow` was called, would fail, and produce a warning in the Xcode console. By making the window an [NSPanel](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/WinPanel/Concepts/UsingPanels.html#//apple_ref/doc/uid/20000224) instead, we can avoid this issue.

## Test Plan:

Loaded RNTester a couple of times and didn't observe an issue with the loading view sticking around. 
