### PR TITLE
ci(0.76): more publish pipeline fixes

### DIFF
--- a/.ado/jobs/npm-publish-dry-run.yml
+++ b/.ado/jobs/npm-publish-dry-run.yml
@@ -11,4 +11,4 @@ jobs:
       fetchFilter: blob:none # partial clone for faster clones while maintaining history
       persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-    - template: /.ado/templates/npm-publish.yml@self
+    - template: /.ado/templates/npm-publish-steps.yml@self

--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as util from "node:util";
 
-const ADO_PUBLISH_PIPELINE = ".ado/templates/npm-publish.yml";
+const ADO_PUBLISH_PIPELINE = ".ado/templates/npm-publish-steps.yml";
 const NX_CONFIG_FILE = "nx.json";
 
 const NPM_TAG_NEXT = "next";

--- a/.ado/templates/apple-tools-setup.yml
+++ b/.ado/templates/apple-tools-setup.yml
@@ -9,4 +9,6 @@ steps:
       script: |
         brew bundle --file .ado/Brewfile
 
-  - template: /.ado/templates/apple-xcode-select.yml@self
+  - script: |
+      sudo xcode-select --switch $(xcode_version)
+    displayName: Use $(xcode_friendly_name)

--- a/.ado/templates/apple-xcode-select.yml
+++ b/.ado/templates/apple-xcode-select.yml
@@ -1,5 +1,0 @@
-steps:
-  - bash: |
-      sudo xcode-select --switch $(xcode_version)
-    displayName: Use $(xcode_friendly_name)
-    failOnStderr: true

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -3,6 +3,8 @@ parameters:
   publishTag: 'latest'
 
 steps:
+  - template: /.ado/templates/configure-git.yml@self
+
   - script: |
       yarn install
     displayName: Install npm dependencies

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -21,7 +21,8 @@ steps:
 
   - script: |
       git switch $(Build.SourceBranchName)
-      yarn nx release --yes --verbose
+      yarn nx release --skip-publish --verbose
+      yarn nx release publish --excludeTaskDependencies
     env:
       GITHUB_TOKEN: $(githubAuthToken)
       NODE_AUTH_TOKEN: $(npmAuthToken)

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-mac/virtualized-lists": "workspace:*",
+    "@react-native-mac/virtualized-lists": "0.76.4",
     "@react-native/assets-registry": "0.76.3",
     "@react-native/codegen": "0.76.3",
     "@react-native/community-cli-plugin": "0.76.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,7 +3322,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@workspace:*, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.76.4, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -12115,7 +12115,7 @@ __metadata:
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "workspace:*"
+    "@react-native-mac/virtualized-lists": "npm:0.76.4"
     "@react-native/assets-registry": "npm:0.76.3"
     "@react-native/codegen": "npm:0.76.3"
     "@react-native/community-cli-plugin": "npm:0.76.3"


### PR DESCRIPTION
## Summary:
A couple of fixes:

1. `nx release` won't publish `react-native-macos` because we use Yarn with what they call a local dependency protocol (AKA: `workspace:*` in our package.json for react-native-macos). `nx` thinks that Yarn doesn't support this, but it has since Yarn 2+. This is a bug in nx, and I've filed https://github.com/nrwl/nx/issues/29242 . Meanwhile, let's just remove the use that protocol to unblock publish. 

2. `nx release` creates a graph of dependent tasks for it's command `nx-release-publish`. This seems to be include publishing a bunch of other packages (You can see the graph with `nx graph`, I've also pasted it here). There's an `--excludeTaskDependencies` option for `nx release publish` (the subcommand) but not `nx release`. So.. I'm splitting the command into 2: Run `nx release` and skip publish, then run `nx release publish` separately.

