### PR TITLE
fix(0.74, macOS): reconcile coordinate systems for mouse events (#2403)

### DIFF
--- a/packages/react-native/React/Base/RCTTouchHandler.m
+++ b/packages/react-native/React/Base/RCTTouchHandler.m
@@ -128,8 +128,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 #else // [macOS
     // -[NSView hitTest:] takes coordinates in a view's superview coordinate system.
     // The assumption here is that a RCTUIView/RCTSurfaceView will always have a superview.
-    CGPoint touchLocation = [self.view.superview convertPoint:touch.locationInWindow fromView:nil];
-    NSView *targetView = [self.view hitTest:touchLocation];
+    NSView *superview = [[self view] superview];
+    const CGPoint touchLocationInSuperview = [superview convertPoint:touch.locationInWindow fromView:nil];
+    NSView *targetView = [self.view hitTest:touchLocationInSuperview];
     // Don't record clicks on scrollbars.
     if ([targetView isKindOfClass:[NSScroller class]]) {
       continue;
@@ -148,8 +149,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     } else {
       _shouldSendMouseUpOnSystemBehalf = NO;
     }
-    touchLocation = [targetView convertPoint:touchLocation fromView:self.view.superview];
-    
+
     while (targetView) {
       BOOL isUserInteractionEnabled = NO;
       if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) { // [macOS]
@@ -161,7 +161,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
       targetView = targetView.superview;
     }
 
-    NSNumber *reactTag = [targetView reactTagAtPoint:touchLocation];
+    const CGPoint touchLocationInSelf = [targetView convertPoint:touchLocationInSuperview fromView:self.view.superview];
+    NSNumber *reactTag = [targetView reactTagAtPoint:touchLocationInSelf];
     BOOL isUserInteractionEnabled = NO;
     if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) { // [macOS]
       isUserInteractionEnabled = ((RCTUIView*)targetView).isUserInteractionEnabled; // [macOS]

--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -489,7 +489,10 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 NS_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, __unused UIEvent *__nullable event)
 {
-  return [view hitTest:point];
+  // [macOS IMPORTANT -- point is in local coordinate space, but OSX expects super coordinate space for hitTest:
+  NSView *superview = [view superview];
+  NSPoint pointInSuperview = superview != nil ? [view convertPoint:point toView:superview] : point;
+  return [view hitTest:pointInSuperview];
 }
 
 BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view);

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -491,7 +491,10 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
 
 - (NSView *)hitTest:(NSPoint)point
 {
-  return [self hitTest:NSPointToCGPoint(point) withEvent:nil];
+  // IMPORTANT point is passed in super coordinates by OSX, but expected to be passed in local coordinates
+  NSView *superview = [self superview];
+  NSPoint pointInSelf = superview != nil ? [self convertPoint:point fromView:superview] : point;
+  return [self hitTest:pointInSelf withEvent:nil];
 }
 
 - (BOOL)wantsUpdateLayer
@@ -542,7 +545,11 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
 
 - (NSView *)hitTest:(CGPoint)point withEvent:(__unused UIEvent *)event
 {
-  return self.userInteractionEnabled ? [super hitTest:NSPointFromCGPoint(point)] : nil;
+// [macOS
+  // IMPORTANT point is expected to be passed in local coordinates, but OSX expects point to be super 
+  NSView *superview = [self superview];
+  NSPoint pointInSuperview = superview != nil ? [self convertPoint:point toView:superview] : point;
+  return self.userInteractionEnabled ? [super hitTest:pointInSuperview] : nil;
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(__unused UIEvent *)event

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -252,17 +252,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     // of the hit view will return YES from -pointInside:withEvent:). See:
     //  - https://developer.apple.com/library/ios/qa/qa2013/qa1812.html
     for (RCTUIView *subview in [sortedSubviews reverseObjectEnumerator]) { // [macOS]
-      CGPoint pointForHitTest = CGPointZero; // [macOS
-#if !TARGET_OS_OSX // [macOS]
-      pointForHitTest = [subview convertPoint:point fromView:self];
-#else // [macOS
-      if ([subview isKindOfClass:[RCTView class]]) {
-        pointForHitTest = [subview convertPoint:point fromView:self];
-      } else {
-        pointForHitTest = point;
-      }
-#endif // macOS]
-      hitSubview = RCTUIViewHitTestWithEvent(subview, pointForHitTest, event); // macOS]
+      CGPoint pointForHitTest = [subview convertPoint:point fromView:self];
+      hitSubview = RCTUIViewHitTestWithEvent(subview, pointForHitTest, event); // [macOS]
       if (hitSubview != nil) {
         break;
       }

--- a/packages/react-native/React/Views/UIView+React.m
+++ b/packages/react-native/React/Views/UIView+React.m
@@ -573,10 +573,13 @@ static __weak RCTPlatformView *_pendingFocusView; // [macOS]
 
 // [macOS
 #pragma mark - Hit testing
-#if TARGET_OS_OSX  
+#if TARGET_OS_OSX
+// IMPORTANT -- point is in local coordinate space, unlike the hitTest: version from OSX which is in super's coordinate space
 - (RCTPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
-  return [self hitTest:point];
+  NSView *superview = [self superview];
+  NSPoint pointInSuper = superview != nil ? [self convertPoint:point toView:superview] : point;
+  return [self hitTest:pointInSuper];
 }
 #endif // macOS]
 


### PR DESCRIPTION
On iOS, [-hitTest:withEvent:](https://developer.apple.com/documentation/uikit/uiview/hittest(_:with:)?changes=la_3_2_7_2_8&language=objc) works with the coordinate system of the view that is being hit tested. On the other hand, on macOS, [-hitTest:](https://developer.apple.com/documentation/appkit/nsview/hittest(_:)?language=objc) works with the coordinate system of the *superview*. React Native macOS currently appears to mix these two coordinate systems, which can lead to unexpected behaviors, one of which that I have personally observed is `mouseDown:` events being delievered to a view that does not pass OS-level hit testing (e.g. the hit point is completely outside of the view that was allegedly hit, even if accounting for not clipping to bounds and any possible descendant view larger than the hit view).

To enforce consistent behavior, we will use the macOS style coordinate system for APIs that follow the macOS signature, and the iOS style coordinate system for APIs that follow the iOS signature, or are obviously React Native APIs. Several APIs were scrubbed for calls and implementation.

The following APIs shall work with superview's coordinate space:
* `- hitTest:`

The following APIs shall work with the view's (i.e. self) coordinate space:
* `RCTUIViewHitTestWithEvent`
* `- reactTagAtMouseLocationFromEvent:`
* `- reactTagAtPoint:`
* `- hitTest:withEvent:`
* `- betterHitTest:withEvent:`
* `- pointInside:withEvent:`

With the proper coordinate system usage, we no longer need new RN components inheriting from NSView to behave in special manners. Updating documentation to reflect that.

Manual Testing:

* Downstream scenario around misrouted mouseDown: events was verified fixed
* Sanity tested mouse clicks -- everything seems to work as expected

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
