### PR TITLE
[0.72-stable] fix(textinput): Account for float dimensions when showing scroller

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -134,7 +134,9 @@
   CGSize textViewSize = [_backedTextInputView intrinsicContentSize];
   NSClipView *clipView = (NSClipView *)_scrollView.contentView;
   if (textViewSize.height > clipView.bounds.size.height) {
-    return YES;
+    // Sometimes dimensions returned are in floating point numbers. 
+    // If the floats are close enough, then don't show the scrollbar even if there is a fraction of overflow with the text.
+    return fabs(textViewSize.height - clipView.bounds.size.height) >= 1;
   };
 
   return NO;


### PR DESCRIPTION
Backporting changes from #2341, see PR for details.