### PR TITLE
ci: Use Ubuntu for publish job

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -55,7 +55,9 @@ extends:
          - job: RNGithubNpmJSPublish
            displayName: NPM Publish React-native-macos
            pool:
-             vmImage: $(vmImageApple)
+             name: Azure Pipelines
+             vmImage: macos-13
+             os: macOS
            variables:
              - name: BUILDSECMON_OPT_IN
                value: true

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -55,9 +55,9 @@ extends:
          - job: RNGithubNpmJSPublish
            displayName: NPM Publish React-native-macos
            pool:
-             name: Azure Pipelines
-             vmImage: macos-latest-internal
-             os: macOS
+             name: cxeiss-ubuntu-20-04-large
+             image: cxe-ubuntu-20-04-1es-pt
+             os: linux
            variables:
              - name: BUILDSECMON_OPT_IN
                value: true
@@ -86,7 +86,7 @@ extends:
                  parameters:
                    build_type: nightly
              - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
-               - template: .ado/templates/≈l@self
+               - template: .ado/templates/apple-steps-publish.yml@self
                  parameters:
                    build_type: release
              - ${{ else }}:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -56,7 +56,7 @@ extends:
            displayName: NPM Publish React-native-macos
            pool:
              name: Azure Pipelines
-             vmImage: macos-13
+             vmImage: macos-latest-internal
              os: macOS
            variables:
              - name: BUILDSECMON_OPT_IN
@@ -86,7 +86,7 @@ extends:
                  parameters:
                    build_type: nightly
              - ${{ elseif endsWith(variables['Build.SourceBranchName'], '-stable') }}:
-               - template: .ado/templates/apple-steps-publish.yml@self
+               - template: .ado/templates/≈l@self
                  parameters:
                    build_type: release
              - ${{ else }}:

--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -2,8 +2,6 @@ parameters:
   build_type: ''
 
 steps:
-  - template: /.ado/templates/apple-tools-setup.yml@self
-
   - task: CmdLine@2
     displayName: yarn install (local react-native-macos)
     inputs:


### PR DESCRIPTION
## Summary:

#2255 removed the `os` key from the YAML, which broke our publish. Also apparently I'm not allowed to use variables. 
Since it's hard to find a suitable macOS image and I probably don't need a macOS image for what is just a JS publish.. let's switch to Ubuntu. Specifically, the same image/pool as the other publish job so we know it will work.


## Test Plan:

Ran a publish pipeline run on a clone of this branch and it ran successfully.