### PR TITLE
fix(0.77): dismiss all sheets created by `RCTDevLoadingView` when `hide` is called

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -27,7 +27,7 @@
     "e2e-test-ios": "./scripts/maestro-test-ios.sh"
   },
   "dependencies": {
-    "@react-native/oss-library-example": "0.77.2",
+    "@react-native/oss-library-example": "workspace:*",
     "@react-native/popup-menu-android": "workspace:*",
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,7 +2753,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.77.1, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.77.2, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -3048,13 +3048,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@npm:0.77.2, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "npm:0.77.0"
-    react-native-macos: "npm:0.77.1"
+    react-native-macos: "npm:0.77.2"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -3097,7 +3097,7 @@ __metadata:
     "@react-native-community/cli": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-android": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-ios": "npm:15.0.0-alpha.2"
-    "@react-native/oss-library-example": "npm:0.77.2"
+    "@react-native/oss-library-example": "workspace:*"
     "@react-native/popup-menu-android": "workspace:*"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -10873,12 +10873,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@npm:0.77.1, react-native-macos@workspace:packages/react-native":
+"react-native-macos@npm:0.77.2, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "npm:0.77.1"
+    "@react-native-mac/virtualized-lists": "npm:0.77.2"
     "@react-native/assets-registry": "npm:0.77.0"
     "@react-native/codegen": "npm:0.77.0"
     "@react-native/community-cli-plugin": "npm:0.77.0"


### PR DESCRIPTION
Backport of #2448 to 0.77-stable