### PR TITLE
fix: avoid race condition crash in `[RCTDataRequestHandler invalidate]`

### DIFF
--- a/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
@@ -40,6 +40,11 @@ RCT_EXPORT_MODULE()
 
   __weak __block NSBlockOperation *weakOp;
   __block NSBlockOperation *op = [NSBlockOperation blockOperationWithBlock:^{
+    NSBlockOperation *strongOp = weakOp;  // Strong reference to avoid deallocation during execution
+    if (strongOp == nil || [strongOp isCancelled]) {
+      return;
+    }
+
     // Get mime type
     NSRange firstSemicolon = [request.URL.resourceSpecifier rangeOfString:@";"];
     NSString *mimeType =
@@ -51,15 +56,15 @@ RCT_EXPORT_MODULE()
                                            expectedContentLength:-1
                                                 textEncodingName:nil];
 
-    [delegate URLRequest:weakOp didReceiveResponse:response];
+    [delegate URLRequest:strongOp didReceiveResponse:response];
 
     // Load data
     NSError *error;
     NSData *data = [NSData dataWithContentsOfURL:request.URL options:NSDataReadingMappedIfSafe error:&error];
     if (data) {
-      [delegate URLRequest:weakOp didReceiveData:data];
+      [delegate URLRequest:strongOp didReceiveData:data];
     }
-    [delegate URLRequest:weakOp didCompleteWithError:error];
+    [delegate URLRequest:strongOp didCompleteWithError:error];
   }];
 
   weakOp = op;

--- a/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
@@ -40,10 +40,12 @@ RCT_EXPORT_MODULE()
 
   __weak __block NSBlockOperation *weakOp;
   __block NSBlockOperation *op = [NSBlockOperation blockOperationWithBlock:^{
+    // [macOS
     NSBlockOperation *strongOp = weakOp;  // Strong reference to avoid deallocation during execution
     if (strongOp == nil || [strongOp isCancelled]) {
       return;
     }
+    // macOS]
 
     // Get mime type
     NSRange firstSemicolon = [request.URL.resourceSpecifier rangeOfString:@";"];
@@ -56,15 +58,15 @@ RCT_EXPORT_MODULE()
                                            expectedContentLength:-1
                                                 textEncodingName:nil];
 
-    [delegate URLRequest:strongOp didReceiveResponse:response];
+    [delegate URLRequest:strongOp didReceiveResponse:response]; // [macOS]
 
     // Load data
     NSError *error;
     NSData *data = [NSData dataWithContentsOfURL:request.URL options:NSDataReadingMappedIfSafe error:&error];
     if (data) {
-      [delegate URLRequest:strongOp didReceiveData:data];
+      [delegate URLRequest:strongOp didReceiveData:data]; // [macOS]
     }
-    [delegate URLRequest:strongOp didCompleteWithError:error];
+    [delegate URLRequest:strongOp didCompleteWithError:error]; // [macOS]
   }];
 
   weakOp = op;

--- a/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
@@ -48,12 +48,17 @@ RCT_EXPORT_MODULE()
 
   __weak __block NSBlockOperation *weakOp;
   __block NSBlockOperation *op = [NSBlockOperation blockOperationWithBlock:^{
+    NSBlockOperation *strongOp = weakOp;  // Strong reference to avoid deallocation during execution
+    if (strongOp == nil || [strongOp isCancelled]) {
+      return;
+    }
+
     // Get content length
     NSError *error = nil;
     NSFileManager *fileManager = [NSFileManager new];
     NSDictionary<NSString *, id> *fileAttributes = [fileManager attributesOfItemAtPath:request.URL.path error:&error];
     if (!fileAttributes) {
-      [delegate URLRequest:weakOp didCompleteWithError:error];
+      [delegate URLRequest:strongOp didCompleteWithError:error];
       return;
     }
 
@@ -70,14 +75,14 @@ RCT_EXPORT_MODULE()
                                            expectedContentLength:[fileAttributes[NSFileSize] ?: @-1 integerValue]
                                                 textEncodingName:nil];
 
-    [delegate URLRequest:weakOp didReceiveResponse:response];
+    [delegate URLRequest:strongOp didReceiveResponse:response];
 
     // Load data
     NSData *data = [NSData dataWithContentsOfURL:request.URL options:NSDataReadingMappedIfSafe error:&error];
     if (data) {
-      [delegate URLRequest:weakOp didReceiveData:data];
+      [delegate URLRequest:strongOp didReceiveData:data];
     }
-    [delegate URLRequest:weakOp didCompleteWithError:error];
+    [delegate URLRequest:strongOp didCompleteWithError:error];
   }];
 
   weakOp = op;

--- a/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
@@ -48,17 +48,19 @@ RCT_EXPORT_MODULE()
 
   __weak __block NSBlockOperation *weakOp;
   __block NSBlockOperation *op = [NSBlockOperation blockOperationWithBlock:^{
+    // [macOS
     NSBlockOperation *strongOp = weakOp;  // Strong reference to avoid deallocation during execution
     if (strongOp == nil || [strongOp isCancelled]) {
       return;
     }
+    // macOS]
 
     // Get content length
     NSError *error = nil;
     NSFileManager *fileManager = [NSFileManager new];
     NSDictionary<NSString *, id> *fileAttributes = [fileManager attributesOfItemAtPath:request.URL.path error:&error];
     if (!fileAttributes) {
-      [delegate URLRequest:strongOp didCompleteWithError:error];
+      [delegate URLRequest:strongOp didCompleteWithError:error]; // [macOS]
       return;
     }
 
@@ -75,14 +77,14 @@ RCT_EXPORT_MODULE()
                                            expectedContentLength:[fileAttributes[NSFileSize] ?: @-1 integerValue]
                                                 textEncodingName:nil];
 
-    [delegate URLRequest:strongOp didReceiveResponse:response];
+    [delegate URLRequest:strongOp didReceiveResponse:response]; // [macOS]
 
     // Load data
     NSData *data = [NSData dataWithContentsOfURL:request.URL options:NSDataReadingMappedIfSafe error:&error];
     if (data) {
-      [delegate URLRequest:strongOp didReceiveData:data];
+      [delegate URLRequest:strongOp didReceiveData:data]; // [macOS]
     }
-    [delegate URLRequest:strongOp didCompleteWithError:error];
+    [delegate URLRequest:strongOp didCompleteWithError:error]; // [macOS]
   }];
 
   weakOp = op;


### PR DESCRIPTION
## Summary:

Upstreaming a fix by @ntre that fixes a crash we saw internally related to `[_queue cancelAllOperations]`.

>Calling [_queue cancelAllOperations] will release all references to any active operations.
>If the blocks of those operations have a reference to itself, it will result in dangling pointers, which could conceptually trigger a later crash if there's a race between the operation completing and it being pulled out of the queue.
>
>Add explicit strong reference while block is running.
>For good measure, fix same pattern also in RCTFileRequestHandler.
>
>Note: separately, that this code is passing the op itself as a requestToken to [delegate URLRequest:] methods is suspect. That delegate can retain said token.

## Test Plan:

Tested internally. 