### PR TITLE
ci: Downgrade to Xcode 15, don't run `pod install` with `react-native-macos-init`

### DIFF
--- a/.ado/jobs/test-react-native-macos-init.yml
+++ b/.ado/jobs/test-react-native-macos-init.yml
@@ -38,6 +38,7 @@ jobs:
           # We need to set the npm registry here otherwise it won't stick
           $(Build.Repository.LocalPath)/.ado/scripts/verdaccio.sh configure
           node $(Build.Repository.LocalPath)/packages/react-native-macos-init/bin.js --verbose --version latest --overwrite --prerelease
+          pod install --project-directory=macos
         workingDirectory: $(Agent.BuildDirectory)/testcli
         displayName: Apply macOS template (new project)
 

--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -1,6 +1,6 @@
 variables:
   VmImageApple: macos-latest-internal
-  xcode_friendly_name: 'Xcode 16.0'
-  xcode_version: '/Applications/Xcode_16.0.app'
-  ios_version: '18.0'
-  ios_simulator: 'iPhone 16'
+  xcode_friendly_name: 'Xcode 15.2'
+  xcode_version: '/Applications/Xcode_15.2.app'
+  ios_version: '17.2'
+  ios_simulator: 'iPhone 15'

--- a/packages/react-native/local-cli/generate-macos.js
+++ b/packages/react-native/local-cli/generate-macos.js
@@ -30,8 +30,6 @@ function generateMacOS (projectDir, name, options) {
     { overwrite: options.overwrite }
   );
 
-  installPods(options);
-
   printFinishMessage(name);
 }
 

--- a/packages/react-native/local-cli/generator-macos/index.js
+++ b/packages/react-native/local-cli/generator-macos/index.js
@@ -130,10 +130,7 @@ function printFinishMessage(newProjectName) {
   ${chalk.blue(`Run instructions for ${chalk.bold('macOS')}`)}:
     • pod install --project-directory=macos
     • npx react-native run-macos
-    ${chalk.dim('- or -')}
-    • Open ${xcworkspacePath(newProjectName)} in Xcode or run "xed -b ${macOSDir}"
     • yarn start:macos
-    • Hit the Run button
 `);
 }
 

--- a/packages/react-native/local-cli/generator-macos/index.js
+++ b/packages/react-native/local-cli/generator-macos/index.js
@@ -123,20 +123,12 @@ function installDependencies(options) {
 }
 
 /**
- * @param {{ verbose?: boolean }=} options
- */
-function installPods(options) {
-  const cwd = path.join(process.cwd(), macOSDir);
-  const quietFlag = options && options.verbose ? '' : '--quiet';
-  childProcess.execSync(`npx ${quietFlag} pod-install --non-interactive ${quietFlag}`, { stdio: 'inherit', cwd });
-}
-
-/**
  * @param {string} newProjectName
  */
 function printFinishMessage(newProjectName) {
   console.log(`
   ${chalk.blue(`Run instructions for ${chalk.bold('macOS')}`)}:
+    • pod install --project-directory=macos
     • npx react-native run-macos
     ${chalk.dim('- or -')}
     • Open ${xcworkspacePath(newProjectName)} in Xcode or run "xed -b ${macOSDir}"
@@ -148,6 +140,5 @@ function printFinishMessage(newProjectName) {
 module.exports = {
   copyProjectTemplateAndReplace,
   installDependencies,
-  installPods,
   printFinishMessage,
 };


### PR DESCRIPTION
Two changes:

### Downgrade to Xcode 15

Reverts microsoft/react-native-macos#2207

Changes in ADO's images means we don't have Xcode 16 on macOS 14, and macOS 15 isn't guaranteed to have visionOS. So we're stuck until we move to GitHub Actions or we get an Arm64 only image of macOS 15. 

### Don't run pod install with `react-native-macos-init`

This caused a failure in CI, and we probably shouldn't do this anyway.