### PR TITLE
ci: remove special case for `0.76-stable`

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -85,13 +85,6 @@ extends:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:
                    build_type: nightly
-             - ${{ elseif endsWith(variables['Build.SourceBranchName'], '0.76-stable') }}:
-                - task: CmdLine@2
-                 displayName: "Skip 0.76-stable"
-                 inputs:
-                   script: |
-                     echo "Skipping publish for branch $(Build.SourceBranchName)"
-                     exit 1
              - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:


### PR DESCRIPTION
## Summary:

Before cutting the `0.76-stable` branch, we made sure to special case it in our publish pipeline to tempoarily disable publishing. Let's remove that special case on main.

## Test Plan:

CI should pass.