### PR TITLE
fix(fabric, textinput): enable spelling and grammer props

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -85,6 +85,15 @@ const RCTTextInputViewConfig = {
     topContentSizeChange: {
       registrationName: 'onContentSizeChange',
     },
+    topAutoCorrectChange: {
+      registrationName: 'onAutoCorrectChange',
+    },
+    topSpellCheckChange: {
+      registrationName: 'onSpellCheckChange',
+    },
+    topGrammarCheckChange: {
+      registrationName: 'onGrammarCheckChange',
+    },
   },
   validAttributes: {
     fontSize: true,

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -63,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_OSX // [macOS
 @property (nonatomic, assign) CGFloat pointScaleFactor;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
+@property (nonatomic, getter=isGrammarCheckingEnabled) BOOL grammarCheckingEnabled;
 @property (nonatomic, getter=isContinuousSpellCheckingEnabled) BOOL continuousSpellCheckingEnabled;
 #endif // macOS]
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) UIEdgeInsets contentInset;
 #if TARGET_OS_OSX // [macOS
 @property (nonatomic, assign) CGFloat pointScaleFactor;
+@property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
 #endif // macOS]
 
 // This protocol disallows direct access to `selectedTextRange` property because

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -63,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_OSX // [macOS
 @property (nonatomic, assign) CGFloat pointScaleFactor;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;
+@property (nonatomic, getter=isContinuousSpellCheckingEnabled) BOOL continuousSpellCheckingEnabled;
 #endif // macOS]
 
 // This protocol disallows direct access to `selectedTextRange` property because

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -67,9 +67,9 @@ RCT_EXPORT_VIEW_PROPERTY(textContentType, NSString)
 RCT_EXPORT_VIEW_PROPERTY(passwordRules, NSString)
 
 #if TARGET_OS_OSX // [macOS
-RCT_EXPORT_VIEW_PROPERTY(onAutoCorrectChange, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onSpellCheckChange, RCTBubblingEventBlock);
-RCT_EXPORT_VIEW_PROPERTY(onGrammarCheckChange, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onAutoCorrectChange, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onSpellCheckChange, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onGrammarCheckChange, RCTDirectEventBlock);
 
 RCT_EXPORT_VIEW_PROPERTY(onPaste, RCTDirectEventBlock)
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -168,13 +168,20 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     _backedTextInputView.autocapitalizationType =
         RCTUITextAutocapitalizationTypeFromAutocapitalizationType(newTextInputProps.traits.autocapitalizationType);
   }
+#endif // [macOS]
 
+#if !TARGET_OS_OSX // [macOS]
   if (newTextInputProps.traits.autoCorrect != oldTextInputProps.traits.autoCorrect) {
     _backedTextInputView.autocorrectionType =
         RCTUITextAutocorrectionTypeFromOptionalBool(newTextInputProps.traits.autoCorrect);
   }
-#endif // [macOS]
-
+#else // [macOS
+  if (newTextInputProps.traits.autoCorrect != oldTextInputProps.traits.autoCorrect && newTextInputProps.traits.autoCorrect.has_value()) {
+    _backedTextInputView.automaticSpellingCorrectionEnabled =
+        newTextInputProps.traits.autoCorrect.value();
+  }
+#endif // macOS]
+  
   if (newTextInputProps.traits.contextMenuHidden != oldTextInputProps.traits.contextMenuHidden) {
     _backedTextInputView.contextMenuHidden = newTextInputProps.traits.contextMenuHidden;
   }
@@ -463,7 +470,11 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 }
 
 #if TARGET_OS_OSX // [macOS
