### PR TITLE
ci(0.76): prepare to publish 0.76.0

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -55,7 +55,9 @@ extends:
          - job: RNGithubNpmJSPublish
            displayName: NPM Publish React-native-macos
            pool:
-             vmImage: $(vmImageApple)
+             name: cxeiss-ubuntu-20-04-large
+             image: cxe-ubuntu-20-04-1es-pt
+             os: linux
            variables:
              - name: BUILDSECMON_OPT_IN
                value: true

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -21,7 +21,7 @@ variables:
     value: production,externalfacing
   # Remember to update this in previous stable branches when creating a new stable branch
   - name : latestStableBranch
-    value: '0.75-stable'
+    value: '0.76-stable'
 
 resources:
   repositories:
@@ -83,13 +83,6 @@ extends:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:
                    build_type: nightly
-             - ${{ elseif endsWith(variables['Build.SourceBranchName'], '0.76-stable') }}:
-                - task: CmdLine@2
-                  displayName: "Skip 0.76-stable"
-                  inputs:
-                    script: |
-                      echo "Skipping publish for branch $(Build.SourceBranchName)"
-                      exit 1
              - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
                - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:

--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -2,8 +2,6 @@ parameters:
   build_type: ''
 
 steps:
-  - template: /.ado/templates/apple-tools-setup.yml@self
-
   - task: CmdLine@2
     displayName: yarn install (local react-native-macos)
     inputs:

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.76.0",
+  "version": "0.76.0-ready",
   "description": "React Native for macOS",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-mac/virtualized-lists": "0.75.99",
+    "@react-native-mac/virtualized-lists": "0.76.0",
     "@react-native/assets-registry": "0.76.0",
     "@react-native/codegen": "0.76.0",
     "@react-native/community-cli-plugin": "0.76.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,7 +3435,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.75.99, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.76.0, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -11941,7 +11941,7 @@ __metadata:
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "npm:0.75.99"
+    "@react-native-mac/virtualized-lists": "npm:0.76.0"
     "@react-native/assets-registry": "npm:0.76.0"
     "@react-native/codegen": "npm:0.76.0"
     "@react-native/community-cli-plugin": "npm:0.76.0"


### PR DESCRIPTION
> [!NOTE]  
> Needs #2251 to land first

## Summary:

Publish React Native macOS 0.76.0. This change uses the `-ready` prefix introduced with https://github.com/microsoft/react-native-macos/commit/a4ac549b42bd881afa4e3f1d0f5c7451876d51e7 to try and publish `0.76.0` instead of `0.76.1`

## Test Plan:

CI should pass
