### PR TITLE
fix(fabric): disable TextInput prop `enablesReturnKeyAutomatically`

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -51,8 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL contextMenuHidden;
 @property (nonatomic, assign, getter=isEditable) BOOL editable;
 @property (nonatomic, assign) BOOL caretHidden;
-@property (nonatomic, assign) BOOL enablesReturnKeyAutomatically;
 #if !TARGET_OS_OSX // [macOS]
+@property (nonatomic, assign) BOOL enablesReturnKeyAutomatically;
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
 #endif // [macOS]
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -183,12 +183,12 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     _backedTextInputView.editable = newTextInputProps.traits.editable;
   }
 
+#if !TARGET_OS_OSX // [macOS]
   if (newTextInputProps.traits.enablesReturnKeyAutomatically !=
       oldTextInputProps.traits.enablesReturnKeyAutomatically) {
     _backedTextInputView.enablesReturnKeyAutomatically = newTextInputProps.traits.enablesReturnKeyAutomatically;
   }
 
-#if !TARGET_OS_OSX // [macOS]
   if (newTextInputProps.traits.keyboardAppearance != oldTextInputProps.traits.keyboardAppearance) {
     _backedTextInputView.keyboardAppearance =
         RCTUIKeyboardAppearanceFromKeyboardAppearance(newTextInputProps.traits.keyboardAppearance);


### PR DESCRIPTION
## Summary:

We already have this iOS only prop disabled on macOS in Paper, let's disable it in Fabric. Otherwise the TextInput test page crashes

## Test Plan:

TextInput page no longer crashes
