### PR TITLE
ci: temporarily disable publish pipeline on 0.76-stable

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -86,6 +86,13 @@ extends:
                  parameters:
                    build_type: nightly
              - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
+                - task: CmdLine@2
+                 displayName: "Skip 0.76-stable"
+                 inputs:
+                   script: |
+                     echo "Skipping publish for branch $(Build.SourceBranchName)"
+                     exit 1
+             - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:
                    build_type: release

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -85,7 +85,7 @@ extends:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:
                    build_type: nightly
-             - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
+             - ${{ elseif endsWith(variables['Build.SourceBranchName'], '0.76-stable') }}:
                 - task: CmdLine@2
                  displayName: "Skip 0.76-stable"
                  inputs:


### PR DESCRIPTION
## Summary:

Before we cut `0.76-stable`, let's disable publishing on that branch. 

## Test Plan:

CI should pass. 
