### PR TITLE
ci(0.78): update preid check in prepublish.mjs (#2432)

### DIFF
--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -217,11 +217,12 @@ function enablePublishing(config, currentBranch, { npmTag: tag, prerelease, isNe
 
   // Determines whether we need to add "nightly" or "rc" to the version string.
   const { generatorOptions } = release.version;
-  if (prerelease && generatorOptions.preid !== prerelease) {
-    errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease || ""}'`);
+  if (generatorOptions.preid !== prerelease) {
     if (prerelease) {
+      errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease}'`);
       generatorOptions.preid = prerelease;
     } else {
+      errors.push(`'release.version.generatorOptions.preid' must be removed`);
       generatorOptions.preid = undefined;
     }
   }

--- a/nx.json
+++ b/nx.json
@@ -29,7 +29,6 @@
         "currentVersionResolverMetadata": {
           "tag": "latest"
         },
-        "preid": "",
         "skipLockFileUpdate": true
       }
     }


### PR DESCRIPTION
## Summary:

Backport of #2432 to 0.78-stable

## Test Plan:

CI should pass
