### PR TITLE
ci: setup npm authentication for publish

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -26,8 +26,10 @@ steps:
 
   - script: |
       git switch $(Build.SourceBranchName)
+      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
       yarn nx release --skip-publish --verbose
       yarn nx release publish --excludeTaskDependencies
+      rm ~/.npmrc
     env:
       GITHUB_TOKEN: $(githubAuthToken)
       NODE_AUTH_TOKEN: $(npmAuthToken)


### PR DESCRIPTION
## Summary:

`nx release` requires a `.npmrc` file. Let's create one with our NPM auth token, and remove it after we finish publishing out of an abundance of caution.

## Test Plan:

Change is already in 0.76-stable and 0.77-stable. For whatever reason, it works on 0.76 and not on 0.77