### PR TITLE
fix(react-native): `xcodeProject.path` may not always be present

### DIFF
--- a/packages/react-native/local-cli/runMacOS/runMacOS.js
+++ b/packages/react-native/local-cli/runMacOS/runMacOS.js
@@ -162,7 +162,7 @@ function buildProject(sourceDir, xcodeProject, scheme, args) {
   return new Promise((resolve, reject) => {
     const xcodebuildArgs = [
       xcodeProject.isWorkspace ? '-workspace' : '-project',
-      path.join(sourceDir, xcodeProject.path, xcodeProject.name),
+      path.join(sourceDir, xcodeProject.path || '.', xcodeProject.name),
       '-configuration',
       args.mode,
       '-scheme',

--- a/packages/react-native/local-cli/runMacOS/runMacOS.js
+++ b/packages/react-native/local-cli/runMacOS/runMacOS.js
@@ -20,7 +20,7 @@
  *
  * @typedef {{
  *   name: string;
- *   path: string;
+ *   path?: string;
  *   isWorkspace: boolean;
  * }} XcodeProject
  *


### PR DESCRIPTION
## Summary:

`xcodeProject.path` may not always be present

## Test Plan:

n/a