### PR TITLE
fix(0.78): Add missing loadFromSource method in the DefaultRNFactoryDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -122,4 +122,11 @@
   return nullptr;
 }
 
+- (void)loadSourceForBridge:(RCTBridge *)bridge
+                 onProgress:(RCTSourceLoadProgressBlock)onProgress
+                 onComplete:(RCTSourceLoadBlock)loadCallback
+{
+  [RCTJavaScriptLoader loadBundleAtURL:[self sourceURLForBridge:bridge] onProgress:onProgress onComplete:loadCallback];
+}
+
 @end

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -90,13 +90,6 @@ NSString *kBundlePath = @"js/RNTesterApp.macos";
 }
 #endif // [macOS]
 
-- (void)loadSourceForBridge:(RCTBridge *)bridge
-                 onProgress:(RCTSourceLoadProgressBlock)onProgress
-                 onComplete:(RCTSourceLoadBlock)loadCallback
-{
-  [RCTJavaScriptLoader loadBundleAtURL:[self sourceURLForBridge:bridge] onProgress:onProgress onComplete:loadCallback];
-}
-
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {


### PR DESCRIPTION
## Summary:

Cherry pick https://github.com/facebook/react-native/commit/8b33668c4338d31c27e6bd90b2a0e6fc0a077588 to fix an issue where new apps made with the old architecture never call metro and therefore show a blank screen. 

## Test Plan:

Tested on a new app using `@react-native-community/cli init && react-native-macos-init`