### PR TITLE
ci: use blobless clones in publishing pipelines

### DIFF
--- a/.ado/jobs/npm-publish-dry-run.yml
+++ b/.ado/jobs/npm-publish-dry-run.yml
@@ -8,9 +8,7 @@ jobs:
   steps:
     - checkout: self # self represents the repo where the initial Pipelines YAML file was found
       clean: true # whether to fetch clean each time
-      # fetchDepth: 2 # the depth of commits to ask Git to fetch
-      lfs: false # whether to download Git-LFS files
-      submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+      fetchFilter: blob:none # partial clone for faster clones while maintaining history
       persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
     - template: /.ado/templates/npm-publish.yml@self

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -68,9 +68,7 @@ extends:
            steps:
              - checkout: self # self represents the repo where the initial Pipelines YAML file was found
                clean: true # whether to fetch clean each time
-               # fetchDepth: 2 # the depth of commits to ask Git to fetch
-               lfs: false # whether to download Git-LFS files
-               submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+               fetchFilter: blob:none # partial clone for faster clones while maintaining history
                persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
              - template: /.ado/templates/npm-publish.yml@self


### PR DESCRIPTION
## Summary:

On CI, checkouts start by creating a new Git repo, then adding a remote and performing a checkout to a specific commit. This means that we're usually left in a headless state. Switching to a blobless clone should allow us to access full Git history without the cost of a full clone.

## Test Plan:

Verified that `git show HEAD` works:

![image](https://github.com/user-attachments/assets/1f5feadb-cd56-4d8f-ad29-e57b8d90b1ab)

Logs: https://dev.azure.com/ms/react-native/_build/results?buildId=617877&view=logs&j=31c9baed-b2a6-554c-7a70-551207daefaf&t=7e256de5-d29e-5b82-98c8-a05e66789a98