### PR TITLE
fix(0.76, animated): load NativeAnimatedModule on macOS

### DIFF
--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -430,7 +430,9 @@ export default {
       nativeEventEmitter = new NativeEventEmitter(
         // T88715063: NativeEventEmitter only used this parameter on iOS. Now it uses it on all platforms, so this code was modified automatically to preserve its behavior
         // If you want to use the native module on other platforms, please remove this condition and test its behavior
-        Platform.OS !== 'ios' ? null : NativeAnimatedModule,
+        Platform.OS !== 'ios' && Platform.OS !== 'macos' // [macOS]
+          ? null
+          : NativeAnimatedModule,
       );
     }
     return nativeEventEmitter;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,13 +3647,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@npm:0.76.5, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "npm:0.76.3"
-    react-native-macos: "workspace:*"
+    react-native-macos: "npm:0.76.5"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -3697,7 +3697,7 @@ __metadata:
     "@react-native-community/cli-platform-android": "npm:15.0.1"
     "@react-native-community/cli-platform-apple": "npm:15.0.1"
     "@react-native-community/cli-platform-ios": "npm:15.0.1"
-    "@react-native/oss-library-example": "workspace:*"
+    "@react-native/oss-library-example": "npm:0.76.5"
     "@react-native/popup-menu-android": "workspace:*"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -12110,7 +12110,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@workspace:*, react-native-macos@workspace:packages/react-native":
+"react-native-macos@npm:0.76.5, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:


### PR DESCRIPTION
## Summary:

Port #2302 to 0.76-stable

