### PR TITLE
ci(0.76): fix usage of set-version script

### DIFF
--- a/.ado/templates/apple-steps-publish.yml
+++ b/.ado/templates/apple-steps-publish.yml
@@ -24,14 +24,12 @@ steps:
           echo "##vso[task.setvariable variable=RNM_PACKAGE_VERSION]$(node .ado/get-next-semver-version.js)"
           echo "Next package version: $RNM_PACKAGE_VERSION"
 
-    # Note, This won't do the actual `git tag` and `git push` as we're doing a dry run.
-    # We do that as a separate step in `.ado/publish.yml`.
     - task: CmdLine@2
       displayName: Prepare React Native macOS release
       inputs:
         script: |
           set -eox pipefail
-          node scripts/releases/set-version.js -v $RNåM_PACKAGE_VERSION --build-type "release"
+          node scripts/releases/set-version.js $RNM_PACKAGE_VERSION
 
   # Note: This won't actually publish to NPM as we've commented that bit out.
   # We do that as a separate step in `.ado/publish.yml`. 


### PR DESCRIPTION
Backport of #2262 , along with a typo fix. 