### PR TITLE
ci: properly pass NPM auth token secret to script

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -33,7 +33,7 @@ steps:
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
   - script: |
-      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
+      echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
       yarn nx release publish --excludeTaskDependencies
     env:
       NODE_AUTH_TOKEN: $(npmAuthToken)

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -33,10 +33,8 @@ steps:
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
   - script: |
-      echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
+      echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
       yarn nx release publish --excludeTaskDependencies
-    env:
-      NODE_AUTH_TOKEN: $(npmAuthToken)
     displayName: Publish packages
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -26,7 +26,6 @@ steps:
 
   - script: |
       git switch $(Build.SourceBranchName)
-      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
       yarn nx release --skip-publish --verbose
     env:
       GITHUB_TOKEN: $(githubAuthToken)


### PR DESCRIPTION
## Summary:

I noticed NPM publish failing still. My guess is the second addition of this line to our `.npmrc` is messing it up

## Test Plan:

Testing on 0.78 release.
