### PR TITLE
fix(react-native): RCTAppDelegate::bundleURL not implemented from `0.76-stable` to main

### DIFF
--- a/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld-macOS/AppDelegate.mm
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld-macOS/AppDelegate.mm
@@ -16,6 +16,11 @@
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
+  return [self bundleURL];
+}
+
+- (NSURL *)bundleURL
+{
 #if DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else


### PR DESCRIPTION
## Summary:

Bring template fix done in `0.76-stable` (#2309) to main

