### PR TITLE
ci: introduce `release.mjs` script

### DIFF
--- a/.ado/scripts/release.mjs
+++ b/.ado/scripts/release.mjs
@@ -1,0 +1,62 @@
+import { releaseChangelog, releasePublish, releaseVersion } from 'nx/release/index.js';
+
+import { spawnSync } from "node:child_process";
+import * as util from "node:util";
+// import {updateReactNativeArtifacts} from '../../releases/set-rn-artifacts-version.js';
+
+async function main(options) {
+    const { workspaceVersion, projectsVersionData } = await releaseVersion({
+        specifier: options.version,
+        dryRun: true,
+        verbose: options.verbose,
+    });
+
+    const newRNMVersion = projectsVersionData["react-native-macos"].newVersion;
+    spawnSync("node", ["scripts/releases/set-rn-artifacts-version.js", "--build-type", "release", "--to-version", newRNMVersion], { encoding: "utf-8" });
+    spawnSync("git", ["add", 
+      "packages/react-native/Libraries/Core/ReactNativeVersion.js",
+      "packages/react-native/React/Base/RCTVersion.m",
+      "packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h",
+      "packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java",
+      "packages/react-native/ReactAndroid/gradle.properties"
+    ], { encoding: "utf-8" });
+
+  
+    // await releaseChangelog({
+    //     versionData: projectsVersionData,
+    //     version: workspaceVersion,
+    //     dryRun: true,
+    //     verbose: options.verbose,
+    // });
+
+    // // publishResults contains a map of project names and their exit codes
+    // const publishResults = await releasePublish({
+    //     dryRun: true,
+    //     verbose: options.verbose,
+    // });
+    
+    // process.exit(
+    //     Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1
+    // );
+}
+
+const { values } = util.parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    version: {
+      type: "string",
+    },
+    'dry-run': {
+      type: "boolean",
+      short: "d",
+      default: false,
+    },
+    verbose: {
+      type: "boolean",
+      default: false,
+    },
+  },
+  strict: true,
+});
+
+main(values);

--- a/.ado/scripts/release.mjs
+++ b/.ado/scripts/release.mjs
@@ -2,12 +2,11 @@ import { releaseChangelog, releasePublish, releaseVersion } from 'nx/release/ind
 
 import { spawnSync } from "node:child_process";
 import * as util from "node:util";
-// import {updateReactNativeArtifacts} from '../../releases/set-rn-artifacts-version.js';
 
 async function main(options) {
     const { workspaceVersion, projectsVersionData } = await releaseVersion({
         specifier: options.version,
-        dryRun: true,
+        dryRun: options["dry-run"],
         verbose: options.verbose,
     });
 
@@ -22,22 +21,22 @@ async function main(options) {
     ], { encoding: "utf-8" });
 
   
-    // await releaseChangelog({
-    //     versionData: projectsVersionData,
-    //     version: workspaceVersion,
-    //     dryRun: true,
-    //     verbose: options.verbose,
-    // });
+    await releaseChangelog({
+        versionData: projectsVersionData,
+        version: workspaceVersion,
+        dryRun: options["dry-run"],
+        verbose: options.verbose,
+    });
 
-    // // publishResults contains a map of project names and their exit codes
-    // const publishResults = await releasePublish({
-    //     dryRun: true,
-    //     verbose: options.verbose,
-    // });
+    // publishResults contains a map of project names and their exit codes
+    const publishResults = await releasePublish({
+        dryRun: options["dry-run"],
+        verbose: options.verbose,
+    });
     
