### PR TITLE
fix(macos): <Text> with backgroundColor spills color past it's frame

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -164,7 +164,10 @@ const Text: component(
       // cause the color to spill pass the frame of the Text. We can solve this by setting a dummy
       // value for borderRadius.
       if (Platform.OS === 'macos') {
-        if ('backgroundColor' in processedStyle && !('borderRadius' in processedStyle)) {
+        if (
+          'backgroundColor' in processedStyle &&
+          !('borderRadius' in processedStyle)
+        ) {
           overrides = overrides || ({}: {...TextStyleInternal});
           overrides.borderRadius = Number.MIN_VALUE;
         }

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -159,21 +159,22 @@ const Text: component(
         overrides.verticalAlign = undefined;
       }
 
+      // [macOS
+      // For some reason on macOS, Setting backgroundColor without borderRadius on Text will
+      // cause the color to spill pass the frame of the Text. We can solve this by setting a dummy
+      // value for borderRadius.
+      if (Platform.OS === 'macos') {
+        if ('backgroundColor' in processedStyle && !('borderRadius' in processedStyle)) {
+          overrides = overrides || ({}: {...TextStyleInternal});
+          overrides.borderRadius = Number.MIN_VALUE;
+        }
+      }
+      // macOS]
+
       if (overrides != null) {
         // $FlowFixMe[incompatible-type]
         _style = [_style, overrides];
       }
-
-      // [macOS
-      // For some reason, on macOS, Setting backgroundColor without borderRadius on Text will
-      // cause the color to spill pass the frame of the view. We can solve this by setting a dummy
-      // value for borderRadius.
-      if (Platform.OS === 'macos') {
-        if ('backgroundColor' in _style && !('borderRadius' in _style)) {
-          _style.borderRadius = 0.001;
-        }
-      }
-      // macOS]
     }
 
     const _nativeID = id ?? nativeID;

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -163,6 +163,17 @@ const Text: component(
         // $FlowFixMe[incompatible-type]
         _style = [_style, overrides];
       }
+
+      // [macOS
+      // For some reason, on macOS, Setting backgroundColor without borderRadius on Text will
+      // cause the color to spill pass the frame of the view. We can solve this by setting a dummy
+      // value for borderRadius.
+      if (Platform.OS === 'macos') {
+        if ('backgroundColor' in _style && !('borderRadius' in _style)) {
+          _style.borderRadius = 0.001;
+        }
+      }
+      // macOS]
     }
 
     const _nativeID = id ?? nativeID;


### PR DESCRIPTION
## Summary:

For some odd reason, if you set `backgroundColor` on a Text component, the color spills out past the frame to the parent. We can work around this by setting border radius... which somehow prevents this behavior. I need to debug the native side more (and may update this PR with a proper fix if I find one), but for now let's patch the JS to set a dummy value for borderRadius if we create a Text Element with backgroundColor and without borderRadius

## Test Plan:

A bunch of examples in RNTester are now visible... like the "Recently Viewed" section.

<img width="616" alt="image" src="https://github.com/user-attachments/assets/10ac2e6e-2ee6-4a04-8f96-56c92dcc2e68" />

