### PR TITLE
chore(0.77): add post-version step to Nx Release (#2418)

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -23,6 +23,7 @@
     "projectsRelationship": "independent",
     "versionPlans": true,
     "version": {
+      "generator": "@react-native-mac/nx-release-version:release-version",
       "generatorOptions": {
         "currentVersionResolver": "registry",
         "currentVersionResolverMetadata": {

--- a/packages/nx-release-version/generators.json
+++ b/packages/nx-release-version/generators.json
@@ -1,0 +1,12 @@
+{
+  "name": "@react-native-macos/nx-release-version",
+  "version": "0.0.1",
+  "generators": {
+    "release-version": {
+      "factory": "./index.js",
+      "schema": "./schema.json",
+      "description": "DO NOT INVOKE DIRECTLY WITH `nx generate`. Use `nx release version` instead.",
+      "hidden": true
+    }
+  }
+}

--- a/packages/nx-release-version/index.js
+++ b/packages/nx-release-version/index.js
@@ -1,0 +1,83 @@
+// @ts-check
+
+const { releaseVersionGenerator } = require('@nx/js/src/generators/release-version/release-version');
+const fs = require('node:fs');
+const path = require('node:path');
+
+async function runSetVersion() {
+  const rnmPkgJson = require.resolve('react-native-macos/package.json');
+  const { REPO_ROOT } = require('../../scripts/consts');
+  const { updateReactNativeArtifacts } = require('../../scripts/releases/set-rn-artifacts-version');
+
+  const manifest = fs.readFileSync(rnmPkgJson, { encoding: 'utf-8' });
+  const { version } = JSON.parse(manifest);
+
+  await updateReactNativeArtifacts(version);
+
+  return [
+    path.join(
+      REPO_ROOT,
+      'packages',
+      'react-native',
+      'ReactAndroid',
+      'gradle.properties',
+    ),
+    path.join(
+      REPO_ROOT,
+      'packages',
+      'react-native',
+      'ReactAndroid',
+      'src',
+      'main',
+      'java',
+      'com',
+      'facebook',
+      'react',
+      'modules',
+      'systeminfo',
+      'ReactNativeVersion.java',
+    ),
+    path.join(REPO_ROOT,
+      'packages',
+      'react-native',
+      'React',
+      'Base',
+      'RCTVersion.m',
+    ),
+    path.join(
+      REPO_ROOT,
+      'packages',
+      'react-native',
+      'ReactCommon',
+      'cxxreact',
+      'ReactNativeVersion.h',
+    ),
+    path.join(
+      REPO_ROOT,
+      'packages',
+      'react-native',
+      'Libraries',
+      'Core',
+      'ReactNativeVersion.js',
+    ),
+  ];
+}
+
+/** @type {typeof releaseVersionGenerator} */
+module.exports = async function(tree, options) {
+  const { data, callback } = await releaseVersionGenerator(tree, options);
+  return {
+    data,
+    callback: async (tree, options) => {
+      const result = await callback(tree, options);
+
+      const versionedFiles = await runSetVersion();
+      if (versionedFiles) {
+        const changedFiles = Array.isArray(result) ? result : result.changedFiles;
+        changedFiles.push(...versionedFiles);
+      }
+
+      return result;
+    },
+  };
+};

--- a/packages/nx-release-version/package.json
+++ b/packages/nx-release-version/package.json
@@ -1,0 +1,30 @@
+{
+  "private": true,
+  "name": "@react-native-mac/nx-release-version",
+  "version": "0.0.1-dev",
+  "description": "Nx Release plugin that adds post-versioning logic",
+  "homepage": "https://github.com/microsoft/react-native-macos/tree/HEAD/packages/nx-release-version#readme",
+  "license": "MIT",
+  "files": [
+    "generators.json",
+    "index.js",
+    "schema.json"
+  ],
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/react-native-macos.git",
+    "directory": "packages/nx-release-version"
+  },
+  "dependencies": {
+    "@nx/js": "~20.0.0"
+  },
+  "devDependencies": {
+    "@rnx-kit/tsconfig": "^2.0.0",
+    "typescript": "^5.6.3"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "generators": "./generators.json"
+}

--- a/packages/nx-release-version/schema.json
+++ b/packages/nx-release-version/schema.json
@@ -1,0 +1,68 @@
+
+{
+  "$schema": "https://json-schema.org/schema",
+  "$id": "NxJSReleaseVersionGeneratorCopy",
+  "cli": "nx",
+  "title": "Implementation details of `nx release version`",
+  "description": "DO NOT INVOKE DIRECTLY WITH `nx generate`. Use `nx release version` instead.",
+  "type": "object",
+  "properties": {
+    "projects": {
+      "type": "array",
+      "description": "The ProjectGraphProjectNodes being versioned in the current execution.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "projectGraph": {
+      "type": "object",
+      "description": "ProjectGraph instance"
+    },
+    "specifier": {
+      "type": "string",
+      "description": "Exact version or semver keyword to apply to the selected release group. Overrides specifierSource."
+    },
+    "releaseGroup": {
+      "type": "object",
+      "description": "The resolved release group configuration, including name, relevant to all projects in the current execution."
+    },
+    "specifierSource": {
+      "type": "string",
+      "default": "prompt",
+      "description": "Which approach to use to determine the semver specifier used to bump the version of the project.",
+      "enum": ["prompt", "conventional-commits", "version-plans"]
+    },
+    "preid": {
+      "type": "string",
+      "description": "The optional prerelease identifier to apply to the version, in the case that the specifier argument has been set to prerelease."
+    },
+    "packageRoot": {
+      "type": "string",
+      "description": "The root directory of the directory (containing a manifest file at its root) to publish. Defaults to the project root"
+    },
+    "currentVersionResolver": {
+      "type": "string",
+      "default": "disk",
+      "description": "Which approach to use to determine the current version of the project.",
+      "enum": ["registry", "disk", "git-tag"]
+    },
+    "currentVersionResolverMetadata": {
+      "type": "object",
+      "description": "Additional metadata to pass to the current version resolver.",
+      "default": {}
+    },
+    "skipLockFileUpdate": {
+      "type": "boolean",
+      "description": "Whether to skip updating the lock file after updating the version."
+    },
+    "installArgs": {
+      "type": "string",
+      "description": "Additional arguments to pass to the package manager when updating the lock file with an install command."
+    },
+    "installIgnoreScripts": {
+      "type": "boolean",
+      "description": "Whether to ignore install lifecycle scripts when updating the lock file with an install command."
+    }
+  },
+  "required": ["projects", "projectGraph", "releaseGroup"]
+}

--- a/packages/nx-release-version/tsconfig.json
+++ b/packages/nx-release-version/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rnx-kit/tsconfig/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["index.js"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,6 +2743,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@react-native-mac/nx-release-version@workspace:packages/nx-release-version":
+  version: 0.0.0-use.local
+  resolution: "@react-native-mac/nx-release-version@workspace:packages/nx-release-version"
+  dependencies:
+    "@nx/js": "npm:~20.0.0"
+    "@rnx-kit/tsconfig": "npm:^2.0.0"
+    typescript: "npm:^5.6.3"
+  languageName: unknown
+  linkType: soft
+
 "@react-native-mac/virtualized-lists@npm:0.77.0, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"


### PR DESCRIPTION
Adds a post-version step to Nx Release for updating generated artifacts (e.g., `RCTVersion.m`).

Bump the version and run `nx release`:

```
yarn nx release plan --only-touched=false patch
yarn nx release --skip-publish --verbose
```

Verify that generated artifacts have been updated with the latest version number.

---------

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
