### PR TITLE
ci: fix the `react-native-macos-init` pipeline

### DIFF
--- a/.ado/jobs/test-react-native-macos-init.yml
+++ b/.ado/jobs/test-react-native-macos-init.yml
@@ -1,6 +1,6 @@
 jobs:
   - job: CliInit
-    displayName: Verify react-native-macos-init
+    displayName: Verify react-native-macos in a new project
     pool:
       vmImage: $(VmImageApple)
     steps:
@@ -13,80 +13,59 @@ jobs:
 
       - template: /.ado/templates/apple-tools-setup.yml@self
 
-      - task: CmdLine@2
-        displayName: yarn install react-native-macos-init
-        inputs:
-          script: |
-            set -eox pipefail
-            cd packages/react-native-macos-init
-            yarn install
+      - script: |
+          set -eox pipefail
+          yarn install
+        displayName: Install npm dependencies
 
-      - task: CmdLine@2
+      - script: |
+          set -eox pipefail
+          yarn build
+        displayName: Build @react-native/community-cli-plugin
+
+      - script: |
+          set -eox pipefail
+          yarn build
+        workingDirectory: packages/react-native-macos-init
         displayName: Build react-native-macos-init
-        inputs:
-          script: |
-            set -eox pipefail
-            cd packages/react-native-macos-init
-            yarn build
 
       - template: /.ado/templates/verdaccio-init.yml@self
 
-      - template: /.ado/templates/verdaccio-publish.yml@self
+      - script: |
+          .ado/scripts/verdaccio.sh publish --branch origin/$(System.PullRequest.TargetBranch)
+        displayName: Publish react-native-macos to Verdaccio
 
-      # First do a build of the local package, since we point the cli at the local files, it needs to be pre-built
-      - task: CmdLine@2
-        displayName: yarn install (local react-native-macos)
-        inputs:
-          script:  |
-            set -eox pipefail
-            yarn install --immutable
+      - script: |
+          set -eox pipefail
+          npx --yes @react-native-community/cli init testcli --version 0.75 --skip-install
+        workingDirectory: $(Agent.BuildDirectory)
+        displayName: Initialize a new project
 
-      - task: CmdLine@2
-        displayName: yarn install (local react-native-macos-init)
-        inputs:
-          script: |
-            set -eox pipefail
-            cd packages/react-native-macos-init
-            yarn install --immutable
+      - script: |
+          set -eox pipefail
+          yarn install --mode=update-lockfile
+          # `update-lockfile` skips the linking step, so we need to run `yarn install` again
+          yarn install
+        workingDirectory: $(Agent.BuildDirectory)/testcli
+        displayName: Install npm dependencies (new project)
 
-      - task: CmdLine@2
-        displayName: yarn build (local react-native-macos-init)
-        inputs:
-          script: |
-            set -eox pipefail
-            cd packages/react-native-macos-init
-            yarn build
+      - script: |
+          set -eox pipefail
+          # We need to set the npm registry here otherwise it won't stick
+          $(Build.Repository.LocalPath)/.ado/scripts/verdaccio.sh configure
+          node $(Build.Repository.LocalPath)/packages/react-native-macos-init/bin.js --verbose --version latest --overwrite --prerelease
+          yarn why react-native-macos
+        workingDirectory: $(Agent.BuildDirectory)/testcli
+        displayName: Apply macOS template (new project)
 
-      - task: CmdLine@2
-        displayName: Init new project
-        inputs:
-          script: |
-            set -eox pipefail
-            npx --yes @react-native-community/cli init testcli --version 0.75 --skip-install
-          workingDirectory: $(Agent.BuildDirectory)
+      - script: |
+          set -eox pipefail
+          npx react-native build-macos
+        workingDirectory: $(Agent.BuildDirectory)/testcli
+        displayName: Build macOS app (new project)
 
