### PR TITLE
fix(textinput): Account for float dimensions when showing scroller

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.mm
@@ -136,7 +136,7 @@
   if (textViewSize.height > clipView.bounds.size.height) {
     // Sometimes dimensions returned are in floating point numbers. 
     // If the floats are close enough, then don't show the scrollbar even if there is a fraction of overflow with the text.
-    return textViewSize.height - clipView.bounds.size.height >= 1;
+    return fabs(textViewSize.height - clipView.bounds.size.height) >= 1;
   };
 
   return NO;

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.mm
@@ -134,7 +134,9 @@
   CGSize textViewSize = [_backedTextInputView intrinsicContentSize];
   NSClipView *clipView = (NSClipView *)_scrollView.contentView;
   if (textViewSize.height > clipView.bounds.size.height) {
-    return YES;
+    // Sometimes dimensions returned are in floating point numbers. 
+    // If the floats are close enough, then don't show the scrollbar even if there is a fraction of overflow with the text.
+    return textViewSize.height - clipView.bounds.size.height >= 1;
   };
 
   return NO;


### PR DESCRIPTION
## Summary:

In certain scenarios, the internal dimensions of elements are returned as floating point numbers because of variables such as view scaling. The current comparison for showing / hiding the scrollbar in the multiline text input does not account for this. If it's the case where the ClipView within the multiline text input is a fraction smaller than the text itself, then the scrollbar persistently shows. 

## Test Plan:

Tested on local app - scrollview still shows at appropriate times.
![image](https://github.com/user-attachments/assets/87341cad-3929-4342-b7ba-5ae66ab1089c)
