### PR TITLE
ci(0.76): use verdaccio for npm publish dry run PR check

### DIFF
--- a/.ado/jobs/npm-publish-dry-run.yml
+++ b/.ado/jobs/npm-publish-dry-run.yml
@@ -11,4 +11,6 @@ jobs:
       fetchFilter: blob:none # partial clone for faster clones while maintaining history
       persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+    - template: /.ado/templates/verdaccio-init.yml@self
+
     - template: /.ado/templates/npm-publish-steps.yml@self

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -15,6 +15,7 @@ steps:
 
   - script: |
       echo Target branch: $(System.PullRequest.TargetBranch)
+      yarn nx release plan --message 'Dry run test' patch
       yarn nx release --skip-publish --verbose
       yarn nx release publish --excludeTaskDependencies
     displayName: Version and publish packages (dry run)

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -14,7 +14,6 @@ steps:
     displayName: Verify release config
 
   - script: |
-      set -eox pipefail
       echo Target branch: $(System.PullRequest.TargetBranch)
       git push --set-upstream origin test-publish
       yarn nx release plan --message 'Dry run test' --only-touched=false patch

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -15,7 +15,6 @@ steps:
 
   - script: |
       echo Target branch: $(System.PullRequest.TargetBranch)
-      git push --set-upstream origin test-publish
       yarn nx release plan --message 'Dry run test' --only-touched=false patch
       yarn nx release --skip-publish --verbose
       yarn nx release publish --excludeTaskDependencies

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -14,8 +14,9 @@ steps:
     displayName: Verify release config
 
   - script: |
+      set -eox pipefail
       echo Target branch: $(System.PullRequest.TargetBranch)
-      yarn nx release plan --message 'Dry run test' patch
+      yarn nx release plan --message 'Dry run test' --only-touched=false patch
       yarn nx release --skip-publish --verbose
       yarn nx release publish --excludeTaskDependencies
     displayName: Version and publish packages (dry run)

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -16,7 +16,7 @@ steps:
   - script: |
       set -eox pipefail
       echo Target branch: $(System.PullRequest.TargetBranch)
-      git checkout -b test
+      git push --set-upstream origin test-publish
       yarn nx release plan --message 'Dry run test' --only-touched=false patch
       yarn nx release --skip-publish --verbose
       yarn nx release publish --excludeTaskDependencies

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -16,6 +16,7 @@ steps:
   - script: |
       set -eox pipefail
       echo Target branch: $(System.PullRequest.TargetBranch)
+      git checkout -b test
       yarn nx release plan --message 'Dry run test' --only-touched=false patch
       yarn nx release --skip-publish --verbose
       yarn nx release publish --excludeTaskDependencies

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -15,7 +15,8 @@ steps:
 
   - script: |
       echo Target branch: $(System.PullRequest.TargetBranch)
-      yarn nx release --dry-run --verbose
+      yarn nx release --skip-publish --verbose
+      yarn nx release publish --excludeTaskDependencies
     displayName: Version and publish packages (dry run)
     condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,13 +3647,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@npm:0.76.5, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "npm:0.76.3"
-    react-native-macos: "workspace:*"
+    react-native-macos: "npm:0.76.5"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -3697,7 +3697,7 @@ __metadata:
     "@react-native-community/cli-platform-android": "npm:15.0.1"
     "@react-native-community/cli-platform-apple": "npm:15.0.1"
     "@react-native-community/cli-platform-ios": "npm:15.0.1"
-    "@react-native/oss-library-example": "workspace:*"
+    "@react-native/oss-library-example": "npm:0.76.5"
     "@react-native/popup-menu-android": "workspace:*"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -12110,7 +12110,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@workspace:*, react-native-macos@workspace:packages/react-native":
+"react-native-macos@npm:0.76.5, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:


### PR DESCRIPTION
## Summary:

While trying to test different publish pipelines, I've found that the `--dry run` flag of various tools (rpm cli, beachball, nx-release) all don't test enough. However, publishing to a verdaciio server may give us a better indication whether the publish pipeline is good enough. 

## Test Plan:

Watch CI output
