### PR TITLE
[0.77] [TextInput] Export TI State's focusInput/blurInput

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -1084,6 +1084,22 @@ interface TextInputState {
    * noop if it wasn't focused
    */
   blurTextInput(textField?: HostInstance): void;
+
+  // [macOS
+  /**
+   * @param textField ref of the text field that was focused
+   * Call on custom implementations of TextInput to notify the control was focused
+   * noop if it was already focused
+   */
+  onTextInputFocus(textField?: HostInstance): void;
+
+  /**
+   * @param textField ref of the text field that was blurred
+   * Call on custom implementations of TextInput to notify the control was blurred
+   * noop if it wasn't focused
+   */
+  onTextInputBlur(textField?: HostInstance): void;
+  // macOS]
 }
 
 /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -1249,6 +1249,8 @@ export type TextInputComponentStatics = $ReadOnly<{|
     currentlyFocusedField: () => ?number,
     focusTextInput: (textField: ?HostInstance) => void,
     blurTextInput: (textField: ?HostInstance) => void,
+    onTextInputFocus: (textField: ?HostInstance) => void, // [macOS]
+    onTextInputBlur: (textField: ?HostInstance) => void, // [macOS]
   |}>,
 |}>;
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -2039,6 +2039,8 @@ ExportedForwardRef.State = {
   currentlyFocusedField: TextInputState.currentlyFocusedField,
   focusTextInput: TextInputState.focusTextInput,
   blurTextInput: TextInputState.blurTextInput,
+  onTextInputFocus: TextInputState.focusInput, // [macOS]
+  onTextInputBlur: TextInputState.blurInput, // [macOS]
 };
 
 export type TextInputComponentStatics = $ReadOnly<{|
@@ -2047,6 +2049,8 @@ export type TextInputComponentStatics = $ReadOnly<{|
     currentlyFocusedField: typeof TextInputState.currentlyFocusedField,
     focusTextInput: typeof TextInputState.focusTextInput,
     blurTextInput: typeof TextInputState.blurTextInput,
+    onTextInputFocus: typeof TextInputState.focusInput, // [macOS]
+    onTextInputBlur: typeof TextInputState.blurInput, // [macOS]
   |}>,
 |}>;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3231,6 +3231,8 @@ export type TextInputComponentStatics = $ReadOnly<{|
     currentlyFocusedField: () => ?number,
     focusTextInput: (textField: ?HostInstance) => void,
     blurTextInput: (textField: ?HostInstance) => void,
+    onTextInputFocus: (textField: ?HostInstance) => void,
+    onTextInputBlur: (textField: ?HostInstance) => void,
   |}>,
 |}>;
 export type TextInputType = InternalTextInput & TextInputComponentStatics;
@@ -3629,6 +3631,8 @@ export type TextInputComponentStatics = $ReadOnly<{|
     currentlyFocusedField: typeof TextInputState.currentlyFocusedField,
     focusTextInput: typeof TextInputState.focusTextInput,
     blurTextInput: typeof TextInputState.blurTextInput,
+    onTextInputFocus: typeof TextInputState.focusInput,
+    onTextInputBlur: typeof TextInputState.blurInput,
   |}>,
 |}>;
 declare module.exports: TextInputType;


### PR DESCRIPTION
[These two functions](https://github.com/microsoft/react-native-macos/blob/9ea059c33143e6766582a1f682e4f144e00cc740/packages/react-native/Libraries/Components/TextInput/TextInputState.js#L60C1-L70C2) are used to [properly handle onFocus\onBlur for TextInput implementations](https://github.com/microsoft/react-native-macos/blob/9ea059c33143e6766582a1f682e4f144e00cc740/packages/react-native/Libraries/Components/TextInput/TextInput.js#L1623C1-L1635C5), specifically they are used to track the currently focused TextInput control and as such cause [focusTextInput](https://github.com/microsoft/react-native-macos/blob/9ea059c33143e6766582a1f682e4f144e00cc740/packages/react-native/Libraries/Components/TextInput/TextInputState.js#L106C1-L106C48) and [blurTextInput](https://github.com/microsoft/react-native-macos/blob/9ea059c33143e6766582a1f682e4f144e00cc740/packages/react-native/Libraries/Components/TextInput/TextInputState.js#L143C1-L143C69) to skip native focus\blur calls if the JS side thinks the control in question is already focused\blurred.

In other words, if someone wants to build a custom `<TextInput>` from the ground up, they can't expect `focusTextInput`,  `blurTextInput`, and `currentlyFocusedInput` (the last one which is especially already used in a bunch of places in the framework) to work properly. This change exports the necessary `focusInput` and `blurInput` out of [TextInput](https://github.com/microsoft/react-native-macos/blob/9ea059c33143e6766582a1f682e4f144e00cc740/packages/react-native/Libraries/Components/TextInput/TextInput.js#L2041C1-L2048C3) statics.