### PR TITLE
ci(0.78): update prepublish check to check prerelease existence

### DIFF
--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -217,7 +217,7 @@ function enablePublishing(config, currentBranch, { npmTag: tag, prerelease, isNe
 
   // Determines whether we need to add "nightly" or "rc" to the version string.
   const { generatorOptions } = release.version;
-  if (generatorOptions.preid !== prerelease) {
+  if (prerelease && generatorOptions.preid !== prerelease) {
     errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease || ""}'`);
     if (prerelease) {
       generatorOptions.preid = prerelease;


### PR DESCRIPTION
## Summary:

`prerelease` can be `undefined` while `generatorOptions.preid` is an empty string. Update the check to handle that

## Test Plan:

CI should pass
