### PR TITLE
ci(0.78): Don't add NPM auth token to npmrc twice

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -26,7 +26,6 @@ steps:
 
   - script: |
       git switch $(Build.SourceBranchName)
-      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
       yarn nx release --skip-publish --verbose
     env:
       GITHUB_TOKEN: $(githubAuthToken)


### PR DESCRIPTION
## Summary:

I noticed NPM publish failing still. My guess is the second addition of this line to our `.npmrc` is messing it up

## Test Plan:

Testing on 0.78 release.
