### PR TITLE
ci: disable nightlies on the main branch

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -24,16 +24,16 @@ steps:
     displayName: Version and publish packages (dry run)
     condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 
-  - script: |
-      git switch $(Build.SourceBranchName)
-      yarn nx release --skip-publish --verbose
-    env:
-      GITHUB_TOKEN: $(githubAuthToken)
-    displayName: Version Packages and Github Release
-    condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
-
   # Disable Nightly publishing on the main branch
-  - ${{ if neq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if endsWith(variables['Build.SourceBranchName'], '-stable') }}:
+    - script: |
+        git switch $(Build.SourceBranchName)
+        yarn nx release --skip-publish --verbose
+      env:
+        GITHUB_TOKEN: $(githubAuthToken)
+      displayName: Version Packages and Github Release
+      condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
+
     - script: |
         echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
         yarn nx release publish --excludeTaskDependencies

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -32,7 +32,7 @@ steps:
     displayName: Version Packages and Github Release
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
-   # Disable Nightly publishing on the main branch
+  # Disable Nightly publishing on the main branch
   - ${{ if neq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     - script: |
         echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -32,11 +32,13 @@ steps:
     displayName: Version Packages and Github Release
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
-  - script: |
-      echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
-      yarn nx release publish --excludeTaskDependencies
-    displayName: Publish packages
-    condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
+   # Disable Nightly publishing on the main branch
+  - ${{ if neq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+    - script: |
+        echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
+        yarn nx release publish --excludeTaskDependencies
+      displayName: Publish packages
+      condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
   - script: |
       rm -f ~/.npmrc


### PR DESCRIPTION
## Summary:

We aren't yet ready to publish nightlies, so unconditionally running `publish` on the main branch might accidentally publish versions of React Native macOS we don't want. Let's disable it for now.

## Test Plan:

As with all publish pipeline changes, merge and hope for the best. 