-- (void)automaticSpellingCorrectionDidChange:(BOOL)enabled {}
+- (void)automaticSpellingCorrectionDidChange:(BOOL)enabled {
+  if (_eventEmitter) {
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onAutoCorrectChange({.enabled =  enabled});
+  }
+}
 
 
 - (void)continuousSpellCheckingDidChange:(BOOL)enabled {}

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -486,21 +486,21 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 #if TARGET_OS_OSX // [macOS
 - (void)automaticSpellingCorrectionDidChange:(BOOL)enabled {
   if (_eventEmitter) {
-    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onAutoCorrectChange({.enabled = static_cast<bool>(enabled)});
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onAutoCorrectChange({.autoCorrectEnabled = static_cast<bool>(enabled)});
   }
 }
 
 - (void)continuousSpellCheckingDidChange:(BOOL)enabled
 {
   if (_eventEmitter) {
-    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onSpellCheckChange({.enabled = static_cast<bool>(enabled)});
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onSpellCheckChange({.spellCheckEnabled = static_cast<bool>(enabled)});
   }
 }
 
 - (void)grammarCheckingDidChange:(BOOL)enabled 
 {
   if (_eventEmitter) {
-    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onGrammarCheckChange({.enabled = static_cast<bool>(enabled)});
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onGrammarCheckChange({.grammarCheckEnabled = static_cast<bool>(enabled)});
   }
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -486,21 +486,21 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 #if TARGET_OS_OSX // [macOS
 - (void)automaticSpellingCorrectionDidChange:(BOOL)enabled {
   if (_eventEmitter) {
-    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onAutoCorrectChange({.enabled =  enabled});
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onAutoCorrectChange({.enabled = static_cast<bool>(enabled)});
   }
 }
 
 - (void)continuousSpellCheckingDidChange:(BOOL)enabled
 {
   if (_eventEmitter) {
-    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onSpellCheckChange({.enabled =  enabled});
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onSpellCheckChange({.enabled = static_cast<bool>(enabled)});
   }
 }
 
 - (void)grammarCheckingDidChange:(BOOL)enabled 
 {
   if (_eventEmitter) {
-    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onGrammarCheckChange({.enabled =  enabled});
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onGrammarCheckChange({.enabled = static_cast<bool>(enabled)});
   }
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -213,6 +213,13 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
         newTextInputProps.traits.spellCheck.value();
   }
 #endif // macOS]
+  
+#if TARGET_OS_OSX // [macOS
+  if (newTextInputProps.traits.grammarCheck != oldTextInputProps.traits.grammarCheck && newTextInputProps.traits.grammarCheck.has_value()) {
+    _backedTextInputView.grammarCheckingEnabled =
+        newTextInputProps.traits.grammarCheck.value();
+  }
+#endif // macOS]
 
   if (newTextInputProps.traits.caretHidden != oldTextInputProps.traits.caretHidden) {
     _backedTextInputView.caretHidden = newTextInputProps.traits.caretHidden;
@@ -490,8 +497,12 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   }
 }
 
-- (void)grammarCheckingDidChange:(BOOL)enabled {}
-
+- (void)grammarCheckingDidChange:(BOOL)enabled 
+{
+  if (_eventEmitter) {
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onGrammarCheckChange({.enabled =  enabled});
+  }
+}
 
 - (BOOL)hasValidKeyDownOrValidKeyUp:(nonnull NSString *)key {
   return YES;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -200,12 +200,19 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     _backedTextInputView.keyboardAppearance =
         RCTUIKeyboardAppearanceFromKeyboardAppearance(newTextInputProps.traits.keyboardAppearance);
   }
-
+#endif // [macOS]
+  
+#if !TARGET_OS_OSX // [macOS]
   if (newTextInputProps.traits.spellCheck != oldTextInputProps.traits.spellCheck) {
     _backedTextInputView.spellCheckingType =
         RCTUITextSpellCheckingTypeFromOptionalBool(newTextInputProps.traits.spellCheck);
   }
-#endif // [macOS]
+#else // [macOS
+  if (newTextInputProps.traits.spellCheck != oldTextInputProps.traits.spellCheck && newTextInputProps.traits.spellCheck.has_value()) {
+    _backedTextInputView.continuousSpellCheckingEnabled =
+        newTextInputProps.traits.spellCheck.value();
+  }
+#endif // macOS]
 
   if (newTextInputProps.traits.caretHidden != oldTextInputProps.traits.caretHidden) {
     _backedTextInputView.caretHidden = newTextInputProps.traits.caretHidden;
@@ -476,9 +483,12 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   }
 }
 
-
-- (void)continuousSpellCheckingDidChange:(BOOL)enabled {}
-
+- (void)continuousSpellCheckingDidChange:(BOOL)enabled
+{
+  if (_eventEmitter) {
+    std::static_pointer_cast<TextInputEventEmitter const>(_eventEmitter)->onSpellCheckChange({.enabled =  enabled});
+  }
+}
 
 - (void)grammarCheckingDidChange:(BOOL)enabled {}
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
@@ -35,7 +35,9 @@ UITextAutocapitalizationType RCTUITextAutocapitalizationTypeFromAutocapitalizati
 
 UIKeyboardAppearance RCTUIKeyboardAppearanceFromKeyboardAppearance(
     facebook::react::KeyboardAppearance keyboardAppearance);
+#endif // [macOS]
 
