### PR TITLE
ci: disable CodeQL in release pipeline

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -17,6 +17,10 @@ variables:
   - group: InfoSec-SecurityResults
   - name: tags
     value: production,externalfacing
+  # CodeQL Still has not fixed their bug running on Apple ARM64 jobs where they inject x64 binaries into arm64 processes and just make it crash :(
+  # Only workaround for now is to disable CodeQL on Apple jobs.
+  - name Codeql.Enabled
+    value: false
   - template: /.ado/variables/vars.yml@self
 
 resources:


### PR DESCRIPTION
## Summary:

If CodeQL is enabled, we get auto-injected some pipeline steps, including a "Use NodeTool" step that has a dylib with the wrong binary for our image (🤦🏽‍♂️). We already run CodeQL elsewhere, so let's disable it. 

## Test Plan:

Merge and hope for the best. 