### PR TITLE
ci(0.76): backport publish pipeline changes

### DIFF
--- a/.ado/scripts/prepublish-check.mjs
+++ b/.ado/scripts/prepublish-check.mjs
@@ -218,10 +218,11 @@ function enablePublishing(config, currentBranch, { npmTag: tag, prerelease, isNe
   // Determines whether we need to add "nightly" or "rc" to the version string.
   const { generatorOptions } = release.version;
   if (generatorOptions.preid !== prerelease) {
-    errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease || ""}'`);
     if (prerelease) {
+      errors.push(`'release.version.generatorOptions.preid' must be set to '${prerelease}'`);
       generatorOptions.preid = prerelease;
     } else {
+      errors.push(`'release.version.generatorOptions.preid' must be removed`);
       generatorOptions.preid = undefined;
     }
   }

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -21,7 +21,6 @@ steps:
 
   - script: |
       git switch $(Build.SourceBranchName)
-      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
       yarn nx release --skip-publish --verbose
     env:
       GITHUB_TOKEN: $(githubAuthToken)
@@ -29,10 +28,8 @@ steps:
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
   - script: |
-      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
+      echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
       yarn nx release publish --excludeTaskDependencies
-    env:
-      NODE_AUTH_TOKEN: $(npmAuthToken)
     displayName: Publish packages
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -23,10 +23,22 @@ steps:
       git switch $(Build.SourceBranchName)
       echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
       yarn nx release --skip-publish --verbose
-      yarn nx release publish --excludeTaskDependencies
-      rm ~/.npmrc
     env:
       GITHUB_TOKEN: $(githubAuthToken)
-      NODE_AUTH_TOKEN: $(npmAuthToken)
-    displayName: Version and publish packages
+    displayName: Version Packages and Github Release
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
+
+  - script: |
+      echo "//registry.npmjs.org/:_authToken=$(NODE_AUTH_TOKEN)" > ~/.npmrc
+      yarn nx release publish --excludeTaskDependencies
+    env:
+      NODE_AUTH_TOKEN: $(npmAuthToken)
+    displayName: Publish packages
+    condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
+
+  - script: |
+      rm -f ~/.npmrc
+    env:
+      NODE_AUTH_TOKEN: $(npmAuthToken)
+    displayName: Remove npmrc if it exists
+    condition: always()


### PR DESCRIPTION
## Summary:

Backport #2422 , #2432 , and #2434 to 0.76-stable

## Test Plan:

CI should pass