+#if !TARGET_OS_OSX // [macOS]
 UITextSpellCheckingType RCTUITextSpellCheckingTypeFromOptionalBool(std::optional<bool> spellCheck);
 
 UITextFieldViewMode RCTUITextFieldViewModeFromTextInputAccessoryVisibilityMode(

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -98,7 +98,9 @@ UIKeyboardAppearance RCTUIKeyboardAppearanceFromKeyboardAppearance(KeyboardAppea
       return UIKeyboardAppearanceDark;
   }
 }
+#endif // [macOS]
 
+#if !TARGET_OS_OSX // [macOS]
 UITextSpellCheckingType RCTUITextSpellCheckingTypeFromOptionalBool(std::optional<bool> spellCheck)
 {
   return spellCheck.has_value() ? (*spellCheck ? UITextSpellCheckingTypeYes : UITextSpellCheckingTypeNo)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -204,6 +204,14 @@ void TextInputEventEmitter::onSpellCheckChange(OnSpellCheckChange event) const {
     return payload;
   });
 }
+
+void TextInputEventEmitter::onGrammarCheckChange(OnGrammarCheckChange event) const {
+  dispatchEvent("grammarCheckChange", [event=std::move(event)](jsi::Runtime &runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "enabled", event.enabled);
+    return payload;
+  });
+}
 #endif // macOS]
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -196,6 +196,14 @@ void TextInputEventEmitter::onAutoCorrectChange(OnAutoCorrectChange event) const
     return payload;
   });
 }
+
+void TextInputEventEmitter::onSpellCheckChange(OnSpellCheckChange event) const {
+  dispatchEvent("spellCheckChange", [event=std::move(event)](jsi::Runtime &runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "enabled", event.enabled);
+    return payload;
+  });
+}
 #endif // macOS]
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -172,6 +172,35 @@ void TextInputEventEmitter::onScroll(const Metrics& textInputMetrics) const {
   });
 }
 
+#if TARGET_OS_OSX // [macOS
+void TextInputEventEmitter::onAutoCorrectChange(
+    const Metrics& textInputMetrics) const {
+  dispatchEvent("autoCorrectChange", [textInputMetrics](jsi::Runtime& runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "enabled", textInputMetrics.autoCorrectEnabled);
+    return payload;
+  });
+}
+
+void TextInputEventEmitter::onSpellCheckChange(
+    const Metrics& textInputMetrics) const {
+  dispatchEvent("spellCheckChange", [textInputMetrics](jsi::Runtime& runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "enabled", textInputMetrics.spellCheckEnabled);
+    return payload;
+  });
+}
+
+void TextInputEventEmitter::onGrammarCheckChange(
+    const Metrics& textInputMetrics) const {
+  dispatchEvent("grammarCheckChange", [textInputMetrics](jsi::Runtime& runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "enabled", textInputMetrics.grammarCheckEnabled);
+    return payload;
+  });
+}
+#endif // macOS]
+
 void TextInputEventEmitter::dispatchTextInputEvent(
     const std::string& name,
     const Metrics& textInputMetrics) const {
@@ -187,31 +216,5 @@ void TextInputEventEmitter::dispatchTextInputContentSizeChangeEvent(
     return textInputMetricsContentSizePayload(runtime, textInputMetrics);
   });
 }
-
-#if TARGET_OS_OSX // [macOS
-void TextInputEventEmitter::onAutoCorrectChange(OnAutoCorrectChange event) const {
-  dispatchEvent("autoCorrectChange", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, "enabled", event.enabled);
-    return payload;
-  });
-}
-
-void TextInputEventEmitter::onSpellCheckChange(OnSpellCheckChange event) const {
-  dispatchEvent("spellCheckChange", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, "enabled", event.enabled);
-    return payload;
-  });
-}
-
-void TextInputEventEmitter::onGrammarCheckChange(OnGrammarCheckChange event) const {
-  dispatchEvent("grammarCheckChange", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, "enabled", event.enabled);
-    return payload;
-  });
-}
-#endif // macOS]
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -188,4 +188,14 @@ void TextInputEventEmitter::dispatchTextInputContentSizeChangeEvent(
   });
 }
 
+#if TARGET_OS_OSX // [macOS
+void TextInputEventEmitter::onAutoCorrectChange(OnAutoCorrectChange event) const {
+  dispatchEvent("autoCorrectChange", [event=std::move(event)](jsi::Runtime &runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "enabled", event.enabled);
+    return payload;
+  });
+}
+#endif // macOS]
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -49,6 +49,11 @@ class TextInputEventEmitter : public ViewEventEmitter {
       bool enabled;
     };
   void onAutoCorrectChange(OnAutoCorrectChange value) const;
