### PR TITLE
fix(0.78): dismiss all sheets created by `RCTDevLoadingView` when `hide` is called

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -27,7 +27,7 @@
     "e2e-test-ios": "./scripts/maestro-test-ios.sh"
   },
   "dependencies": {
-    "@react-native/oss-library-example": "0.78.3",
+    "@react-native/oss-library-example": "workspace:*",
     "@react-native/popup-menu-android": "workspace:*",
     "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,7 +2755,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-mac/virtualized-lists@npm:0.77.3, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-mac/virtualized-lists@npm:0.78.2, @react-native-mac/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-mac/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -3060,7 +3060,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native/oss-library-example@npm:0.78.3, @react-native/oss-library-example@workspace:packages/react-native-test-library":
+"@react-native/oss-library-example@workspace:*, @react-native/oss-library-example@workspace:packages/react-native-test-library":
   version: 0.0.0-use.local
   resolution: "@react-native/oss-library-example@workspace:packages/react-native-test-library"
   dependencies:
@@ -3096,7 +3096,7 @@ __metadata:
     "@react-native-community/cli": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-android": "npm:15.0.0-alpha.2"
     "@react-native-community/cli-platform-ios": "npm:15.0.0-alpha.2"
-    "@react-native/oss-library-example": "npm:0.78.3"
+    "@react-native/oss-library-example": "workspace:*"
     "@react-native/popup-menu-android": "workspace:*"
     flow-enums-runtime: "npm:^0.0.6"
     invariant: "npm:^2.2.4"
@@ -10865,7 +10865,7 @@ __metadata:
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-mac/virtualized-lists": "npm:0.77.3"
+    "@react-native-mac/virtualized-lists": "npm:0.78.2"
     "@react-native/assets-registry": "npm:0.78.1"
     "@react-native/codegen": "npm:0.78.1"
     "@react-native/community-cli-plugin": "npm:0.78.1"


### PR DESCRIPTION
Backport of #2448 to 0.78-stable