### PR TITLE
fix(fabric, text input): use window to focus and blur TextInput

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -531,10 +531,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 #if !TARGET_OS_OSX // [macOS]
   [_backedTextInputView becomeFirstResponder];
 #else // [macOS
-  NSWindow *window = _backedTextInputView.window;
-  if (window) {
-    [window makeFirstResponder:_backedTextInputView];
-  }
+  NSWindow *window = [_backedTextInputView window];
+  [window makeFirstResponder:_backedTextInputView];
 #endif // macOS]
 
   const auto &props = static_cast<const TextInputProps &>(*_props);
@@ -555,12 +553,11 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 #if !TARGET_OS_OSX // [macOS]
   [_backedTextInputView resignFirstResponder];
 #else // [macOS
-  NSWindow *window = _backedTextInputView.window;
-  if (window && window.firstResponder == _backedTextInputView) {
-    // Calling makeFirstResponder with nil will call resignFirstResponder and make the window the first responder
+  NSWindow *window = [_backedTextInputView window];
+  if ([window firstResponder] == _backedTextInputView) {
     [window makeFirstResponder:nil];
   }
-#endif // macOS];
+#endif // macOS]
 }
 
 - (void)setTextAndSelection:(NSInteger)eventCount

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -552,7 +552,15 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
 - (void)blur
 {
+#if !TARGET_OS_OSX // [macOS]
   [_backedTextInputView resignFirstResponder];
+#else // [macOS
+  NSWindow *window = _backedTextInputView.window;
+  if (window && window.firstResponder == _backedTextInputView) {
+    // Calling makeFirstResponder with nil will call resignFirstResponder and make the window the first responder
+    [window makeFirstResponder:nil];
+  }
+#endif // macOS];
 }
 
 - (void)setTextAndSelection:(NSInteger)eventCount

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -528,7 +528,14 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
 - (void)focus
 {
+#if !TARGET_OS_OSX // [macOS]
   [_backedTextInputView becomeFirstResponder];
+#else // [macOS
+  NSWindow *window = _backedTextInputView.window;
+  if (window) {
+    [window makeFirstResponder:_backedTextInputView];
+  }
+#endif // macOS]
 
   const auto &props = static_cast<const TextInputProps &>(*_props);
 


### PR DESCRIPTION
## Summary:

Cherry pick a couple of changes to have TextInput call focus and blur (natively, `makeFirstResponder` and `resignFirstResponder`) through its window instance variable rather than through its' self. 

## Test Plan:

RNTester runs fine while focusing and blurring some text inputs. 
