### PR TITLE
Fix responder chain in reactViewController on macOS

### DIFF
--- a/packages/react-native/React/Views/UIView+React.m
+++ b/packages/react-native/React/Views/UIView+React.m
@@ -313,6 +313,7 @@ static void updateTransform(RCTPlatformView *view) // [macOS]
 
 - (UIViewController *)reactViewController
 {
+#if !TARGET_OS_OSX // [macOS]
   id responder = [self nextResponder];
   while (responder) {
     if ([responder isKindOfClass:[UIViewController class]]) {
@@ -320,6 +321,16 @@ static void updateTransform(RCTPlatformView *view) // [macOS]
     }
     responder = [responder nextResponder];
   }
+#else // [macOS
+  NSView *view = self;
+  while (view) {
+    if ([view.nextResponder isKindOfClass:[NSViewController class]]) {
+      return (NSViewController *)view.nextResponder;
+    }
+    view = view.superview;
+    }
+#endif // macOS]
+
   return nil;
 }
 


### PR DESCRIPTION
## Summary:

I first noticed this while working on SwiftUI views for https://github.com/expo/expo/pull/35078. Calling `reactViewController` on iOS always returns the correct view controller but on macOS, this same function will return nil for nested views.

So this PR addresses the differences in responder chain behavior between iOS and macOS when aliasing UIViewController to NSViewController. On iOS, a view's nextResponder is naturally its own UIViewController, ensuring that helper functions like reactViewController work as expected. However, on macOS, an NSView's nextResponder does not include its NSViewController by default, which causes issues when trying to retrieve the view controller directly from the responder chain. 
This change ensures that traversals will properly locate the NSViewController using the superview chain, mirroring iOS behavior.

## Test Plan:

Run RNTester and we've been using this same function to render SwiftUI views on macOS in expo's repo