### PR TITLE
ci(0.76): check publish_react_native_macos with a runtime condition

### DIFF
--- a/.ado/templates/npm-publish.yml
+++ b/.ado/templates/npm-publish.yml
@@ -14,7 +14,7 @@ steps:
   - script: |
       yarn nx release --dry-run
     displayName: Version and publish packages (dry run)
-    condition: ${{ ne(variables['publish_react_native_macos'], '1') }}
+    condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 
   - script: |
       yarn nx release --yes
@@ -22,4 +22,4 @@ steps:
       GITHUB_TOKEN: $(githubAuthToken)
       NODE_AUTH_TOKEN: $(npmAuthToken)
     displayName: Version and publish packages
-    condition: ${{ eq(variables['publish_react_native_macos'], '1') }}
+    condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))

--- a/.ado/templates/npm-publish.yml
+++ b/.ado/templates/npm-publish.yml
@@ -12,12 +12,12 @@ steps:
     displayName: Verify release config
 
   - script: |
-      yarn nx release --dry-run
+      yarn nx release --dry-run --verbose
     displayName: Version and publish packages (dry run)
     condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 
   - script: |
-      yarn nx release --yes
+      yarn nx release --yes --verbose
     env:
       GITHUB_TOKEN: $(githubAuthToken)
       NODE_AUTH_TOKEN: $(npmAuthToken)


### PR DESCRIPTION
## Summary:

The syntax `${{ variables.foo }}` in Azure Pipelines yml is only valid for _template_ variables. For our `npm-publish.yml` steps, we are setting a _runtime_ variable, so it cannot be accessed in a `${{ }}` in a successive steps' condition. We can fix this by slightly refactoring the condition so that it now evaluates at runtime. The solution was taken from here: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#variables-created-in-a-step-used-in-subsequent-step-conditions

While we're at it, let's add the `--verbose` flag too.

## Test Plan:

CI should pass