### PR TITLE
chore: Remove unnecessary NSLog

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
@@ -149,7 +149,6 @@ static UIFont *RCTDefaultFontWithFontProperties(RCTFontProperties fontProperties
 #if TARGET_OS_OSX // [macOS
 NSArray<NSString *> *RCTFontNamesForFamilyName(NSString *familyName) {
   NSArray<NSArray *> *fontMembers = [[NSFontManager sharedFontManager] availableMembersOfFontFamily:familyName];
-  NSLog(@"SAAD");
   NSMutableArray<NSString *> *fontNames = [NSMutableArray array];
 
   for (NSArray *fontMember in fontMembers) {


### PR DESCRIPTION
## Summary:

I notice this getting printed multiple times in my Xcode console when running react-native-macos 0.77

<img width="641" alt="image" src="https://github.com/user-attachments/assets/da6fc4dc-d8e7-486e-bf53-73d7005891bd" />

So this PR just removes this accidental print statement 


## Test Plan:

Run RNTester locally
