### PR TITLE
ci(0.75): Set `latestStableBranch` to `0.76-stable`

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -21,7 +21,7 @@ variables:
     value: production,externalfacing
   # Remember to update this in previous stable branches when creating a new stable branch
   - name : latestStableBranch
-    value: '0.75-stable'
+    value: '0.76-stable'
 
 resources:
   repositories:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -53,7 +53,9 @@ extends:
          - job: RNGithubNpmJSPublish
            displayName: NPM Publish React-native-macos
            pool:
-             vmImage: $(vmImageApple)
+             name: cxeiss-ubuntu-20-04-large
+             image: cxe-ubuntu-20-04-1es-pt
+             os: linux
            variables:
              - name: BUILDSECMON_OPT_IN
                value: true

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -53,9 +53,7 @@ extends:
          - job: RNGithubNpmJSPublish
            displayName: NPM Publish React-native-macos
            pool:
-             name: Azure Pipelines
-             vmImage: macos-13
-             os: macOS
+             vmImage: $(vmImageApple)
            variables:
              - name: BUILDSECMON_OPT_IN
                value: true

--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -2,8 +2,6 @@ parameters:
   build_type: ''
 
 steps:
-  - template: /.ado/templates/apple-tools-setup.yml@self
-
   - task: CmdLine@2
     displayName: yarn install (local react-native-macos)
     inputs:


### PR DESCRIPTION
> [!NOTE] 
> Needs #2251 and #2252 to land first

## Summary:

Set the `latestStableBranch` variable in our CI pipeline to 0.76-stable, so that `0.75.x` releases are no longer tagged as `latest` on NPM.

## Test Plan:

CI should pass