-    // process.exit(
-    //     Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1
-    // );
+    process.exit(
+        Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1
+    );
 }
 
 const { values } = util.parseArgs({

--- a/.ado/scripts/release.mjs
+++ b/.ado/scripts/release.mjs
@@ -10,33 +10,44 @@ async function main(options) {
         verbose: options.verbose,
     });
 
-    const newRNMVersion = projectsVersionData["react-native-macos"].newVersion;
-    spawnSync("node", ["scripts/releases/set-rn-artifacts-version.js", "--build-type", "release", "--to-version", newRNMVersion], { encoding: "utf-8" });
-    spawnSync("git", ["add", 
-      "packages/react-native/Libraries/Core/ReactNativeVersion.js",
-      "packages/react-native/React/Base/RCTVersion.m",
-      "packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h",
-      "packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java",
-      "packages/react-native/ReactAndroid/gradle.properties"
-    ], { encoding: "utf-8" });
+    console.log("hit 1");
+    console.log(projectsVersionData["react-native-macos"]);
 
-  
-    await releaseChangelog({
+    const newRNMVersion = projectsVersionData["react-native-macos"].newVersion;
+
+    if (newRNMVersion) {
+      spawnSync("node", ["scripts/releases/set-rn-artifacts-version.js", "--build-type", "release", "--to-version", newRNMVersion], { encoding: "utf-8" });
+      spawnSync("git", ["add", 
+        "packages/react-native/Libraries/Core/ReactNativeVersion.js",
+        "packages/react-native/React/Base/RCTVersion.m",
+        "packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h",
+        "packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java",
+        "packages/react-native/ReactAndroid/gradle.properties"
+      ], { encoding: "utf-8" });
+
+      console.log("hit 2");
+
+      await releaseChangelog({
         versionData: projectsVersionData,
         version: workspaceVersion,
         dryRun: options["dry-run"],
         verbose: options.verbose,
-    });
+      });
 
-    // publishResults contains a map of project names and their exit codes
-    const publishResults = await releasePublish({
+      console.log("hit 3");
+
+      // publishResults contains a map of project names and their exit codes
+      const publishResults = await releasePublish({
         dryRun: options["dry-run"],
         verbose: options.verbose,
-    });
-    
-    process.exit(
-        Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1
-    );
+       });
+  
+      console.log("hit 3");
+
+      process.exit(
+          Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1
+      );
+    }
 }
 
 const { values } = util.parseArgs({

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -1,6 +1,12 @@
 parameters:
   # If this is a new stable branch, change `publishTag` to `latest` when going stable
   publishTag: 'nightly'
+  dryRun: false
+
+variables:
+  - template: /.ado/variables/vars.yml@self
+  - name: dryRun
+    value: 'true'
 
 steps:
   - checkout: self
@@ -20,14 +26,16 @@ steps:
 
   - script: |
       echo Target branch: $(System.PullRequest.TargetBranch)
-      yarn nx release --dry-run --verbose
+      # yarn nx release --dry-run --verbose
+      node .ado/scripts/release.mjs --dry-run --verbose
     displayName: Version and publish packages (dry run)
     condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 
   - script: |
       git switch $(Build.SourceBranchName)
-      yarn nx release --skip-publish --verbose
-      yarn nx release publish --excludeTaskDependencies
+      # yarn nx release --skip-publish --verbose
+      # yarn nx release publish --excludeTaskDependencies
+      node .ado/scripts/release.mjs --dry-run --verbose
     env:
       GITHUB_TOKEN: $(githubAuthToken)
       NODE_AUTH_TOKEN: $(npmAuthToken)

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -1,12 +1,6 @@
 parameters:
   # If this is a new stable branch, change `publishTag` to `latest` when going stable
   publishTag: 'nightly'
-  dryRun: false
-
-variables:
-  - template: /.ado/variables/vars.yml@self
-  - name: dryRun
-    value: 'true'
 
 steps:
   - checkout: self

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -27,15 +27,15 @@
     "e2e-test-ios": "./scripts/maestro-test-ios.sh"
   },
   "dependencies": {
-    "@react-native/oss-library-example": "workspace:*",
-    "@react-native/popup-menu-android": "workspace:*",
+    "@react-native/oss-library-example": "0.77.0-main",
+    "@react-native/popup-menu-android": "0.77.0-main",
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",
     "nullthrows": "^1.1.1"
   },
   "peerDependencies": {
     "react": "18.3.1",
-    "react-native-macos": "workspace:*"
+    "react-native-macos": "0.77.0-main"
   },
   "codegenConfig": {
     "name": "AppSpecs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3039,7 +3039,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@npm:0.77.0-main, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
@@ -3052,7 +3052,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/popup-menu-android@workspace:*, @react-native/popup-menu-android@workspace:packages/react-native-popup-menu-android":
+"@react-native/popup-menu-android@npm:0.77.0-main, @react-native/popup-menu-android@workspace:packages/react-native-popup-menu-android":
   version: 0.0.0-use.local
   resolution: "@react-native/popup-menu-android@workspace:packages/react-native-popup-menu-android"
   dependencies:
@@ -3088,14 +3088,14 @@ __metadata:
     "@react-native-community/cli": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-android": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-ios": "npm:15.0.0-alpha.2"
-    "@react-native/oss-library-example": "workspace:*"
-    "@react-native/popup-menu-android": "workspace:*"
+    "@react-native/oss-library-example": "npm:0.77.0-main"
+    "@react-native/popup-menu-android": "npm:0.77.0-main"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
     react: 18.3.1
-    react-native-macos: "workspace:*"
+    react-native-macos: 0.77.0-main
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary:

We want to be able to use `nx release` in ways we cannot with just the standard workflow with a static config. Namely:

I want to use the version resolver / bumper from nx, get the new version (let's say `0.76.6` for this example), then before publish, run `scripts/releases/set-rn-artifacts-version.js` so that we can bump files like `ReactNativeVersion.h` as part of our upgrade. The only way I could think of using `nx` to both get the version and commit the files was to use the programmatic API.

## Test Plan

Testing against the `0.76-stable` branch

