### PR TITLE
feat(RCTUIKit): Shim RCTUIGraphicsImageRenderer

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -382,25 +382,19 @@ UIImage *__nullable RCTTransformImage(UIImage *image, CGSize destSize, CGFloat d
   }
 
   BOOL opaque = !RCTUIImageHasAlpha(image); // [macOS]
-#if !TARGET_OS_OSX // [macOS]
-  UIGraphicsImageRendererFormat *const rendererFormat = [UIGraphicsImageRendererFormat defaultFormat];
+  RCTUIGraphicsImageRendererFormat *const rendererFormat = [RCTUIGraphicsImageRendererFormat defaultFormat]; // [macOS]
   rendererFormat.opaque = opaque;
   rendererFormat.scale = destScale;
-  UIGraphicsImageRenderer *const renderer = [[UIGraphicsImageRenderer alloc] initWithSize:destSize
+  RCTUIGraphicsImageRenderer *const renderer = [[RCTUIGraphicsImageRenderer alloc] initWithSize:destSize // [macOS]
                                                                                    format:rendererFormat];
-  return [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull context) {
+  return [renderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull context) { // [macOS]
     CGContextConcatCTM(context.CGContext, transform);
+#if !TARGET_OS_OSX // [macOS]
     [image drawAtPoint:CGPointZero];
-  }];
 #else // [macOS
-  UIGraphicsBeginImageContextWithOptions(destSize, opaque, destScale);
-  CGContextRef currentContext = UIGraphicsGetCurrentContext();
-  CGContextConcatCTM(currentContext, transform);
-  [image drawAtPoint:CGPointZero fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
-  UIImage *result = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-  return result;
+    [image drawAtPoint:CGPointZero fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
 #endif // macOS]
+  }];
 }
 
 BOOL RCTImageHasAlpha(CGImageRef image)

--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -269,9 +269,6 @@ extern "C" {
 
 // UIGraphics.h
 CGContextRef UIGraphicsGetCurrentContext(void);
-void UIGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale);
-NSImage *UIGraphicsGetImageFromCurrentImageContext(void);
-void UIGraphicsEndImageContext(void);
 CGImageRef UIImageGetCGImageRef(NSImage *image);
 
 #ifdef __cplusplus
@@ -640,4 +637,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UIViewContentMode contentMode;
 NS_ASSUME_NONNULL_END
 @end
+#endif
+
+#if !TARGET_OS_OSX
+typedef UIGraphicsImageRendererContext RCTUIGraphicsImageRendererContext;
+typedef UIGraphicsImageDrawingActions RCTUIGraphicsImageDrawingActions;
+typedef UIGraphicsImageRendererFormat RCTUIGraphicsImageRendererFormat;
+typedef UIGraphicsImageRenderer RCTUIGraphicsImageRenderer;
+#else
+NS_ASSUME_NONNULL_BEGIN
+typedef NSGraphicsContext RCTUIGraphicsImageRendererContext;
+typedef void (^RCTUIGraphicsImageDrawingActions)(RCTUIGraphicsImageRendererContext *rendererContext);
+
+@interface RCTUIGraphicsImageRendererFormat : NSObject
+
++ (instancetype)defaultFormat;
+
+@property (nonatomic) CGFloat scale;
+@property (nonatomic) BOOL opaque;
+
+@end
+
+@interface RCTUIGraphicsImageRenderer : NSObject
+
+- (instancetype)initWithSize:(CGSize)size format:(RCTUIGraphicsImageRendererFormat *)format;
+- (NSImage *)imageWithActions:(NS_NOESCAPE RCTUIGraphicsImageDrawingActions)actions;
+
+@end
+NS_ASSUME_NONNULL_END
 #endif

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -1006,12 +1006,8 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 @implementation RCTUIGraphicsImageRendererFormat
 
 + (nonnull instancetype)defaultFormat {
-    static dispatch_once_t token = 0;
-    static RCTUIGraphicsImageRendererFormat *_sharedObject = nil;
-    dispatch_once(&token, ^{
-        _sharedObject = [[self alloc] init];
-    });
-    return _sharedObject;
+    RCTUIGraphicsImageRendererFormat *format = [RCTUIGraphicsImageRendererFormat new];
+    return format;
 }
 
 @end
