### PR TITLE
ci(0.76) use `workspace:*` for `@react-native/oss-library-example` in RNTester

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -23,7 +23,7 @@
     "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock"
   },
   "dependencies": {
-    "@react-native/oss-library-example": "0.76.5",
+    "@react-native/oss-library-example": "workspace:*",
     "@react-native/popup-menu-android": "workspace:*",
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,7 +3322,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.76.4, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.76.5, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -3647,13 +3647,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@npm:0.76.5, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "npm:0.76.3"
-    react-native-macos: "npm:0.76.5"
+    react-native-macos: "npm:0.76.6"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -3697,7 +3697,7 @@ __metadata:
     "@react-native-community/cli-platform-android": "npm:15.0.1"
     "@react-native-community/cli-platform-apple": "npm:15.0.1"
     "@react-native-community/cli-platform-ios": "npm:15.0.1"
-    "@react-native/oss-library-example": "npm:0.76.5"
+    "@react-native/oss-library-example": "workspace:*"
     "@react-native/popup-menu-android": "workspace:*"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -12110,12 +12110,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@npm:0.76.5, react-native-macos@workspace:packages/react-native":
+"react-native-macos@npm:0.76.6, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "npm:0.76.4"
+    "@react-native-mac/virtualized-lists": "npm:0.76.5"
     "@react-native/assets-registry": "npm:0.76.3"
     "@react-native/codegen": "npm:0.76.3"
     "@react-native/community-cli-plugin": "npm:0.76.3"


### PR DESCRIPTION
## Summary:

With the switch to our new publish pipeline, some state is currently in flux (should we use `workspace:*`, or hardcode the version, etc). But while that isn't resolved, let's fix this to unblock merges. 

## Test Plan:

CI should pass
