### PR TITLE
ci: update preid check in prepublish.mjs

### DIFF
--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -217,7 +217,7 @@ function enablePublishing(config, currentBranch, { npmTag: tag, prerelease, isNe
 
   // Determines whether we need to add "nightly" or "rc" to the version string.
   const { generatorOptions } = release.version;
-  if (generatorOptions.preid !== prerelease) {
+  if (prerelease && generatorOptions.preid !== prerelease) {
     errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease || ""}'`);
     if (prerelease) {
       generatorOptions.preid = prerelease;

--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -216,6 +216,7 @@ function enablePublishing(config, currentBranch, { npmTag: tag, prerelease, isNe
   }
 
   // Determines whether we need to add "nightly" or "rc" to the version string.
+  const { generatorOptions } = release.version;
   if (generatorOptions.preid !== prerelease) {
     if (prerelease) {
       errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease}'`);

--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -216,12 +216,12 @@ function enablePublishing(config, currentBranch, { npmTag: tag, prerelease, isNe
   }
 
   // Determines whether we need to add "nightly" or "rc" to the version string.
-  const { generatorOptions } = release.version;
-  if (prerelease && generatorOptions.preid !== prerelease) {
-    errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease || ""}'`);
+  if (generatorOptions.preid !== prerelease) {
     if (prerelease) {
+      errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease}'`);
       generatorOptions.preid = prerelease;
     } else {
+      errors.push(`'release.version.generatorOptions.preid' must be removed`);
       generatorOptions.preid = undefined;
     }
   }


### PR DESCRIPTION
## Summary:

`prerelease` can be `undefined` while `generatorOptions.preid` is an empty string. Update the check to handle that

## Test Plan:

CI should pass
