### PR TITLE
ci(0.76): Patch nx release to support modern yarn

### DIFF
--- a/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch
+++ b/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch
@@ -1,0 +1,41 @@
+diff --git a/src/executors/release-publish/release-publish.impl.js b/src/executors/release-publish/release-publish.impl.js
+index 08cd58274d308bcb2ca644e8af5bd99a153c9e91..0c6a99d035e300e428fcbd20eb1239439e898745 100644
+--- a/src/executors/release-publish/release-publish.impl.js
++++ b/src/executors/release-publish/release-publish.impl.js
+@@ -10,6 +10,7 @@ const npm_config_1 = require("../../utils/npm-config");
+ const extract_npm_publish_json_data_1 = require("./extract-npm-publish-json-data");
+ const log_tar_1 = require("./log-tar");
+ const chalk = require("chalk");
++const semver_1 = require("semver");
+ const LARGE_BUFFER = 1024 * 1000000;
+ function processEnv(color) {
+     const env = {
+@@ -23,6 +24,7 @@ function processEnv(color) {
+ }
+ async function runExecutor(options, context) {
+     const pm = (0, devkit_1.detectPackageManager)();
++    const isYarnBerry = (packageManager === 'yarn' && !(0, semver_1.gte)((0, devkit_1.getPackageManagerVersion)(pm), '2.0.0'));
+     /**
+      * We need to check both the env var and the option because the executor may have been triggered
+      * indirectly via dependsOn, in which case the env var will be set, but the option will not.
+@@ -37,7 +39,7 @@ async function runExecutor(options, context) {
+      * pnpm supports dynamically updating locally linked packages during its packing phase, but other package managers do not.
+      * Therefore, protect the user from publishing invalid packages by checking if it contains local dependency protocols.
+      */
+-    if (pm !== 'pnpm') {
++    if (pm !== 'pnpm' || (pm !== 'yarn' && isYarnBerry)) {
+         const depTypes = ['dependencies', 'devDependencies', 'peerDependencies'];
+         for (const depType of depTypes) {
+             const deps = packageJson[depType];
+@@ -187,7 +189,10 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
+         pm === 'pnpm'
+             ? // Unlike npm, pnpm publish does not support a custom registryConfigKey option, and will error on uncommitted changes by default if --no-git-checks is not set
+                 `pnpm publish "${packageRoot}" --json --registry="${registry}" --tag=${tag} --no-git-checks`
+-            : `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
++            : pm === 'yarn'
++                ? `yarn npm publish "${packageRoot}" --tag=${tag}`
++                : `npm publish "${packageRoot}" --json --"${registryConfigKey}=${registry}" --tag=${tag}`,
++                  
+     ];
+     if (options.otp) {
+         publishCommandSegments.push(`--otp=${options.otp}`);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-flow": "^7.24.7",
     "@definitelytyped/dtslint": "^0.0.127",
     "@jest/create-cache-key-function": "^29.6.3",
-    "@nx/js": "~20.0.0",
+    "@nx/js": "patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch",
     "@pkgjs/parseargs": "^0.11.0",
     "@react-native/metro-babel-transformer": "0.76.3",
     "@react-native/metro-config": "0.76.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2785,7 +2785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nx/js@npm:~20.0.0":
+"@nx/js@npm:20.0.7":
   version: 20.0.7
   resolution: "@nx/js@npm:20.0.7"
   dependencies:
@@ -2825,6 +2825,49 @@ __metadata:
     verdaccio:
       optional: true
   checksum: 10c0/eae4688886a73c2fc0354dbfc1b626c897337b4a77a264f851cc166ae48ae9e7437fd052d94325c1270724e95e9cebb2e45b872adbe742fc3784d3a454815b93
+  languageName: node
+  linkType: hard
+
+"@nx/js@patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch":
+  version: 20.0.7
+  resolution: "@nx/js@patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch::version=20.0.7&hash=e48e8a"
+  dependencies:
+    "@babel/core": "npm:^7.23.2"
+    "@babel/plugin-proposal-decorators": "npm:^7.22.7"
+    "@babel/plugin-transform-class-properties": "npm:^7.22.5"
+    "@babel/plugin-transform-runtime": "npm:^7.23.2"
+    "@babel/preset-env": "npm:^7.23.2"
+    "@babel/preset-typescript": "npm:^7.22.5"
+    "@babel/runtime": "npm:^7.22.6"
+    "@nx/devkit": "npm:20.0.7"
+    "@nx/workspace": "npm:20.0.7"
+    "@zkochan/js-yaml": "npm:0.0.7"
+    babel-plugin-const-enum: "npm:^1.0.1"
+    babel-plugin-macros: "npm:^2.8.0"
+    babel-plugin-transform-typescript-metadata: "npm:^0.3.1"
+    chalk: "npm:^4.1.0"
+    columnify: "npm:^1.6.0"
+    detect-port: "npm:^1.5.1"
+    enquirer: "npm:~2.3.6"
+    fast-glob: "npm:3.2.7"
+    ignore: "npm:^5.0.4"
+    js-tokens: "npm:^4.0.0"
+    jsonc-parser: "npm:3.2.0"
+    minimatch: "npm:9.0.3"
+    npm-package-arg: "npm:11.0.1"
+    npm-run-path: "npm:^4.0.1"
+    ora: "npm:5.3.0"
+    semver: "npm:^7.5.3"
+    source-map-support: "npm:0.5.19"
+    ts-node: "npm:10.9.1"
+    tsconfig-paths: "npm:^4.1.2"
+    tslib: "npm:^2.3.0"
+  peerDependencies:
+    verdaccio: ^5.0.4
+  peerDependenciesMeta:
+    verdaccio:
+      optional: true
+  checksum: 10c0/7221b6ef17ede1ca094726114642229bd48cedd3144fcb43bb0b724d89c6be0b450157cdd292f4cb71e646ceccaf91c255a83e5ab0957fd6c59031b4934d70b9
   languageName: node
   linkType: hard
 
@@ -3263,7 +3306,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.24.7"
     "@definitelytyped/dtslint": "npm:^0.0.127"
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@nx/js": "npm:~20.0.0"
+    "@nx/js": "patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch"
     "@pkgjs/parseargs": "npm:^0.11.0"
     "@react-native/metro-babel-transformer": "npm:0.76.3"
     "@react-native/metro-config": "npm:0.76.3"


### PR DESCRIPTION
## Summary:

Followup from https://github.com/nrwl/nx/issues/29242#issuecomment-2622693876 

Test if we can patch nx to let us use the `workspace:*` protocol for publishing using Yarn berry's (AKA, Yarn 2+) npm publish command.

## Test Plan:

Can't really test publish changes. 🤷‍♂️
