### PR TITLE
chore: fix prepublish script inconsistencies

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -15,7 +15,7 @@ steps:
     displayName: Install npm dependencies
 
   - script: |
-      node .ado/scripts/prepublish-check.mjs --tag ${{ parameters['publishTag'] }}
+      node .ado/scripts/prepublish-check.mjs --verbose --tag ${{ parameters['publishTag'] }}
     displayName: Verify release config
 
   - script: |

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -1,6 +1,6 @@
 parameters:
   # If this is a new stable branch, change `publishTag` to `latest` when going stable
-  publishTag: 'next'
+  publishTag: 'nightly'
 
 steps:
   - checkout: self


### PR DESCRIPTION
## Summary:

Addresses inconsistencies in the prepublish script by moving the Azure Pipelines checks after the correct tag has been determined.

## Test Plan:

Ensure tag is correctly set on `main`:

```
~/S/react-native-macos (main) % node .ado/scripts/prepublish-check.mjs --verbose
❌ .ado/templates/npm-publish-steps.yml: 'publishTag' needs to be set to 'nightly'
```

Ensure tag is correctly set for `0.76-stable` (previous):

```
~/S/react-native-macos (0.76-stable) % node .ado/scripts/prepublish-check.mjs --verbose
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 76
ℹ️ Expected npm tag: v0.76-stable
❌ 'release.version.generatorOptions.currentVersionResolverMetadata.tag' must be set to 'v0.76-stable'
❌ Nx Release is not correctly configured for the current branch
```

Ensure tag is correctly set for `0.77-stable` (current):

```
~/S/react-native-macos (0.77-stable) % node .ado/scripts/prepublish-check.mjs --verbose
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 77
ℹ️ Expected npm tag: latest
##vso[task.setvariable variable=publish_react_native_macos]1
```

Ensure tag is correctly set for `0.78-stable` (release candidate):

```
~/S/react-native-macos (0.78-stable) % node .ado/scripts/prepublish-check.mjs --verbose
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 78
ℹ️ Expected npm tag: next
❌ 'defaultBase' must be set to '0.78-stable'
❌ 'release.version.generatorOptions.preid' must be set to 'rc'
❌ 'release.version.generatorOptions.currentVersionResolverMetadata.tag' must be set to 'next'
❌ Nx Release is not correctly configured for the current branch
```

Update config for `0.78-stable` (release candidate):

```
~/S/react-native-macos (0.78-stable) % node .ado/scripts/prepublish-check.mjs --update
❌ 'defaultBase' must be set to '0.78-stable'
❌ 'release.version.generatorOptions.preid' must be set to 'rc'
❌ 'release.version.generatorOptions.currentVersionResolverMetadata.tag' must be set to 'next'

~/S/react-native-macos (0.78-stable) [1]% node .ado/scripts/prepublish-check.mjs --verbose
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 78
ℹ️ Expected npm tag: next
❌ .ado/templates/npm-publish-steps.yml: 'publishTag' needs to be set to 'next'
```

Mark `0.78-stable` stable:

```
~/S/react-native-macos (0.78-stable) % node .ado/scripts/prepublish-check.mjs --verbose --tag latest --update
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 78
ℹ️ Expected npm tag: latest
❌ 'defaultBase' must be set to '0.78-stable'

~/S/react-native-macos (0.78-stable) [1]% node .ado/scripts/prepublish-check.mjs --verbose --tag latest
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 78
ℹ️ Expected npm tag: latest
##vso[task.setvariable variable=publish_react_native_macos]1
```