### PR TITLE
ci: Various fixes

### DIFF
--- a/.ado/jobs/build-test-rntester.yml
+++ b/.ado/jobs/build-test-rntester.yml
@@ -98,16 +98,6 @@ jobs:
       steps:
         - template: /.ado/templates/apple-tools-setup.yml@self
 
-        - ${{ if in(slice.sdk, 'xros', 'xrsimulator') }}:
-          - script: |
-              set -eox pipefail
-              # https://github.com/actions/runner-images/issues/10559
-              sudo xcodebuild -runFirstLaunch
-              sudo xcrun simctl list
-              sudo xcodebuild -downloadPlatform visionOS
-              sudo xcodebuild -runFirstLaunch
-            displayName: Download visionOS SDK
-
         - script: |
             yarn install
           displayName: Install npm dependencies

--- a/.ado/scripts/xcodebuild.sh
+++ b/.ado/scripts/xcodebuild.sh
@@ -70,6 +70,8 @@ if ! command -v xcbeautify 1> /dev/null; then
   brew install xcbeautify
 fi
 
+xcodebuild -downloadAllPlatforms
+
 eval "$build_cmd" | xcbeautify --report junit
 
 if [[ "$CCACHE_DISABLE" != "1" ]]; then

--- a/.ado/templates/apple-tools-setup.yml
+++ b/.ado/templates/apple-tools-setup.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '18.x'
+      versionSpec: '23.x'
 
   - script: |
       brew bundle --file .ado/Brewfile

--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -1,6 +1,6 @@
 variables:
   VmImageApple: macos-latest-internal
-  xcode_friendly_name: 'Xcode 16.0'
-  xcode_version: '/Applications/Xcode_16.0.app'
+  xcode_friendly_name: 'Xcode 16.2'
+  xcode_version: '/Applications/Xcode_16.2.app'
   ios_version: '18.0'
   ios_simulator: 'iPhone 16'


### PR DESCRIPTION
## Summary:

A couple of fixes:
- Xcode 16.0 was removed from the macOS 14 image. Use Xcode 16.2
- We needed to both remove the step to download the visionOS SDK and add a step to download all platforms in Xcode because.. well.. that was the combo that got visionOS to keep building. 
- React Native Test App (off main) uses Node 23's typescript stripping, and we have a job that tests RNTA integration. That means we now need Node 23 as well (@tido64 fyi)

## Test Plan:

CI should pass
