### PR TITLE
chore(0.77): don't set the new architecture by default for macOS yet

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -407,7 +407,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         assert_false(is_enabled)
     end
 
-    def test_newArchEnabled_whenRCTNewArchEnabledIsNotSet_returnFalse
+    def test_newArchEnabled_whenRCTNewArchEnabledIsNotSet_returnFalse  # [macOS] Disable Fabric by default till macOS supports it]
         ENV["RCT_NEW_ARCH_ENABLED"] = nil
         is_enabled = NewArchitectureHelper.new_arch_enabled
         assert_false(is_enabled)

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -407,10 +407,10 @@ class NewArchitectureTests < Test::Unit::TestCase
         assert_false(is_enabled)
     end
 
-    def test_newArchEnabled_whenRCTNewArchEnabledIsNotSet_returnTrue
+    def test_newArchEnabled_whenRCTNewArchEnabledIsNotSet_returnFalse
         ENV["RCT_NEW_ARCH_ENABLED"] = nil
         is_enabled = NewArchitectureHelper.new_arch_enabled
-        assert_true(is_enabled)
+        assert_false(is_enabled)
     end
 
 

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -189,6 +189,6 @@ class NewArchitectureHelper
     end
 
     def self.new_arch_enabled
-        return ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+        return ENV["RCT_NEW_ARCH_ENABLED"] == "1" # [macOS] Disable Fabric by default till macOS supports it
     end
 end

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -189,6 +189,6 @@ class NewArchitectureHelper
     end
 
     def self.new_arch_enabled
-        return ENV["RCT_NEW_ARCH_ENABLED"] == nil || ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+        return ENV["RCT_NEW_ARCH_ENABLED"] == "1"
     end
 end


### PR DESCRIPTION
## Summary:

Backport of #2423 
This reverts commit b9f3186ee6314f56863c05272640d47643709a39.

The new architecture isn't ready on macOS yet. Specifically, the Fabric renderer isn't ready. This is causing issue for new projects off the macOS template. Let's disable it until we're ready.
## Test Plan:

CI should pass
