### PR TITLE
fix(fabric): Add `typingAttributes` to `RCTUITextField` to fix crash

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *text;
 @property (nonatomic, copy, nullable) NSAttributedString *attributedText;
 @property (nonatomic, copy) NSDictionary<NSAttributedStringKey, id> *defaultTextAttributes;
+@property (nullable, nonatomic, copy) NSDictionary<NSAttributedStringKey, id> *typingAttributes;
 @property (nonatomic, assign) NSTextAlignment textAlignment;
 @property (nonatomic, getter=isAutomaticTextReplacementEnabled) BOOL automaticTextReplacementEnabled;
 @property (nonatomic, getter=isAutomaticSpellingCorrectionEnabled) BOOL automaticSpellingCorrectionEnabled;


### PR DESCRIPTION
## Summary:

`typingAttributes` was added in a recent React Native release, but not brought to `RCTUITextField` (where we have to port some iOS only props to macOS). This caused an `unrecognized selector` style crash when trying to set `typingAttributes`.

## Test Plan:

Booting RNTester-macOS with the new architecture no longer crashes,