### PR TITLE
[0.77-stable] Fix `Platform.select` on Mac

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.macos.js
+++ b/packages/react-native/Libraries/Utilities/Platform.macos.js
@@ -84,7 +84,7 @@ const Platform: PlatformType = {
   },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     // $FlowFixMe[incompatible-return]
-    'ios' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
+    'macos' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
 };
 
 module.exports = Platform;

--- a/packages/react-native/Libraries/Utilities/Platform.macos.js
+++ b/packages/react-native/Libraries/Utilities/Platform.macos.js
@@ -84,7 +84,11 @@ const Platform: PlatformType = {
   },
   select: <T>(spec: PlatformSelectSpec<T>): T =>
     // $FlowFixMe[incompatible-return]
-    'macos' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
+    'macos' in spec
+      ? spec.macos
+      : 'native' in spec
+        ? spec.native
+        : spec.default,
 };
 
 module.exports = Platform;

--- a/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
@@ -39,13 +39,21 @@ describe('Platform', () => {
       expect(PlatformMacOS.select(iosSpecific)).toEqual(iosSpecific.native);
 
       const androidSpecific = {android: 'android', native: 'native'};
-      expect(PlatformIOS.select(androidSpecific)).toEqual(androidSpecific.native);
-      expect(PlatformAndroid.select(androidSpecific)).toEqual(androidSpecific.android);
-      expect(PlatformMacOS.select(androidSpecific)).toEqual(androidSpecific.native);
+      expect(PlatformIOS.select(androidSpecific)).toEqual(
+        androidSpecific.native,
+      );
+      expect(PlatformAndroid.select(androidSpecific)).toEqual(
+        androidSpecific.android,
+      );
+      expect(PlatformMacOS.select(androidSpecific)).toEqual(
+        androidSpecific.native,
+      );
 
       const macosSpecific = {macos: 'macos', native: 'native'};
       expect(PlatformIOS.select(macosSpecific)).toEqual(macosSpecific.native);
-      expect(PlatformAndroid.select(macosSpecific)).toEqual(macosSpecific.native);
+      expect(PlatformAndroid.select(macosSpecific)).toEqual(
+        macosSpecific.native,
+      );
       expect(PlatformMacOS.select(macosSpecific)).toEqual(macosSpecific.macos);
     });
     // macOS]

--- a/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
@@ -12,32 +12,56 @@
 
 const PlatformAndroid = require('../Platform.android');
 const PlatformIOS = require('../Platform.ios');
+const PlatformMacOS = require('../Platform.macos'); // [macOS]
 
 describe('Platform', () => {
   describe('OS', () => {
     it('should have correct value', () => {
       expect(PlatformIOS.OS).toEqual('ios');
       expect(PlatformAndroid.OS).toEqual('android');
+      expect(PlatformMacOS.OS).toEqual('macos'); // [macOS]
     });
   });
 
   describe('select', () => {
     it('should return platform specific value', () => {
-      const obj = {ios: 'ios', android: 'android'};
+      const obj = {ios: 'ios', android: 'android', macos: 'macos'}; // [macOS]
       expect(PlatformIOS.select(obj)).toEqual(obj.ios);
       expect(PlatformAndroid.select(obj)).toEqual(obj.android);
+      expect(PlatformMacOS.select(obj)).toEqual(obj.macos); // [macOS]
     });
+
+    // [macOS
+    it('should return correct platform given partial platform overrides', () => {
+      const iosSpecific = {ios: 'ios', native: 'native'};
+      expect(PlatformIOS.select(iosSpecific)).toEqual(iosSpecific.ios);
+      expect(PlatformAndroid.select(iosSpecific)).toEqual(iosSpecific.native);
+      expect(PlatformMacOS.select(iosSpecific)).toEqual(iosSpecific.native);
+
+      const androidSpecific = {android: 'android', native: 'native'};
+      expect(PlatformIOS.select(androidSpecific)).toEqual(androidSpecific.native);
+      expect(PlatformAndroid.select(androidSpecific)).toEqual(androidSpecific.android);
+      expect(PlatformMacOS.select(androidSpecific)).toEqual(androidSpecific.native);
+
+      const macosSpecific = {macos: 'macos', native: 'native'};
+      expect(PlatformIOS.select(macosSpecific)).toEqual(macosSpecific.native);
+      expect(PlatformAndroid.select(macosSpecific)).toEqual(macosSpecific.native);
+      expect(PlatformMacOS.select(macosSpecific)).toEqual(macosSpecific.macos);
+    });
+    // macOS]
 
     it('should return native value if no specific value was found', () => {
       const obj = {native: 'native', default: 'default'};
       expect(PlatformIOS.select(obj)).toEqual(obj.native);
       expect(PlatformAndroid.select(obj)).toEqual(obj.native);
+      expect(PlatformMacOS.select(obj)).toEqual(obj.native); // [macOS]
     });
 
     it('should return default value if no specific value was found', () => {
       const obj = {default: 'default'};
       expect(PlatformIOS.select(obj)).toEqual(obj.default);
       expect(PlatformAndroid.select(obj)).toEqual(obj.default);
+      expect(PlatformMacOS.select(obj)).toEqual(obj.default); // [macOS]
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,7 +2743,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@workspace:*, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.77.0, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -3038,13 +3038,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@npm:0.77.2, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "npm:0.77.0"
-    react-native-macos: "workspace:*"
+    react-native-macos: "npm:0.77.0"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -3087,7 +3087,7 @@ __metadata:
     "@react-native-community/cli": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-android": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-ios": "npm:15.0.0-alpha.2"
-    "@react-native/oss-library-example": "workspace:*"
+    "@react-native/oss-library-example": "npm:0.77.2"
     "@react-native/popup-menu-android": "workspace:*"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -10863,12 +10863,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@workspace:*, react-native-macos@workspace:packages/react-native":
+"react-native-macos@npm:0.77.0, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "workspace:*"
+    "@react-native-mac/virtualized-lists": "npm:0.77.0"
     "@react-native/assets-registry": "npm:0.77.0"
     "@react-native/codegen": "npm:0.77.0"
     "@react-native/community-cli-plugin": "npm:0.77.0"


### PR DESCRIPTION
Cherry picks #2374 into 0.77-stable.