### PR TITLE
ci(0.76): Download All Platforms with Xcode

### DIFF
--- a/.ado/jobs/build-test-rntester.yml
+++ b/.ado/jobs/build-test-rntester.yml
@@ -98,16 +98,6 @@ jobs:
       steps:
         - template: /.ado/templates/apple-tools-setup.yml@self
 
-        - ${{ if in(slice.sdk, 'xros', 'xrsimulator') }}:
-          - script: |
-              set -eox pipefail
-              # https://github.com/actions/runner-images/issues/10559
-              sudo xcodebuild -runFirstLaunch
-              sudo xcrun simctl list
-              sudo xcodebuild -downloadPlatform visionOS
-              sudo xcodebuild -runFirstLaunch
-            displayName: Download visionOS SDK
-
         - script: |
             yarn install
           displayName: Install npm dependencies

--- a/.ado/templates/apple-tools-setup.yml
+++ b/.ado/templates/apple-tools-setup.yml
@@ -1,14 +1,16 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '18.x'
+      versionSpec: '23.x'
 
-  - task: CmdLine@2
-    displayName: 'brew bundle'
-    inputs:
-      script: |
-        brew bundle --file .ado/Brewfile
+  - script: |
+      brew bundle --file .ado/Brewfile
+    displayName: 'Install Homebrew dependencies'
 
   - script: |
       sudo xcode-select --switch $(xcode_version)
     displayName: Use $(xcode_friendly_name)
+
+  - script: |
+      xcodebuild -downloadAllPlatforms
+    displayName: 'Download Xcode Platforms'

--- a/.ado/templates/apple-tools-setup.yml
+++ b/.ado/templates/apple-tools-setup.yml
@@ -13,4 +13,5 @@ steps:
 
   - script: |
       xcodebuild -downloadAllPlatforms
+      sudo xcodebuild -runFirstLaunch
     displayName: 'Download Xcode Platforms'


### PR DESCRIPTION
## Summary:

Backporting a change I added to #2314, The Azure Runner images sometimes swap what Xcode platforms / simulators they have pre-installed in the interest of disk space. To help mitigate our risk, I'll just add a step to download all the Xcode platforms as part of our tools setup. 

## Test Plan:

CI should pass. 