### PR TITLE
ci: Update to Xcode 16.3

### DIFF
--- a/.ado/variables/vars.yml
+++ b/.ado/variables/vars.yml
@@ -1,6 +1,6 @@
+# See https://github.com/actions/runner-images/tree/main/images/macos for the latest macOS images and Xcode versions
+
 variables:
-  VmImageApple: macos-latest-internal
-  xcode_friendly_name: 'Xcode 16.2'
-  xcode_version: '/Applications/Xcode_16.2.app'
-  ios_version: '18.0'
-  ios_simulator: 'iPhone 16'
+  VmImageApple: macos-15
+  xcode_friendly_name: 'Xcode 16.3'
+  xcode_version: '/Applications/Xcode_16.3.0.app'


### PR DESCRIPTION
## Summary:

Update our CI pipelines to Xcode 16.3

## Test Plan:

CI should pass
