### PR TITLE
ci: Use the same VM image for PR and publish

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -55,9 +55,7 @@ extends:
          - job: RNGithubNpmJSPublish
            displayName: NPM Publish React-native-macos
            pool:
-             name: Azure Pipelines
-             vmImage: macos-13
-             os: macOS
+             vmImage: $(vmImageApple)
            variables:
              - name: BUILDSECMON_OPT_IN
                value: true


### PR DESCRIPTION
## Summary:

I noticed we were still using `macOS-13`, which was causing publish to fail. Let's fix that

## Test Plan:

CI should pass. 
