### PR TITLE
ci(0.77): Downgrade `0.77` from latest to stable

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -1,6 +1,6 @@
 parameters:
   # If this is a new stable branch, change `publishTag` to `latest` when going stable
-  publishTag: 'latest'
+  publishTag: 'v0.77-stable'
 
 steps:
   - template: /.ado/templates/configure-git.yml@self

--- a/.nx/version-plans/version-plan-1743111896868.md
+++ b/.nx/version-plans/version-plan-1743111896868.md
@@ -1,0 +1,6 @@
+---
+react-native-macos: patch
+'@react-native-mac/virtualized-lists': patch
+---
+
+Release a new patch release of 0.77

--- a/nx.json
+++ b/nx.json
@@ -29,6 +29,7 @@
         "currentVersionResolverMetadata": {
           "tag": "v0.77-stable"
         },
+        "fallbackCurrentVersionResolver": "disk",
         "skipLockFileUpdate": true
       }
     }

--- a/nx.json
+++ b/nx.json
@@ -27,7 +27,7 @@
       "generatorOptions": {
         "currentVersionResolver": "registry",
         "currentVersionResolverMetadata": {
-          "tag": "latest"
+          "tag": "v0.77-stable"
         },
         "skipLockFileUpdate": true
       }


### PR DESCRIPTION

## Summary:

Now that `0.78` is marked as latest, `0.77` needs to have its tag updated. 

## Test Plan:

CI should pass. 
