### PR TITLE
fix: Properly dismiss RCTDevLoadingView

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -142,10 +142,10 @@ RCT_EXPORT_MODULE()
                                                  styleMask:NSWindowStyleMaskBorderless
                                                    backing:NSBackingStoreBuffered
                                                      defer:YES];
-      self->_window.releasedWhenClosed = NO;
       self->_window.backgroundColor = [NSColor clearColor];
 
       NSTextField *label = [[NSTextField alloc] initWithFrame:self->_window.contentView.bounds];
+      label.font = [NSFont monospacedDigitSystemFontOfSize:12.0 weight:NSFontWeightRegular];
       label.alignment = NSTextAlignmentCenter;
       label.bezeled = NO;
       label.editable = NO;
@@ -169,7 +169,11 @@ RCT_EXPORT_MODULE()
     self->_label.textColor = color;
 
     self->_label.backgroundColor = backgroundColor;
-    [RCTKeyWindow() beginSheet:self->_window completionHandler:nil];
+    if (![[RCTKeyWindow() sheets] doesContain:self->_window]) {
+      [RCTKeyWindow() beginSheet:self->_window completionHandler:^(NSModalResponse returnCode) {
+        [self->_window orderOut:self];
+      }];
+    }
 #endif // macOS]
   });
 


### PR DESCRIPTION
## Summary:

This is attempt #2 to fix issues with the [refactor of RCTDevLoadingView](#2151 ) , the first being #2201 . Namely, the RCTDevLoadingView sheet doesn't always dismiss, and sticks around blocking the app. 

This PR addresses two main things:
1. React Native seems to not balance its' own calls to `[RCTDevLoadingView showMessage]` and `[RCTDevLoadingView hide]`. As a result, we might end up calling `beginSheet` more times than we call `endSheet`. My theory is we're ending up with multiple sheets/modals, which is why the sheet is sticking around. We can fix this by only calling `beginSheet` if we aren't already presented.

2. Digging around a couple of places in StackOverflow, it seems it's also important to call `[mySheetWindow orderOut:]` I the `beginSheet` completion handler to make the sheet go away. In my testing, this seems to be true. 

While we're here, let's fix a couple of nits:
1. Release the sheet window when closed. I don't think there's any benefit keeping it around, especially if we're already nilling it out in `hide`.
2. Set the font of the label to be the same as iOS.

## Test Plan:

Launching the app a bunch of times (sometimes with breakpoints set to interrupt the flow), I seem to not have the sheet stick around. Of course this is intermittent, so it's not a definitive test. 
