### PR TITLE
fix(0.76, publish): use `set-version` instead of `set-rn-version`

### DIFF
--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -31,7 +31,7 @@ steps:
       inputs:
         script: |
           set -eox pipefail
-          node scripts/releases/set-rn-version.js -v $RNM_PACKAGE_VERSION --build-type "release"
+          node scripts/releases/set-version.js -v $RNåM_PACKAGE_VERSION --build-type "release"
 
   # Note: This won't actually publish to NPM as we've commented that bit out.
   # We do that as a separate step in `.ado/publish.yml`. 


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/commit/4a6b889e9343652adebedc075c97463af0f1c1f2 moved the React Native publish scripts to call `set-version` instead of `set-rn-version`. This wasn't reflected in our publish pipeline. 

## Test Plan:

Theoretically the "NPM Publish Dry Run" job tests this, but it doesn't. So.. I'll need to look into that. 