### PR TITLE
ci: Disable Xcode tests

### DIFF
--- a/.ado/jobs/build-test-rntester.yml
+++ b/.ado/jobs/build-test-rntester.yml
@@ -129,7 +129,9 @@ jobs:
             CCACHE_DISABLE: 1
           displayName: Build ${{ slice.scheme }}
 
-        # Skip testing on visionOS via the conditions below
+
+        # https://github.com/microsoft/react-native-macos/issues/2297
+        # Skip native tests as they tend to be flaky
 
         - ${{ if ne(slice.scheme, 'RNTester-visionOS') }}:
           - task: ShellScript@2

--- a/.ado/jobs/build-test-rntester.yml
+++ b/.ado/jobs/build-test-rntester.yml
@@ -133,35 +133,35 @@ jobs:
         # https://github.com/microsoft/react-native-macos/issues/2297
         # Skip native tests as they tend to be flaky
 
-        - ${{ if ne(slice.scheme, 'RNTester-visionOS') }}:
-          - task: ShellScript@2
-            displayName: Setup packager and WebSocket test server
-            inputs:
-              scriptPath: .ado/scripts/ado-test-setup.sh
-              disableAutoCwd: true
-              cwd: ''
+        # - ${{ if ne(slice.scheme, 'RNTester-visionOS') }}:
+        #  - task: ShellScript@2
+        #    displayName: Setup packager and WebSocket test server
+        #    inputs:
+        #      scriptPath: .ado/scripts/ado-test-setup.sh
+        #      disableAutoCwd: true
+        #      cwd: ''
 
-          - script: |
-              echo Preparing the packager for platform $PLATFORM
-              curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/packages/rn-tester/js/RNTesterApp.${PLATFORM}.bundle?platform=${PLATFORM}&dev=true" -o /dev/null
-              curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/packages/rn-tester/js/RNTesterApp.${PLATFORM}.bundle?platform=${PLATFORM}&dev=true&minify=false" -o /dev/null
-              curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=${PLATFORM}&dev=true" -o /dev/null
-              curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/IntegrationTests/RCTRootViewIntegrationTestApp.bundle?platform=${PLATFORM}&dev=true" -o /dev/null
-            env:
-              PLATFORM: ${{ slice.packager_platform }}
-            displayName: Fetch JS bundles from dev server
+        #  - script: |
+        #      echo Preparing the packager for platform $PLATFORM
+        #      curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/packages/rn-tester/js/RNTesterApp.${PLATFORM}.bundle?platform=${PLATFORM}&dev=true" -o /dev/null
+        #      curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/packages/rn-tester/js/RNTesterApp.${PLATFORM}.bundle?platform=${PLATFORM}&dev=true&minify=false" -o /dev/null
+        #      curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=${PLATFORM}&dev=true" -o /dev/null
+        #      curl --retry-connrefused --connect-timeout 5 --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 120 "http://localhost:8081/IntegrationTests/RCTRootViewIntegrationTestApp.bundle?platform=${PLATFORM}&dev=true" -o /dev/null
+        #    env:
+        #      PLATFORM: ${{ slice.packager_platform }}
+        #    displayName: Fetch JS bundles from dev server
 
-          - script: |
-              set -eox pipefail
-              .ado/scripts/xcodebuild.sh packages/rn-tester/RNTesterPods.xcworkspace ${{ slice.sdk }} ${{ slice.scheme }} test
-            env:
-              CCACHE_DISABLE: 1
-            displayName: Test ${{ slice.scheme }}
+        #  - script: |
+        #      set -eox pipefail
+        #      .ado/scripts/xcodebuild.sh packages/rn-tester/RNTesterPods.xcworkspace ${{ slice.sdk }} ${{ slice.scheme }} test
+        #    env:
+        #      CCACHE_DISABLE: 1
+        #    displayName: Test ${{ slice.scheme }}
 
-          - task: ShellScript@2
-            displayName: Cleanup packager and WebSocket test server
-            inputs:
-              scriptPath: .ado/scripts/ado-test-cleanup.sh
-              disableAutoCwd: true
-              cwd: ''
-            condition: always()
+        #  - task: ShellScript@2
+        #    displayName: Cleanup packager and WebSocket test server
+        #    inputs:
+        #      scriptPath: .ado/scripts/ado-test-cleanup.sh
+        #      disableAutoCwd: true
+        #      cwd: ''
+        #    condition: always()


### PR DESCRIPTION
## Summary:

These test tend to be flaky, giving a false negative for many PRs. They tend to be disabled upstream as well. Let's disable them here in our CI while we are mass merging Fabric commits

## Test Plan:

CI should pass
