### PR TITLE
fix: dismiss all sheets created by `RCTDevLoadingView` when `hide` is called

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -24,6 +24,8 @@
 
 using namespace facebook::react;
 
+static NSString *sRCTDevLoadingViewWindowIdentifier = @"RCTDevLoadingViewWindow";
+
 @interface RCTDevLoadingView () <NativeDevLoadingViewSpec>
 @end
 
@@ -131,6 +133,7 @@ RCT_EXPORT_MODULE()
                                                styleMask:NSWindowStyleMaskBorderless
                                                  backing:NSBackingStoreBuffered
                                                    defer:YES];
+    [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];
 #endif // macOS]
 
     self->_container = [[RCTUIView alloc] init]; // [macOS]
@@ -221,7 +224,9 @@ RCT_EXPORT_METHOD(hide)
         }];
 #else // [macOS]
     for (NSWindow *window in [RCTKeyWindow() sheets]) {
-      [RCTKeyWindow() endSheet:window];
+      if ([[window identifier] isEqualToString:sRCTDevLoadingViewWindowIdentifier]) {
+        [RCTKeyWindow() endSheet:window];
+      }
     }
     self->_window = nil;
     self->_hiding = false;

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -121,13 +121,13 @@ RCT_EXPORT_MODULE()
 
     self->_showDate = [NSDate date];
 
-    RCTPlatformWindow *mainWindow = RCTKeyWindow(); // [macOS]
 #if !TARGET_OS_OSX // [macOS]
+    UIWindow *mainWindow = RCTKeyWindow();
     self->_window = [[UIWindow alloc] initWithWindowScene:mainWindow.windowScene];
     self->_window.windowLevel = UIWindowLevelStatusBar + 1;
     self->_window.rootViewController = [UIViewController new];
 #else // [macOS
-    self->_window = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
+    self->_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
                                                styleMask:NSWindowStyleMaskBorderless
                                                  backing:NSBackingStoreBuffered
                                                    defer:YES];
@@ -220,7 +220,9 @@ RCT_EXPORT_METHOD(hide)
           self->_hiding = false;
         }];
 #else // [macOS]
-    [RCTKeyWindow() endSheet:self->_window];
+    for (NSWindow *window in [RCTKeyWindow() sheets]) {
+      [RCTKeyWindow() endSheet:window];
+    }
     self->_window = nil;
     self->_hiding = false;
 #endif // macOS]


### PR DESCRIPTION
## Summary:

We've had a recurring bug where `RCTDevLoadingView` stick around blocking the whole app even after it's dismissed. As far as I can tell, this is a race condition where we have multiple devloadingviews at once (each setting and nilling the same `self->_window` property), which is causing a race condition. Rather than figure out how to make this class only ever show one window or race-safe, for now I will just make sure to dismiss _all_ sheets when `hide` is called.

While we're at it, a couple of other changes:
1. Change the type from `NSPanel` to `NSWindow`. Panels don't release when closed, which may be causing them to stick around longer than we like
2. Move the iOS only variable `mainWindow` into the iOS ifdef, and remove the diffs and diff tag around it. 

## Test Plan:

Initial testing shows RNTester no longer getting blocked. It could still happen (race conditions are hard), but I think the change is safe to add regardless.