### PR TITLE
fix(fabric): Add conditional coordinate space conversion for native view hit testing

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -660,16 +660,17 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   }
 
   for (RCTUIView *subview in [self.subviews reverseObjectEnumerator]) { // [macOS]
-    // Native macOS views require the point to be in the super view coordinate space for hit testing. [macOS]
+#if !TARGET_OS_OSX // [macOS]
+    RCTUIView *hitView = [subview hitTest:[subview convertPoint:point fromView:self] withEvent:event]; // [macOS]
+#else // [macOS
+    // Native macOS views require the point to be in the super view coordinate space for hit testing.
     CGPoint hitTestPoint = point;
-#if TARGET_OS_OSX // [macOS
     // Fabric components use the target view coordinate space for hit testing
     if ([subview isKindOfClass:[RCTViewComponentView class]]) {
       hitTestPoint = [subview convertPoint:point fromView:self];
     }
-#endif // macOS]
-    
     RCTUIView *hitView = [subview hitTest:hitTestPoint withEvent:event]; // [macOS]
+#endif // macOS]
     if (hitView) {
       return hitView;
     }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -18,7 +18,6 @@
 #import <React/RCTCursor.h> // [macOS]
 #import <React/RCTLocalizedString.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
-#import <React/RCTView.h> // [macOS]
 #import <react/renderer/components/view/ViewComponentDescriptor.h>
 #import <react/renderer/components/view/ViewEventEmitter.h>
 #import <react/renderer/components/view/ViewProps.h>
@@ -664,8 +663,8 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
     // Native macOS views require the point to be in the super view coordinate space for hit testing. [macOS]
     CGPoint hitTestPoint = point;
 #if TARGET_OS_OSX // [macOS
-    // Paper and Fabric components use the target view coordinate space for hit testing
-    if ([subview isKindOfClass:[RCTView class]] || [subview isKindOfClass:[RCTViewComponentView class]]) {
+    // Fabric components use the target view coordinate space for hit testing
+    if ([subview isKindOfClass:[RCTViewComponentView class]]) {
       hitTestPoint = [subview convertPoint:point fromView:self];
     }
 #endif // macOS]

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -18,6 +18,7 @@
 #import <React/RCTCursor.h> // [macOS]
 #import <React/RCTLocalizedString.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
+#import <React/RCTView.h> // [macOS]
 #import <react/renderer/components/view/ViewComponentDescriptor.h>
 #import <react/renderer/components/view/ViewEventEmitter.h>
 #import <react/renderer/components/view/ViewProps.h>
@@ -660,7 +661,16 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   }
 
   for (RCTUIView *subview in [self.subviews reverseObjectEnumerator]) { // [macOS]
-    RCTUIView *hitView = [subview hitTest:[subview convertPoint:point fromView:self] withEvent:event]; // [macOS]
+    // Native macOS views require the point to be in the super view coordinate space for hit testing. [macOS]
+    CGPoint hitTestPoint = point;
+#if TARGET_OS_OSX // [macOS
+    // Paper and Fabric components use the target view coordinate space for hit testing
+    if ([subview isKindOfClass:[RCTView class]] || [subview isKindOfClass:[RCTViewComponentView class]]) {
+      hitTestPoint = [subview convertPoint:point fromView:self];
+    }
+#endif // macOS]
+    
+    RCTUIView *hitView = [subview hitTest:hitTestPoint withEvent:event]; // [macOS]
     if (hitView) {
       return hitView;
     }


### PR DESCRIPTION
This is part of a series of PRs where we are cherry-picking fixes from https://github.com/microsoft/react-native-macos/pull/2117 to update our Fabric implementation on macOS.

## Summary:

Unlike UIKit,  AppKit hit testing requires the point to be in the superview coordinate system. As such, we have to override hit testing in React Native macOS to match the assumed iOS semantics. 

Followup change I made to the original commit: I removed the `RCTView` import/check for hit testing in `RCTViewComponentView` because I don't think we'll ever be moving paper and fabric views like that. 

## Test Plan:

CI should pass, maybe also try picking 71fae19c0b and see if selection works now
