### PR TITLE
chore: use fallback resolver for new tags

### DIFF
--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -9,10 +9,20 @@ const NX_CONFIG_FILE = "nx.json";
 const NPM_TAG_NEXT = "next";
 const NPM_TAG_NIGHTLY = "nightly";
 const RNMACOS_LATEST = "react-native-macos@latest";
+const RNMACOS_NEXT = "react-native-macos@next";
 
 /**
- * @typedef {typeof import("../../nx.json")} NxConfig
- * @typedef {{ tag?: string; update?: boolean; verbose?: boolean; }} Options
+ * @typedef {import("nx/src/command-line/release/version").ReleaseVersionGeneratorSchema} ReleaseVersionGeneratorSchema;
+ * @typedef {{
+ *   defaultBase: string;
+ *   release: {
+ *     version: {
+ *       generatorOptions: ReleaseVersionGeneratorSchema;
+ *     };
+ *   };
+ * }} NxConfig;
+ * @typedef {{ tag?: string; update?: boolean; verbose?: boolean; }} Options;
+ * @typedef {{ npmTag: string; prerelease?: string; isNewTag?: boolean; }} TagInfo;
  */
 
 /**
@@ -100,10 +110,11 @@ function getCurrentBranch() {
 
 /**
  * Returns the latest published version of `react-native-macos` from npm.
+ * @param {"latest" | "next"} tag
  * @returns {number}
  */
