### PR TITLE
fix(fabric, text): render Text in an NSTextView

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
@@ -56,6 +56,12 @@ using RCTTextLayoutFragmentEnumerationBlock =
                               frame:(CGRect)frame
                          usingBlock:(RCTTextLayoutFragmentEnumerationBlock)block;
 
+#if TARGET_OS_OSX // [macOS
+- (NSTextStorage *)getTextStorageForAttributedString:(facebook::react::AttributedString)attributedString
+                                 paragraphAttributes:(facebook::react::ParagraphAttributes)paragraphAttributes
+                                                size:(CGSize)size;
+#endif // macOS]
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -399,4 +399,18 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   return TextMeasurement{{size.width, size.height}, attachments};
 }
 
+#if TARGET_OS_OSX // [macOS
+- (NSTextStorage *)getTextStorageForAttributedString:(AttributedString)attributedString
+                                 paragraphAttributes:(ParagraphAttributes)paragraphAttributes
+                                                size:(CGSize)size
+{
+  NSAttributedString *nsAttributedString = [self _nsAttributedStringFromAttributedString:attributedString];
+  NSTextStorage *textStorage = [self _textStorageAndLayoutManagerWithAttributesString:nsAttributedString
+                                                                  paragraphAttributes:paragraphAttributes
+                                                                                 size:size];
+  
+  return textStorage;
+}
+#endif // macOS]
+
 @end


### PR DESCRIPTION
## Summary:

This is part of a series of PRs where we are cherry-picking fixes from https://github.com/microsoft/react-native-macos/pull/2117 to update our Fabric implementation on macOS.

Cherry pick the first couple of fixes to Text. Notable changes from the initial commits:

- Since these commits were made, React Native upstream added https://github.com/facebook/react-native/commit/f4609dbb5fd8b2db986b9341ab866d03a56c8640 which heavily refactors TextInput on iOS. Specifically, it moves Text rendering from the Paragraph component view to its' inner content view. As such, I refactor the macOS implementation in b33797f5a986e9f148829e97d47218fbf0d08707 to match iOS. 
- The macOS implementation involves direct access to `NSTextStorage` through `RCTTextLayoutManager`. However, since https://github.com/facebook/react-native/commit/840fd30194b9091576122f255276cae01bc0ebea , that method doesn't exist. So we refactored a bit to add it back. 

## Test Plan:

Launched RNTester and Text seems to render as it did on Paper. 
