### PR TITLE
Fix `Platform.select` on Mac

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.macos.js
+++ b/packages/react-native/Libraries/Utilities/Platform.macos.js
@@ -84,7 +84,7 @@ const Platform: PlatformType = {
   },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     // $FlowFixMe[incompatible-return]
-    'ios' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
+    'macos' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
 };
 
 module.exports = Platform;

--- a/packages/react-native/Libraries/Utilities/Platform.macos.js
+++ b/packages/react-native/Libraries/Utilities/Platform.macos.js
@@ -84,7 +84,11 @@ const Platform: PlatformType = {
   },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     // $FlowFixMe[incompatible-return]
-    'macos' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
+    'macos' in spec
+      ? spec.macos
+      : 'native' in spec
+        ? spec.native
+        : spec.default,
 };
 
 module.exports = Platform;

--- a/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
@@ -39,13 +39,21 @@ describe('Platform', () => {
       expect(PlatformMacOS.select(iosSpecific)).toEqual(iosSpecific.native);
 
       const androidSpecific = {android: 'android', native: 'native'};
-      expect(PlatformIOS.select(androidSpecific)).toEqual(androidSpecific.native);
-      expect(PlatformAndroid.select(androidSpecific)).toEqual(androidSpecific.android);
-      expect(PlatformMacOS.select(androidSpecific)).toEqual(androidSpecific.native);
+      expect(PlatformIOS.select(androidSpecific)).toEqual(
+        androidSpecific.native,
+      );
+      expect(PlatformAndroid.select(androidSpecific)).toEqual(
+        androidSpecific.android,
+      );
+      expect(PlatformMacOS.select(androidSpecific)).toEqual(
+        androidSpecific.native,
+      );
 
       const macosSpecific = {macos: 'macos', native: 'native'};
       expect(PlatformIOS.select(macosSpecific)).toEqual(macosSpecific.native);
-      expect(PlatformAndroid.select(macosSpecific)).toEqual(macosSpecific.native);
+      expect(PlatformAndroid.select(macosSpecific)).toEqual(
+        macosSpecific.native,
+      );
       expect(PlatformMacOS.select(macosSpecific)).toEqual(macosSpecific.macos);
     });
     // macOS]

--- a/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
@@ -12,32 +12,56 @@
 
 const PlatformAndroid = require('../Platform.android');
 const PlatformIOS = require('../Platform.ios');
+const PlatformMacOS = require('../Platform.macos'); // [macOS]
 
 describe('Platform', () => {
   describe('OS', () => {
     it('should have correct value', () => {
       expect(PlatformIOS.OS).toEqual('ios');
       expect(PlatformAndroid.OS).toEqual('android');
+      expect(PlatformMacOS.OS).toEqual('macos'); // [macOS]
     });
   });
 
   describe('select', () => {
     it('should return platform specific value', () => {
-      const obj = {ios: 'ios', android: 'android'};
+      const obj = {ios: 'ios', android: 'android', macos: 'macos'}; // [macOS]
       expect(PlatformIOS.select(obj)).toEqual(obj.ios);
       expect(PlatformAndroid.select(obj)).toEqual(obj.android);
+      expect(PlatformMacOS.select(obj)).toEqual(obj.macos); // [macOS]
     });
+
+    // [macOS
+    it('should return correct platform given partial platform overrides', () => {
+      const iosSpecific = {ios: 'ios', native: 'native'};
+      expect(PlatformIOS.select(iosSpecific)).toEqual(iosSpecific.ios);
+      expect(PlatformAndroid.select(iosSpecific)).toEqual(iosSpecific.native);
+      expect(PlatformMacOS.select(iosSpecific)).toEqual(iosSpecific.native);
+
+      const androidSpecific = {android: 'android', native: 'native'};
+      expect(PlatformIOS.select(androidSpecific)).toEqual(androidSpecific.native);
+      expect(PlatformAndroid.select(androidSpecific)).toEqual(androidSpecific.android);
+      expect(PlatformMacOS.select(androidSpecific)).toEqual(androidSpecific.native);
+
+      const macosSpecific = {macos: 'macos', native: 'native'};
+      expect(PlatformIOS.select(macosSpecific)).toEqual(macosSpecific.native);
+      expect(PlatformAndroid.select(macosSpecific)).toEqual(macosSpecific.native);
+      expect(PlatformMacOS.select(macosSpecific)).toEqual(macosSpecific.macos);
+    });
+    // macOS]
 
     it('should return native value if no specific value was found', () => {
       const obj = {native: 'native', default: 'default'};
       expect(PlatformIOS.select(obj)).toEqual(obj.native);
       expect(PlatformAndroid.select(obj)).toEqual(obj.native);
+      expect(PlatformMacOS.select(obj)).toEqual(obj.native); // [macOS]
     });
 
     it('should return default value if no specific value was found', () => {
       const obj = {default: 'default'};
       expect(PlatformIOS.select(obj)).toEqual(obj.default);
       expect(PlatformAndroid.select(obj)).toEqual(obj.default);
+      expect(PlatformMacOS.select(obj)).toEqual(obj.default); // [macOS]
     });
   });
 });


### PR DESCRIPTION
## Summary:

During the merge up to 0.77, `Platform.select` was accidentally broken. This fixes it.

https://github.com/microsoft/react-native-macos/blame/5c43268b1c28538c517702ce83d0ca5adffcb05a/packages/react-native/Libraries/Utilities/Platform.macos.js#L87

## Test Plan:

The newly added unit tests properly cover this case.