### PR TITLE
ci(0.78): properly pass NPM auth token secret to script

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -33,10 +33,8 @@ steps:
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
   - script: |
-      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
+      echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
       yarn nx release publish --excludeTaskDependencies
-    env:
-      NODE_AUTH_TOKEN: $(npmAuthToken)
     displayName: Publish packages
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 

--- a/.nx/version-plans/version-plan-1742941422258.md
+++ b/.nx/version-plans/version-plan-1742941422258.md
@@ -1,0 +1,6 @@
+---
+react-native-macos: patch
+'@react-native-mac/virtualized-lists': patch
+---
+
+Bump version to 0.78.1


### PR DESCRIPTION
## Summary:

Backport of #2434 to 0.78-stable, along with a change file to publish a new version

## Test Plan:

As with Publish pipeline changes, merge and hope for the best 🙏