### PR TITLE
ci(0.76): prepare to publish @react-native-mac/virtualized-lists version `0.76.0`

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -55,9 +55,7 @@ extends:
          - job: RNGithubNpmJSPublish
            displayName: NPM Publish React-native-macos
            pool:
-             name: Azure Pipelines
-             vmImage: macos-13
-             os: macOS
+             vmImage: $(vmImageApple)
            variables:
              - name: BUILDSECMON_OPT_IN
                value: true

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -87,11 +87,11 @@ extends:
                    build_type: nightly
              - ${{ elseif endsWith(variables['Build.SourceBranchName'], '0.76-stable') }}:
                 - task: CmdLine@2
-                 displayName: "Skip 0.76-stable"
-                 inputs:
-                   script: |
-                     echo "Skipping publish for branch $(Build.SourceBranchName)"
-                     exit 1
+                  displayName: "Skip 0.76-stable"
+                  inputs:
+                    script: |
+                      echo "Skipping publish for branch $(Build.SourceBranchName)"
+                      exit 1
              - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:

--- a/change/@react-native-mac-virtualized-lists-ea506566-9d65-477c-a749-d3252327432b.json
+++ b/change/@react-native-mac-virtualized-lists-ea506566-9d65-477c-a749-d3252327432b.json
@@ -3,5 +3,5 @@
   "comment": "chore(0.76): Merge up to 0.76.0 (#2232)",
   "packageName": "@react-native-mac/virtualized-lists",
   "email": "sanajmi@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@react-native-mac-virtualized-lists-ea506566-9d65-477c-a749-d3252327432b.json
+++ b/change/@react-native-mac-virtualized-lists-ea506566-9d65-477c-a749-d3252327432b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore(0.76): Merge up to 0.76.0 (#2232)",
+  "packageName": "@react-native-mac/virtualized-lists",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-mac/virtualized-lists": "0.76.0",
+    "@react-native-mac/virtualized-lists": "0.75.99",
     "@react-native/assets-registry": "0.76.0",
     "@react-native/codegen": "0.76.0",
     "@react-native/community-cli-plugin": "0.76.0",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-mac/virtualized-lists",
-  "version": "0.76.0",
+  "version": "0.75.99",
   "description": "Virtualized lists for React Native macOS.",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,7 +3435,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.76.0, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.75.99, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -11941,7 +11941,7 @@ __metadata:
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "npm:0.76.0"
+    "@react-native-mac/virtualized-lists": "npm:0.75.99"
     "@react-native/assets-registry": "npm:0.76.0"
     "@react-native/codegen": "npm:0.76.0"
     "@react-native/community-cli-plugin": "npm:0.76.0"


### PR DESCRIPTION

## Summary:

Our publish pipelines are still a mess, in between [beachball](https://microsoft.github.io/beachball/), the custom scripts we inherit from React Native Core, and our own Azure Pipelines publish pipeline. This means that publishing a new minor looks like:

1. Set up  the monorepo packages we fork (only `virtualized-lists` right now) to publish a new `0.N.0` release by downgrading to `0.N-1.99` and adding a change file to publish the new minor. We did this in [0.75 as well](https://github.com/microsoft/react-native-macos/commit/d9e7ee9effbb6914ebddeb019a54c63cfb071540#diff-18bf2abf141c729ca075d35babc61e205e3c8c5d1dbb72130446cc0426e3e0ebR116).
2. Publish the new `react-native-macos` minor afterwards.

This PR does step 1, with step 2 as a followup

## Test Plan:

CI should pass
