### PR TITLE
ci: switch branch before publishing artifacts

### DIFF
--- a/.ado/templates/npm-publish.yml
+++ b/.ado/templates/npm-publish.yml
@@ -12,11 +12,13 @@ steps:
     displayName: Verify release config
 
   - script: |
+      echo Target branch: $(System.PullRequest.TargetBranch)
       yarn nx release --dry-run --verbose
     displayName: Version and publish packages (dry run)
     condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 
   - script: |
+      git switch $(Build.SourceBranchName)
       yarn nx release --yes --verbose
     env:
       GITHUB_TOKEN: $(githubAuthToken)


### PR DESCRIPTION
## Summary:

Even though we do a blobless clone, ADO still leaves us in a detached state. At least now we have all the information needed to switch branch.

## Test Plan:

n/a