@@ -1019,11 +1015,13 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 @implementation RCTUIGraphicsImageRenderer
 {
     CGSize _size;
+    RCTUIGraphicsImageRendererFormat *_format;
 }
 
 - (nonnull instancetype)initWithSize:(CGSize)size format:(nonnull RCTUIGraphicsImageRendererFormat *)format {
     if (self = [super init]) {
         self->_size = size;
+        self->_format = format;
     }
     return self;
 }

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -1028,10 +1028,12 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 
 - (nonnull NSImage *)imageWithActions:(NS_NOESCAPE RCTUIGraphicsImageDrawingActions)actions {
 
-    NSImage *image = [[NSImage alloc] initWithSize:_size];
-    [image lockFocusFlipped:YES];
-    actions([NSGraphicsContext currentContext]);
-    [image unlockFocus];
+    NSImage *image = [NSImage imageWithSize:_size
+                                    flipped:YES
+                             drawingHandler:^BOOL(NSRect dstRect) {
+        actions([NSGraphicsContext currentContext]);
+        return YES;
+    }];
     return image;
 }
 

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -1031,7 +1031,12 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
     NSImage *image = [NSImage imageWithSize:_size
                                     flipped:YES
                              drawingHandler:^BOOL(NSRect dstRect) {
-        actions([NSGraphicsContext currentContext]);
+        
+        RCTUIGraphicsImageRendererContext *context = [NSGraphicsContext currentContext];
+        if (self->_format.opaque) {
+            CGContextSetAlpha([context CGContext], 1.0);
+        }
+        actions(context);
         return YES;
     }];
     return image;

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -228,6 +228,7 @@ static UIImage *RCTGetSolidBorderImage(
 
   RCTUIGraphicsImageRenderer *const imageRenderer =
       RCTMakeUIGraphicsImageRenderer(size, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
+      CGColorRetain(backgroundColor); // [macOS] CGColorRefs are not atuomtically retained wehn passed into a block
   UIImage *image = [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     const CGContextRef context = rendererContext.CGContext;
     const CGRect rect = {.size = size};
@@ -238,6 +239,7 @@ static UIImage *RCTGetSolidBorderImage(
       CGContextAddPath(context, path);
       CGContextFillPath(context);
     }
+   CGColorRelease(backgroundColor); // [macOS]
 
     CGContextAddPath(context, path);
     CGPathRelease(path);

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -228,7 +228,7 @@ static UIImage *RCTGetSolidBorderImage(
 
   RCTUIGraphicsImageRenderer *const imageRenderer =
       RCTMakeUIGraphicsImageRenderer(size, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
-      CGColorRetain(backgroundColor); // [macOS] CGColorRefs are not atuomtically retained wehn passed into a block
+      CGColorRetain(backgroundColor); // [macOS] CGColorRefs are not atuomtically retained when passed into a block
   UIImage *image = [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     const CGContextRef context = rendererContext.CGContext;
     const CGRect rect = {.size = size};

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -172,7 +172,7 @@ static CGPathRef RCTPathCreateOuterOutline(BOOL drawToEdge, CGRect rect, RCTCorn
 }
 
 static RCTUIGraphicsImageRenderer * // [macOS]
-RCTUIGraphicsImageRenderer2(CGSize size, CGColorRef backgroundColor, BOOL hasCornerRadii, BOOL drawToEdge)
+RCTMakeUIGraphicsImageRenderer(CGSize size, CGColorRef backgroundColor, BOOL hasCornerRadii, BOOL drawToEdge) // [macOS]
 {
   const CGFloat alpha = CGColorGetAlpha(backgroundColor);
   const BOOL opaque = (drawToEdge || !hasCornerRadii) && alpha == 1.0;
@@ -227,7 +227,7 @@ static UIImage *RCTGetSolidBorderImage(
   } // macOS]
 
   RCTUIGraphicsImageRenderer *const imageRenderer =
-      RCTUIGraphicsImageRenderer2(size, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
+      RCTMakeUIGraphicsImageRenderer(size, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
   UIImage *image = [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     const CGContextRef context = rendererContext.CGContext;
     const CGRect rect = {.size = size};
@@ -487,7 +487,7 @@ static UIImage *RCTGetDashedOrDottedBorderImage(
 
   const BOOL hasCornerRadii = RCTCornerRadiiAreAboveThreshold(cornerRadii);
   RCTUIGraphicsImageRenderer *const imageRenderer = // [macOS]
-      RCTUIGraphicsImageRenderer2(viewSize, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
+      RCTMakeUIGraphicsImageRenderer(viewSize, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
   return [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     const CGContextRef context = rendererContext.CGContext;
     const CGRect rect = {.size = viewSize};

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -171,27 +171,16 @@ static CGPathRef RCTPathCreateOuterOutline(BOOL drawToEdge, CGRect rect, RCTCorn
   return RCTPathCreateWithRoundedRect(rect, RCTGetCornerInsets(cornerRadii, UIEdgeInsetsZero), NULL);
 }
 
-#if !TARGET_OS_OSX // [macOS]
-static UIGraphicsImageRenderer *
-RCTUIGraphicsImageRenderer(CGSize size, CGColorRef backgroundColor, BOOL hasCornerRadii, BOOL drawToEdge)
+static RCTUIGraphicsImageRenderer * // [macOS]
+RCTUIGraphicsImageRenderer2(CGSize size, CGColorRef backgroundColor, BOOL hasCornerRadii, BOOL drawToEdge)
 {
   const CGFloat alpha = CGColorGetAlpha(backgroundColor);
   const BOOL opaque = (drawToEdge || !hasCornerRadii) && alpha == 1.0;
-  UIGraphicsImageRendererFormat *const rendererFormat = [UIGraphicsImageRendererFormat defaultFormat];
+  RCTUIGraphicsImageRendererFormat *const rendererFormat = [RCTUIGraphicsImageRendererFormat defaultFormat]; // [macOS]
   rendererFormat.opaque = opaque;
-  UIGraphicsImageRenderer *const renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:rendererFormat];
+  RCTUIGraphicsImageRenderer *const renderer = [[RCTUIGraphicsImageRenderer alloc] initWithSize:size format:rendererFormat]; // [macOS]
   return renderer;
 }
-#else // [macOS
-static CGContextRef
-RCTUIGraphicsBeginImageContext(CGSize size, CGColorRef backgroundColor, BOOL hasCornerRadii, BOOL drawToEdge, CGFloat scaleFactor)
-{
-  const CGFloat alpha = CGColorGetAlpha(backgroundColor);
-  const BOOL opaque = (drawToEdge || !hasCornerRadii) && alpha == 1.0;
-  UIGraphicsBeginImageContextWithOptions(size, opaque, scaleFactor);
-  return UIGraphicsGetCurrentContext();
-}
-#endif // macOS]
 
 static UIImage *RCTGetSolidBorderImage(
     RCTCornerRadii cornerRadii,
@@ -237,16 +226,10 @@ static UIImage *RCTGetSolidBorderImage(
     return nil;
   } // macOS]
 
-#if !TARGET_OS_OSX // [macOS]
-  UIGraphicsImageRenderer *const imageRenderer =
-      RCTUIGraphicsImageRenderer(size, backgroundColor, hasCornerRadii, drawToEdge);
-  UIImage *image = [imageRenderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+  RCTUIGraphicsImageRenderer *const imageRenderer =
+      RCTUIGraphicsImageRenderer2(size, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
+  UIImage *image = [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     const CGContextRef context = rendererContext.CGContext;
-#else // [macOS
-  CGContextRef context = RCTUIGraphicsBeginImageContext(size, backgroundColor, hasCornerRadii, drawToEdge, scaleFactor);
-  // Add extra braces for scope to match the indentation level of the iOS block
-  {
-#endif // macOS]
     const CGRect rect = {.size = size};
     CGPathRef path = RCTPathCreateOuterOutline(drawToEdge, rect, cornerRadii);
 
@@ -402,13 +385,7 @@ static UIImage *RCTGetSolidBorderImage(
     }
 
     CGPathRelease(insetPath);
-#if !TARGET_OS_OSX // [macOS]
   }];
-#else // [macOS
-  }
-  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-#endif // macOS]
 
   if (makeStretchable) {
 #if !TARGET_OS_OSX // [macOS]
@@ -509,16 +486,10 @@ static UIImage *RCTGetDashedOrDottedBorderImage(
   } // macOS]
 
   const BOOL hasCornerRadii = RCTCornerRadiiAreAboveThreshold(cornerRadii);
-#if !TARGET_OS_OSX // [macOS]
-  UIGraphicsImageRenderer *const imageRenderer =
-      RCTUIGraphicsImageRenderer(viewSize, backgroundColor, hasCornerRadii, drawToEdge);
-  return [imageRenderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+  RCTUIGraphicsImageRenderer *const imageRenderer = // [macOS]
+      RCTUIGraphicsImageRenderer2(viewSize, backgroundColor, hasCornerRadii, drawToEdge); // [macOS]
+  return [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     const CGContextRef context = rendererContext.CGContext;
-#else // [macOS
-  CGContextRef context = RCTUIGraphicsBeginImageContext(viewSize, backgroundColor, hasCornerRadii, drawToEdge, scaleFactor);
-  // Add extra braces for scope to match the indentation level of the iOS block
-  {
-#endif // macOS]
     const CGRect rect = {.size = viewSize};
 
     if (backgroundColor) {
@@ -549,14 +520,7 @@ static UIImage *RCTGetDashedOrDottedBorderImage(
     CGContextStrokePath(context);
 
     CGPathRelease(path);
-#if !TARGET_OS_OSX // [macOS]
   }];
-#else // [macOS
-  }
-  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-  return image;
-#endif // macOS]
 }
 
 UIImage *RCTGetBorderImage(

--- a/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Diff.m
+++ b/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Diff.m
@@ -16,20 +16,13 @@
   }
   CGSize imageSize = CGSizeMake(MAX(self.size.width, image.size.width), MAX(self.size.height, image.size.height));
 
-#if !TARGET_OS_OSX // [macOS]
-  UIGraphicsImageRendererFormat *const rendererFormat = [UIGraphicsImageRendererFormat defaultFormat];
+  RCTUIGraphicsImageRendererFormat *const rendererFormat = [RCTUIGraphicsImageRendererFormat defaultFormat]; // [macOS]
   rendererFormat.opaque = YES;
-  UIGraphicsImageRenderer *const renderer = [[UIGraphicsImageRenderer alloc] initWithSize:imageSize
-                                                                                   format:rendererFormat];
+  RCTUIGraphicsImageRenderer *const renderer = [[RCTUIGraphicsImageRenderer alloc] initWithSize:imageSize // [macOS]
+                                                                                         format:rendererFormat];
 
-  return [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+  return [renderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
 		const CGContextRef context = rendererContext.CGContext;
-#else // [macOS
-  UIGraphicsBeginImageContextWithOptions(imageSize, YES, 0.0);
-  CGContextRef context = UIGraphicsGetCurrentContext();
-  // Add extra braces for scope to match the indentation level of the iOS block
-  {
-#endif // macOS]
     [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
     CGContextSetAlpha(context, 0.5f);
     CGContextBeginTransparencyLayer(context, NULL);
@@ -38,14 +31,7 @@
     CGContextSetFillColorWithColor(context, [RCTUIColor whiteColor].CGColor);
     CGContextFillRect(context, CGRectMake(0, 0, self.size.width, self.size.height));
     CGContextEndTransparencyLayer(context);
-#if !TARGET_OS_OSX // [macOS]
   }];
-#else // [macOS
-  }
-  UIImage *returnImage = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-  return returnImage;
-#endif // macOS]
 }
 
 @end


### PR DESCRIPTION
Related upstream PRs:
- Rename the function `RCTUIGraphicsImageRenderer()` (which conflicts with my shim) upstream to `RCTMakeUIGraphicsImageRenderer()`: https://github.com/facebook/react-native/pull/46772
- Fix backgroundColor not getting retained/released: https://github.com/facebook/react-native/pull/46797

## Summary:

Back in https://github.com/facebook/react-native/commit/d70d7fd0b3984ee54622afc4692a6c945618c345 , React Native switched their usages of `UIGraphicsBeginImageContext()` / `UIGraphicsEndImageContext()` with `UIGraphicsImageRenderer`. There is no macOS equivalent to this class, so we kept maintaining larger ifdefs with our old shims for the deprecated methods. With React Native 0.76+, I'm starting to see more usage of `UIGraphicsImageRenderer` (specifically, to render web-style box shadows), so let's make a proper shim of it on macOS.

Let's create a class `RCTUIGraphicsImageRenderer` that has the same shape as the equivalent iOS code, only implementing the methods and properties we need. Functionally, the new class is doing the same thing as the old code, but in a more cross platform friendly way. There are some changes though, namely we don't flip and scale the `CGContext` to match the iOS and macOS coordinate systems. It seems calling `[image lockFocusFlipped:YES]` is sufficient.

Inspiration for this shim came from a few sources, namely https://github.com/shaps80/GraphicsRenderer .

## Test Plan:

At the current repo sync point, the main use case is in border drawing, which seems to look fine:
<img width="786" alt="Screenshot 2024-10-01 at 10 54 20 PM" src="https://github.com/user-attachments/assets/1907d578-400a-4549-a80c-18d2ae755a44">

