### PR TITLE
[0.74-stable] Update deprecated enums in RCTTextPrimitivesConversions.h (#2377)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
@@ -89,9 +89,9 @@ inline static NSUnderlineStyle RCTNSUnderlineStyleFromTextDecorationStyle(
     case facebook::react::TextDecorationStyle::Double:
       return NSUnderlineStyleDouble;
     case facebook::react::TextDecorationStyle::Dashed:
-      return NSUnderlinePatternDash | NSUnderlineStyleSingle;
+      return NSUnderlineStylePatternDash | NSUnderlineStyleSingle; // [macOS]
     case facebook::react::TextDecorationStyle::Dotted:
-      return NSUnderlinePatternDot | NSUnderlineStyleSingle;
+      return NSUnderlineStylePatternDot | NSUnderlineStyleSingle; // [macOS]
   }
 }
 


### PR DESCRIPTION
Backport of #2377