### PR TITLE
fix(react-native): implement `build-macos` command (#2225)

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -42,7 +42,7 @@ try {
   }
 }
 
-const macosCommands = [require('./local-cli/runMacOS/runMacOS')]; // [macOS]
+const macosCommands = require('./local-cli/runMacOS/runMacOS'); // [macOS]
 const {
   bundleCommand,
   startCommand,


### PR DESCRIPTION
## Summary:

We should implement the config command (?) first so that the `.xcworkspace` path, scheme, etc. get passed to us via the CLI. But this will at least unblock users who need `build-macos`.

Cherry-picks #2225

## Test Plan:

n/a