-      - task: CmdLine@2
-        displayName: yarn install (testcli)
-        inputs:
-          script: |
-            set -eox pipefail
-            yarn install --mode=update-lockfile
-            # `update-lockfile` skips the linking step, so we need to run `yarn install` again
-            yarn install
-          workingDirectory: $(Agent.BuildDirectory)/testcli
-
-      - task: CmdLine@2
-        displayName: Apply macos template
-        inputs:
-          script: |
-            set -eox pipefail
-            npx react-native-macos-init --version latest --overwrite --prerelease
-          workingDirectory: $(Agent.BuildDirectory)/testcli
-
-      - task: CmdLine@2
-        displayName: Run macos [test]
-        inputs:
-          script: |
-            set -eox pipefail
-            npx react-native run-macos
-          workingDirectory: $(Agent.BuildDirectory)/testcli
+      - script: |
+          set -eox pipefail
+          npx react-native run-macos
+        workingDirectory: $(Agent.BuildDirectory)/testcli
+        displayName: Run macOS app (new project)

--- a/.ado/scripts/verdaccio.sh
+++ b/.ado/scripts/verdaccio.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+NPM_REGISTRY=http://localhost:4873
+
+project_root=$(cd -P "$(dirname $0)" && pwd)
+
+set -eox pipefail
+
+case ${1-} in
+  "configure")
+    yarn config set npmRegistryServer $NPM_REGISTRY
+    yarn config set unsafeHttpWhitelist --json '["localhost"]'
+    ;;
+
+  "init")
+    npm set registry $NPM_REGISTRY
+    npx verdaccio --config $project_root/.ado/verdaccio/config.yaml &
+    node $project_root/.ado/waitForVerdaccio.js
+    node $project_root/.ado/npmAddUser.js user pass mail@nomail.com $NPM_REGISTRY
+    ;;
+
+  "publish")
+    checkpoint=$(git rev-parse HEAD)
+    yarn set-version 1000.0.0-pr
+    git commit --all --message 'bump' --no-verify
+    packages=()
+    for json in $(yarn workspaces list --no-private --json); do
+      packages+=(--package $(node --print "JSON.parse('$json').name"))
+    done
+    npx beachball change --no-fetch --type patch --message 'bump for testing purposes' ${packages[@]}
+    npx beachball $* --no-push --registry $NPM_REGISTRY --yes --access public --no-generate-changelog
+    git reset --hard $checkpoint
+    ;;
+esac

--- a/.ado/templates/verdaccio-publish.yml
+++ b/.ado/templates/verdaccio-publish.yml
@@ -1,6 +1,0 @@
-# Publishes local packages to our verdaccio server.
-
-steps:
-  - script: |
-      npx beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
-    displayName: Publish react-native-macos-init to verdaccio

--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,8 @@ vendor/
 # Ccache
 .ccache
 
+# ADO
+.ado/Brewfile.lock.json
+.ado/verdaccio/htpasswd
+.ado/verdaccio/storage/.verdaccio-db.json
 # macOS]

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -290,7 +290,7 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
       const pkgmgr = isProjectUsingYarn(process.cwd())
         ? `yarn add${verbose ? '' : ' --silent'}`
         : `npm install --save${verbose ? '' : ' --silent'}`;
-      const execOptions = verbose ? {stdio: 'inherit' as 'inherit'} : {};
+      const execOptions = verbose ? {stdio: 'inherit' as const} : {};
       execSync(`${pkgmgr} "${MACOSPKG}@${version}"`, execOptions);
 
       console.log(`${pkgLatest} ${chalk.green('successfully installed!')}`);
@@ -301,10 +301,7 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
     }
 
     const generateMacOS = require(reactNativeMacOSGeneratePath());
-    generateMacOS(process.cwd(), name, {
-      overwrite,
-      verbose,
-    });
+    generateMacOS(process.cwd(), name, {overwrite, verbose});
   } catch (error) {
     printError(error.message, error);
     process.exit(EXITCODE_UNKNOWN_ERROR);

--- a/packages/react-native/local-cli/runMacOS/runMacOS.js
+++ b/packages/react-native/local-cli/runMacOS/runMacOS.js
@@ -162,7 +162,7 @@ function buildProject(sourceDir, xcodeProject, scheme, args) {
   return new Promise((resolve, reject) => {
     const xcodebuildArgs = [
       xcodeProject.isWorkspace ? '-workspace' : '-project',
-      path.join(sourceDir, xcodeProject.path, xcodeProject.name),
+      path.join(sourceDir, xcodeProject.path || '.', xcodeProject.name),
       '-configuration',
       args.mode,
       '-scheme',


### PR DESCRIPTION
## Summary:

The pipeline wasn't actually publishing anything and we've been testing against latest on npm all this time.

## Test Plan:

CI should pass.