### PR TITLE
Multiline TextInput key handling: add check for first responder

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -587,7 +587,7 @@ static RCTUIColor *defaultPlaceholderColor(void) // [macOS]
 }
 #else // [macOS
 - (BOOL)performKeyEquivalent:(NSEvent *)event {
-  if (!self.hasMarkedText && ![self.textInputDelegate textInputShouldHandleKeyEvent:event]) {
+  if (self.window.firstResponder == self && !self.hasMarkedText && ![self.textInputDelegate textInputShouldHandleKeyEvent:event]) {
     return YES;
   }
 


### PR DESCRIPTION
## Summary:

Consider a hypothetical situation where a multiline TextInput handles (by dequeueing from the event queue) Cmd+Enter. If the focus is on another control that also handles Cmd+Enter, then hitting Cmd+Enter will *not* reach this other control -- in fact it will perform the action for the former TextInput, as if it were focused!

performKeyEquivalent is [documented](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/EventArchitecture/EventArchitecture.html#//apple_ref/doc/uid/10000060i-CH3-SW10) to be called even if a view isn't first responder (this is for example how "Enter" binds to the default button on a dialog -- the default button doesn't need to be focused to respond to Enter), but since we override performKeyEquivalent to properly support certain keyboard shortcuts (like noted in #1867), the previous assumption on the actual use of performKeyEquivalent no longer holds -- it's *only intended* for keystrokes sent in focused state, so add that check.

## Test Plan:

Manually tested affected scenario for correct behavior.
