### PR TITLE
ci: update `yarn.lock` as part of nx release

### DIFF
--- a/packages/nx-release-version/index.js
+++ b/packages/nx-release-version/index.js
@@ -3,6 +3,7 @@
 const { releaseVersionGenerator } = require('@nx/js/src/generators/release-version/release-version');
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 async function runSetVersion() {
   const rnmPkgJson = require.resolve('react-native-macos/package.json');
@@ -13,6 +14,8 @@ async function runSetVersion() {
   const { version } = JSON.parse(manifest);
 
   await updateReactNativeArtifacts(version);
+
+  spawnSync('yarn', ['install']);
 
   return [
     path.join(
@@ -59,6 +62,10 @@ async function runSetVersion() {
       'Libraries',
       'Core',
       'ReactNativeVersion.js',
+    ),
+    path.join(
+      REPO_ROOT,
+      'yarn.lock',
     ),
   ];
 }

--- a/packages/nx-release-version/index.js
+++ b/packages/nx-release-version/index.js
@@ -15,7 +15,7 @@ async function runSetVersion() {
 
   await updateReactNativeArtifacts(version);
 
-  spawnSync('yarn', ['install']);
+  spawnSync('yarn', ['install', '--mode', 'update-lockfile']);
 
   return [
     path.join(


### PR DESCRIPTION
## Summary:

`nx release` will bump local packages that are referenced in our lock file, thus invalidating the lock file till we run `yarn install` again. Let's run `yarn install` as part of our generator

## Test Plan:

Tested by cherry picking this commit to a local `0.77-stable` branch, creating a version plan, and running `nx release --dry-run`. `yarn install` was run.
