### PR TITLE
chore(init): use a stricter `tsconfig.json`

### DIFF
--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -26,7 +26,6 @@
     "npm-registry-fetch": "^14.0.0",
     "prompts": "^2.3.0",
     "semver": "^7.5.2",
-    "valid-url": "^1.0.9",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -2,9 +2,13 @@
   "name": "react-native-macos-init",
   "version": "2.1.3",
   "description": "CLI to add react-native-macos to an existing react-native project",
-  "main": "index.js",
-  "repository": "https://github.com/microsoft/react-native-macos",
   "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-macos",
+    "directory": "packages/react-native-macos-init"
+  },
   "scripts": {
     "change": "beachball change",
     "check": "beachball check",
@@ -26,6 +30,7 @@
     "yargs": "^15.1.0"
   },
   "devDependencies": {
+    "@rnx-kit/tsconfig": "^2.0.0",
     "@types/chalk": "^2.2.0",
     "@types/npm-registry-fetch": "^8.0.0",
     "@types/prompts": "^2.0.3",

--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -5,15 +5,15 @@
  * @format
  */
 
-import * as yargs from 'yargs';
-import * as fs from 'fs';
-import * as semver from 'semver';
+import chalk from 'chalk';
 import {execSync} from 'child_process';
-import * as validUrl from 'valid-url';
-import * as prompts from 'prompts';
 import * as findUp from 'find-up';
-import * as chalk from 'chalk';
+import * as fs from 'fs';
 import * as npmFetch from 'npm-registry-fetch';
+import prompts from 'prompts';
+import * as semver from 'semver';
+import * as validUrl from 'valid-url';
+import * as yargs from 'yargs';
 
 const npmConfReg = execSync('npm config get registry').toString().trim();
 const NPM_REGISTRY_URL = validUrl.isUri(npmConfReg)
@@ -104,9 +104,12 @@ function getReactNativeMacOSVersion() {
   return getPackageVersion(MACOSPKG, false);
 }
 
-function errorOutOnUnsupportedVersionOfReactNative(rnVersion: string) {
-  printError(`Unsupported version of ${RNPKG}: ${chalk.cyan(rnVersion)}
-${MACOSPKG} supports ${RNPKG} versions ${chalk.cyan('>=0.60')}`);
+function errorOutOnUnsupportedVersionOfReactNative(rnVersion: string): never {
+  const version = chalk.cyan(rnVersion);
+  const supportedVersions = chalk.cyan('>=0.60');
+  printError(
+    `Unsupported version of ${RNPKG}: ${version}\n${MACOSPKG} supports ${RNPKG} versions ${supportedVersions}`,
+  );
   process.exit(EXITCODE_UNSUPPORTED_VERION_RN);
 }
 
@@ -306,7 +309,7 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
       verbose,
     });
   } catch (error) {
-    printError(error.message, error);
+    printError(`${error}`, error);
     process.exit(EXITCODE_UNKNOWN_ERROR);
   }
 })();

--- a/packages/react-native-macos-init/tsconfig.json
+++ b/packages/react-native-macos-init/tsconfig.json
@@ -1,15 +1,4 @@
 {
-    "compilerOptions": {
-      "baseUrl": ".",
-      "target": "es6",
-      "sourceMap": true,
-      "noImplicitAny": true,
-      "preserveConstEnums": true,
-      "moduleResolution": "node",
-      "noUnusedLocals": true,
-      "skipLibCheck": true,
-      "rootDirs": ["src"],
-    },
-    "include": ["src"],
-    "exclude": ["node_modules"]
-  }
+  "extends": "@rnx-kit/tsconfig/tsconfig.json",
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12931,7 +12931,6 @@ __metadata:
     prompts: "npm:^2.3.0"
     semver: "npm:^7.5.2"
     typescript: "npm:^5.6.3"
-    valid-url: "npm:^1.0.9"
     yargs: "npm:^15.1.0"
   bin:
     react-native-macos-init: ./bin.js
@@ -14896,13 +14895,6 @@ __metadata:
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
     convert-source-map: "npm:^2.0.0"
   checksum: 10c0/7acfc460731b629a0d547b231e9d510aaa826df67f4deeaeeb991b492f78faf3bb1aa4b54fa0f9b06d815bc69eb0a04a6c2180c16ba43a83cc5e5490fa160a96
-  languageName: node
-  linkType: hard
-
-"valid-url@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "valid-url@npm:1.0.9"
-  checksum: 10c0/3995e65f9942dbcb1621754c0f9790335cec61e9e9310c0a809e9ae0e2ae91bb7fc6a471fba788e979db0418d9806639f681ecebacc869bc8c3de88efa562ee6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4132,6 +4132,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rnx-kit/tsconfig@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@rnx-kit/tsconfig@npm:2.0.0"
+  checksum: 10c0/b31353cb1a3b75d4827373887806f5495eccb9e38e9edcf111a85a3e6967256e13f18a7acfbb9eabd7bfbe04b6b5e6ac3ec0a638d31b55f9231ffd3d946c735c
+  languageName: node
+  linkType: hard
+
 "@rushstack/node-core-library@npm:3.61.0":
   version: 3.61.0
   resolution: "@rushstack/node-core-library@npm:3.61.0"
@@ -12909,6 +12916,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-macos-init@workspace:packages/react-native-macos-init"
   dependencies:
+    "@rnx-kit/tsconfig": "npm:^2.0.0"
     "@types/chalk": "npm:^2.2.0"
     "@types/npm-registry-fetch": "npm:^8.0.0"
     "@types/prompts": "npm:^2.0.3"


### PR DESCRIPTION
## Summary:

Use `@rnx-kit/tsconfig` as base for TypeScript and fix build issues.

## Test Plan:

n/a