### PR TITLE
refactor(transforms): simplify macOS transform logic on old and new architecture

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -309,6 +309,12 @@ static void RCTPerformMountInstructions(
     layoutMetrics.frame.size.width = componentView.layer.bounds.size.width;
     layoutMetrics.frame.size.height = componentView.layer.bounds.size.height;
     CATransform3D newTransform = RCTCATransform3DFromTransformMatrix(newViewProps.resolveTransform(layoutMetrics));
+#if TARGET_OS_OSX // [macOS]
+    if (CGPointEqualToPoint(componentView.layer.anchorPoint, CGPointZero) && !CATransform3DEqualToTransform(newTransform, CATransform3DIdentity)) {
+      CATransform3D originAdjust = CATransform3DTranslate(CATransform3DIdentity, componentView.frame.size.width / 2, componentView.frame.size.height / 2, 0);
+      newTransform = CATransform3DConcat(CATransform3DConcat(CATransform3DInvert(originAdjust), newTransform), originAdjust);
+    }
+#endif // macOS]
     if (!CATransform3DEqualToTransform(newTransform, componentView.layer.transform)) {
       componentView.layer.transform = newTransform;
     }

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -161,7 +161,6 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 /**
  * macOS Properties
  */
-@property (nonatomic, assign) CATransform3D transform3D;
 
 // `allowsVibrancy` is readonly on NSView, so let's create a new property to make it assignable
 // that we can set through JS and the getter for `allowsVibrancy` can read in RCTView.

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -179,7 +179,6 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
     _hitTestEdgeInsets = UIEdgeInsetsZero;
     _cursor = RCTCursorAuto;
 #if TARGET_OS_OSX // [macOS
-    _transform3D = CATransform3DIdentity;
     _shadowColor = nil;
     _mouseDownCanMoveWindow = YES;
 #endif // macOS]
@@ -1187,20 +1186,19 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
 #else // [macOS
   RCTUIColor *backgroundColor = _backgroundColor;
 #endif // macOS]
-
+  
 #if TARGET_OS_OSX // [macOS
-  CATransform3D transform = [self transform3D];
+  CATransform3D transform = [[self layer] transform];
   CGPoint anchorPoint = [layer anchorPoint];
   if (CGPointEqualToPoint(anchorPoint, CGPointZero) && !CATransform3DEqualToTransform(transform, CATransform3DIdentity)) {
     // https://developer.apple.com/documentation/quartzcore/calayer/1410817-anchorpoint
     // This compensates for the fact that layer.anchorPoint is {0, 0} instead of {0.5, 0.5} on macOS for some reason.
     CATransform3D originAdjust = CATransform3DTranslate(CATransform3DIdentity, self.frame.size.width / 2, self.frame.size.height / 2, 0);
     transform = CATransform3DConcat(CATransform3DConcat(CATransform3DInvert(originAdjust), transform), originAdjust);
-    // Enable edge antialiasing in perspective transforms
-    [layer setAllowsEdgeAntialiasing:!(transform.m34 == 0.0f)];
   }
   [layer setTransform:transform];
 #endif // macOS]
+
   if (useIOSBorderRendering) {
     layer.cornerRadius = cornerRadii.topLeftHorizontal;
     layer.borderColor = borderColors.left.CGColor;
@@ -1250,14 +1248,6 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
 
   [self updateClippingForLayer:layer];
 }
-
-#if TARGET_OS_OSX // [macOS
-- (void)updateReactTransformInternal:(CATransform3D)transform
-{
-  [self setTransform3D:transform];
-  [self setNeedsDisplay];
-}
-#endif // macOS]
 
 static BOOL RCTLayerHasShadow(CALayer *layer)
 {

--- a/packages/react-native/React/Views/UIView+React.h
+++ b/packages/react-native/React/Views/UIView+React.h
@@ -84,13 +84,6 @@ typedef struct {
 - (void)reactSetFrame:(CGRect)frame;
 
 
-#if TARGET_OS_OSX // [macOS
-/**
- * Used by macOS to propagate transform changes internally.
- */
-- (void)updateReactTransformInternal:(CATransform3D)transform;
-#endif // macOS]
-
 /**
  * This method finds and returns the containing view controller for the view.
  */

--- a/packages/react-native/React/Views/UIView+React.m
+++ b/packages/react-native/React/Views/UIView+React.m
@@ -306,21 +306,10 @@ static void updateTransform(RCTPlatformView *view) // [macOS]
     transform = view.reactTransform;
   }
 
-#if !TARGET_OS_OSX // [macOS]
   view.layer.transform = transform;
   // Enable edge antialiasing in rotation, skew, or perspective transforms
   view.layer.allowsEdgeAntialiasing = transform.m12 != 0.0f || transform.m21 != 0.0f || transform.m34 != 0.0f;
-#else // [macOS
-  [view updateReactTransformInternal:transform];
-#endif // macOS]
 }
-
-#if TARGET_OS_OSX // [macOS
-- (void)updateReactTransformInternal:(CATransform3D)transform
-{
-  // Do nothing, this will get overridden by RCTView and other subclasses as needed.
-}
-#endif // macOS]
 
 - (UIViewController *)reactViewController
 {


### PR DESCRIPTION
This is part of a series of PRs where we are cherry-picking fixes from https://github.com/microsoft/react-native-macos/pull/2117 to update our Fabric implementation on macOS.

## Summary:

For whatever reason, the default transform origin on iOS is the center of a view, while on macOS it is the top left corner. I think this is because `layer.anchorPoint` is getting nilled out into `{0,0}` at some point. Regardless, because of this difference, we've maintained a diff to make the React Native macOS behavior matches iOS (See #1035 ). The diff involved storing the transform in an instance variable and manually applying a new transform on top to adjust the transform origin.

As of React Native 0.73+, there is a new style prop `transformOrigin` (see https://github.com/facebook/react-native/pull/38626/ and https://github.com/facebook/react-native/pull/38559 ) that involved adding a lot of the same logic to save and adjust the transform based on the new `transformOrigin` prop. 

Now that React Native upstream has that logic for adjusting transforms, let's remove the macOS specific diffs to do the same thing and reuse the iOS code. The only macOS diff left is simply adjusting the transform origin from top left to center.

## Test Plan:

I lightly modified the TransformOrigin example in RN-Tester with a fixed border to better show the original view bounds, and then tried out different origins. `top-left`, `center`, and `top-right` work as expected. Note on the new architecture, animations don't work so I haven't been able to test it there. 

### macOS (Old architecture)
https://github.com/user-attachments/assets/3f1ad39d-2e74-4e03-bc37-44e705d1bfed


