### PR TITLE
ci(0.76): use blobless clones in publishing pipelines (#2315)

### DIFF
--- a/.ado/jobs/npm-publish-dry-run.yml
+++ b/.ado/jobs/npm-publish-dry-run.yml
@@ -8,9 +8,7 @@ jobs:
   steps:
     - checkout: self # self represents the repo where the initial Pipelines YAML file was found
       clean: true # whether to fetch clean each time
-      # fetchDepth: 2 # the depth of commits to ask Git to fetch
-      lfs: false # whether to download Git-LFS files
-      submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+      fetchFilter: blob:none # partial clone for faster clones while maintaining history
       persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
     - template: /.ado/templates/npm-publish.yml@self

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -68,9 +68,7 @@ extends:
            steps:
              - checkout: self # self represents the repo where the initial Pipelines YAML file was found
                clean: true # whether to fetch clean each time
-               # fetchDepth: 2 # the depth of commits to ask Git to fetch
-               lfs: false # whether to download Git-LFS files
-               submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+               fetchFilter: blob:none # partial clone for faster clones while maintaining history
                persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
              - template: /.ado/templates/npm-publish.yml@self


### PR DESCRIPTION
## Summary:

On CI, checkouts start by creating a new Git repo, then adding a remote and performing a checkout to a specific commit. This means that we're usually left in a headless state. Switching to a blobless clone should allow us to access full Git history without the cost of a full clone.

Cherry-pick 5bf84b10.

## Test Plan:

n/a