### PR TITLE
ci: upgrade to Xcode 16

### DIFF
--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -1,6 +1,6 @@
 variables:
   VmImageApple: macos-latest-internal
-  xcode_friendly_name: 'Xcode 15.2'
-  xcode_version: '/Applications/Xcode_15.2.app'
-  ios_version: '17.2'
-  ios_simulator: 'iPhone 15'
+  xcode_friendly_name: 'Xcode 16.0'
+  xcode_version: '/Applications/Xcode_16.0.app'
+  ios_version: '18.0'
+  ios_simulator: 'iPhone 16'


### PR DESCRIPTION
## Summary:

Update back to Xcode 16 after we had to back it out with https://github.com/microsoft/react-native-macos/pull/2271

## Test Plan:

CI should pass