### PR TITLE
ci(0.76): update `yarn.lock` as part of nx release (#2426)

### DIFF
--- a/packages/nx-release-version/index.js
+++ b/packages/nx-release-version/index.js
@@ -3,6 +3,7 @@
 const { releaseVersionGenerator } = require('@nx/js/src/generators/release-version/release-version');
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 async function runSetVersion() {
   const rnmPkgJson = require.resolve('react-native-macos/package.json');
@@ -13,6 +14,8 @@ async function runSetVersion() {
   const { version } = JSON.parse(manifest);
 
   await updateReactNativeArtifacts(version);
+
+  spawnSync('yarn', ['install', '--mode', 'update-lockfile']);
 
   return [
     path.join(
@@ -59,6 +62,10 @@ async function runSetVersion() {
       'Libraries',
       'Core',
       'ReactNativeVersion.js',
+    ),
+    path.join(
+      REPO_ROOT,
+      'yarn.lock',
     ),
   ];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3318,7 +3318,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.76.5, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.76.6, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -3643,13 +3643,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@npm:0.76.11, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "npm:0.76.7"
-    react-native-macos: "npm:0.76.6"
+    react-native-macos: "npm:0.76.7"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -3693,7 +3693,7 @@ __metadata:
     "@react-native-community/cli-platform-android": "npm:15.0.1"
     "@react-native-community/cli-platform-apple": "npm:15.0.1"
     "@react-native-community/cli-platform-ios": "npm:15.0.1"
-    "@react-native/oss-library-example": "workspace:*"
+    "@react-native/oss-library-example": "npm:0.76.11"
     "@react-native/popup-menu-android": "workspace:*"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -12083,12 +12083,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@npm:0.76.6, react-native-macos@workspace:packages/react-native":
+"react-native-macos@npm:0.76.7, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "npm:0.76.5"
+    "@react-native-mac/virtualized-lists": "npm:0.76.6"
     "@react-native/assets-registry": "npm:0.76.7"
     "@react-native/codegen": "npm:0.76.7"
     "@react-native/community-cli-plugin": "npm:0.76.7"


### PR DESCRIPTION
Backport of #2426 

## Summary:

`nx release` will bump local packages that are referenced in our lock file, thus invalidating the lock file till we run `yarn install` again. Let's run `yarn install` as part of our generator

## Test Plan:

Tested by cherry picking this commit to a local `0.77-stable` branch, creating a version plan, and running `nx release --dry-run`. `yarn install` was run.

---------

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