-function getLatestVersion() {
-  const { stdout } = spawnSync("npm", ["view", RNMACOS_LATEST, "version"]);
+function getPublishedVersion(tag) {
+  const { stdout } = spawnSync("npm", ["view", `react-native-macos@${tag}`, "version"]);
   return versionToNumber(stdout.toString().trim());
 }
 
@@ -118,14 +129,14 @@ function getLatestVersion() {
  * @param {string} branch
  * @param {Options} options
  * @param {typeof info} log
- * @returns {{ npmTag: string; prerelease?: string; }}
+ * @returns {TagInfo}
  */
 function getTagForStableBranch(branch, { tag }, log) {
   if (!isStableBranch(branch)) {
     throw new Error("Expected a stable branch");
   }
 
-  const latestVersion = getLatestVersion();
+  const latestVersion = getPublishedVersion("latest");
   const currentVersion = versionToNumber(branch);
 
   log(`${RNMACOS_LATEST}: ${latestVersion}`);
@@ -138,11 +149,13 @@ function getTagForStableBranch(branch, { tag }, log) {
     return { npmTag };
   }
 
-  // Patching an older stable version
+  // Demoting or patching an older stable version
   if (currentVersion < latestVersion) {
     const npmTag = "v" + branch;
     log(`Expected npm tag: ${npmTag}`);
-    return { npmTag };
+    // If we're demoting a branch, we will need to create a new tag that will
+    // not available in any npm feed
+    return { npmTag, isNewTag: true };
   }
 
   // Publishing a new latest version
@@ -152,7 +165,14 @@ function getTagForStableBranch(branch, { tag }, log) {
   }
 
   // Publishing a release candidate
+  const nextVersion = getPublishedVersion("next");
+  log(`${RNMACOS_NEXT}: ${nextVersion}`);
   log(`Expected npm tag: ${NPM_TAG_NEXT}`);
+
+  if (currentVersion < nextVersion) {
+    throw new Error(`Current version cannot be a release candidate because it is too old: ${currentVersion} < ${nextVersion}`);
+  }
+
   return { npmTag: NPM_TAG_NEXT, prerelease: "rc" };
 }
 
@@ -169,7 +189,7 @@ function verifyPublishPipeline(file, tag) {
   }
 
   if (m[1] !== tag) {
-    throw new Error(`${file}: 'publishTag' needs to be set to '${tag}'`);
+    throw new Error(`${file}: 'publishTag' must be set to '${tag}'`);
   }
 }
 
@@ -177,11 +197,10 @@ function verifyPublishPipeline(file, tag) {
  * Verifies the configuration and enables publishing on CI.
  * @param {NxConfig} config
  * @param {string} currentBranch
- * @param {string} tag
- * @param {string} [prerelease]
+ * @param {TagInfo} tag
  * @returns {asserts config is NxConfig["release"]}
  */
-function enablePublishing(config, currentBranch, tag, prerelease) {
+function enablePublishing(config, currentBranch, { npmTag: tag, prerelease, isNewTag }) {
   /** @type {string[]} */
   const errors = [];
 
@@ -196,21 +215,32 @@ function enablePublishing(config, currentBranch, tag, prerelease) {
   }
 
   // Determines whether we need to add "nightly" or "rc" to the version string.
-  const { currentVersionResolverMetadata, preid } = release.version.generatorOptions;
-  if (preid !== prerelease) {
+  const { generatorOptions } = release.version;
+  if (generatorOptions.preid !== prerelease) {
     errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease || ""}'`);
     if (prerelease) {
-      release.version.generatorOptions.preid = prerelease;
+      generatorOptions.preid = prerelease;
     } else {
-      // @ts-expect-error `preid` is optional
-      release.version.generatorOptions.preid = undefined;
+      generatorOptions.preid = undefined;
     }
   }
 
   // What the published version should be tagged as e.g., "latest" or "nightly".
-  if (currentVersionResolverMetadata.tag !== tag) {
+  const { currentVersionResolverMetadata } = generatorOptions;
+  if (currentVersionResolverMetadata?.tag !== tag) {
     errors.push(`'release.version.generatorOptions.currentVersionResolverMetadata.tag' must be set to '${tag}'`);
-    release.version.generatorOptions.currentVersionResolverMetadata.tag = tag;
+    generatorOptions.currentVersionResolverMetadata ??= {};
+    generatorOptions.currentVersionResolverMetadata.tag = tag;
+  }
+
+  if (isNewTag) {
+    if (generatorOptions.fallbackCurrentVersionResolver !== "disk") {
+      errors.push("'release.version.generatorOptions.fallbackCurrentVersionResolver' must be set to 'disk'");
+      generatorOptions.fallbackCurrentVersionResolver = "disk";
+    }
+  } else if (typeof generatorOptions.fallbackCurrentVersionResolver === "string") {
+    errors.push("'release.version.generatorOptions.fallbackCurrentVersionResolver' must be unset");
+    generatorOptions.fallbackCurrentVersionResolver = undefined;
   }
 
   if (errors.length > 0) {
@@ -238,10 +268,10 @@ function main(options) {
   const config = loadNxConfig(NX_CONFIG_FILE);
   try {
     if (isMainBranch(branch)) {
-      enablePublishing(config, branch, NPM_TAG_NIGHTLY, NPM_TAG_NIGHTLY);
+      enablePublishing(config, branch, { npmTag: NPM_TAG_NIGHTLY, prerelease: NPM_TAG_NIGHTLY });
     } else if (isStableBranch(branch)) {
-      const { npmTag, prerelease } = getTagForStableBranch(branch, options, logger);
-      enablePublishing(config, branch, npmTag, prerelease);
+      const tag = getTagForStableBranch(branch, options, logger);
+      enablePublishing(config, branch, tag);
     }
   } catch (e) {
     if (options.update) {


### PR DESCRIPTION
## Summary:

When demoting a stable branch, we need to create a new tag. Nx won't be able to find it on npm and should have a fallback. For all other branches, we don't want to use the fallback in case something fails.

## Test Plan:

`main`:

```
~/S/react-native-macos (main) % node .ado/scripts/prepublish-check.mjs --verbose
##vso[task.setvariable variable=publish_react_native_macos]1
```

`0.76-stable`:

```
~/S/react-native-macos (0.76-stable) % node .ado/scripts/prepublish-check.mjs --verbose
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 76
ℹ️ Expected npm tag: v0.76-stable
❌ 'release.version.generatorOptions.currentVersionResolverMetadata.tag' must be set to 'v0.76-stable'
❌ 'release.version.generatorOptions.fallbackCurrentVersionResolver' must be set to 'disk'
❌ Nx Release is not correctly configured for the current branch
```

`0.77-stable`:

```
~/S/react-native-macos (0.77-stable) % node .ado/scripts/prepublish-check.mjs --verbose
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 77
ℹ️ Expected npm tag: latest
❌ 'release.version.generatorOptions.fallbackCurrentVersionResolver' must be unset
❌ Nx Release is not correctly configured for the current branch
```

`0.78-stable`:

```
~/S/react-native-macos (0.78-stable) % node .ado/scripts/prepublish-check.mjs --verbose
ℹ️ react-native-macos@latest: 77
ℹ️ Current version: 78
ℹ️ react-native-macos@next: 76
ℹ️ Expected npm tag: next
❌ 'defaultBase' must be set to '0.78-stable'
❌ 'release.version.generatorOptions.preid' must be set to 'rc'
❌ 'release.version.generatorOptions.currentVersionResolverMetadata.tag' must be set to 'next'
❌ 'release.version.generatorOptions.fallbackCurrentVersionResolver' must be unset
❌ Nx Release is not correctly configured for the current branch
```