+
+  struct OnSpellCheckChange {
+      bool enabled;
+    };
+  void onSpellCheckChange(OnSpellCheckChange value) const;
 #endif // macOS]
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -54,6 +54,11 @@ class TextInputEventEmitter : public ViewEventEmitter {
       bool enabled;
     };
   void onSpellCheckChange(OnSpellCheckChange value) const;
+
+  struct OnGrammarCheckChange {
+      bool enabled;
+    };
+  void onGrammarCheckChange(OnGrammarCheckChange value) const;
 #endif // macOS]
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -27,6 +27,11 @@ class TextInputEventEmitter : public ViewEventEmitter {
     int eventCount;
     Size layoutMeasurement;
     Float zoomScale;
+ #if TARGET_OS_OSX // [macOS
+    bool autoCorrectEnabled;
+    bool spellCheckEnabled;
+    bool grammarCheckEnabled;
+#endif // macOS]   
   };
 
   struct KeyPressMetrics {
@@ -43,23 +48,11 @@ class TextInputEventEmitter : public ViewEventEmitter {
   void onSubmitEditing(const Metrics& textInputMetrics) const;
   void onKeyPress(const KeyPressMetrics& keyPressMetrics) const;
   void onScroll(const Metrics& textInputMetrics) const;
-
-#if TARGET_OS_OSX // [macOS
-  struct OnAutoCorrectChange {
-      bool enabled;
-    };
-  void onAutoCorrectChange(OnAutoCorrectChange value) const;
-
-  struct OnSpellCheckChange {
-      bool enabled;
-    };
-  void onSpellCheckChange(OnSpellCheckChange value) const;
-
-  struct OnGrammarCheckChange {
-      bool enabled;
-    };
-  void onGrammarCheckChange(OnGrammarCheckChange value) const;
-#endif // macOS]
+ #if TARGET_OS_OSX // [macOS
+  void onAutoCorrectChange(const Metrics& textInputMetrics) const;
+  void onSpellCheckChange(const Metrics& textInputMetrics) const;
+  void onGrammarCheckChange(const Metrics& textInputMetrics) const;
+ #endif // macOS]
 
  private:
   void dispatchTextInputEvent(

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -44,6 +44,13 @@ class TextInputEventEmitter : public ViewEventEmitter {
   void onKeyPress(const KeyPressMetrics& keyPressMetrics) const;
   void onScroll(const Metrics& textInputMetrics) const;
 
+#if TARGET_OS_OSX // [macOS
+  struct OnAutoCorrectChange {
+      bool enabled;
+    };
+  void onAutoCorrectChange(OnAutoCorrectChange value) const;
+#endif // macOS]
+
  private:
   void dispatchTextInputEvent(
       const std::string& name,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -231,6 +231,15 @@ class TextInputTraits final {
    * Default value: `empty` (`null`).
    */
   std::optional<bool> smartInsertDelete{};
+
+#ifdef TARGET_OS_OSX // [macOS
+  /*
+   * Can be empty (`null` in JavaScript) which means `default`.
+   * maOS
+   * Default value: `empty` (`null`).
+   */
+  std::optional<bool> grammarCheck{};
+#endif // macOS]
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
@@ -148,6 +148,15 @@ static TextInputTraits convertRawProp(
       sourceTraits.smartInsertDelete,
       defaultTraits.smartInsertDelete);
 
+#ifdef TARGET_OS_OSX // [macOS
+  traits.grammarCheck = convertRawProp(
+      context,
+      rawProps,
+      "grammarCheck",
+      sourceTraits.grammarCheck,
+      defaultTraits.grammarCheck);
+#endif // macOS]
+
   return traits;
 }
 


### PR DESCRIPTION
This is part of a series of PRs where we are cherry-picking fixes from https://github.com/microsoft/react-native-macos/pull/2117 to update our Fabric implementation on macOS.

## Summary:

React Native macOS on the old architecture has some macOS specific props for toggling some of the built-in autocorrect / spell check / grammer check in text inputs. This change cherry-picks the changes to bring them to the new architecture.  

I needed to make a couple of followup changes:
- I needed to add the emitted events to the static view config. I think this is because when the commits were made, static view config validation wasn't enabled in React Native yet. 
-I changed the paper event types to direct events. These feel like they should be direct events, and now they are for both paper and fabric

## Test Plan:

Testing... 
