### PR TITLE
ci: update lock file through `nx.json` flag instead

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -29,8 +29,7 @@
         "currentVersionResolverMetadata": {
           "tag": "nightly"
         },
-        "preid": "nightly",
-        "skipLockFileUpdate": true
+        "preid": "nightly"
       }
     }
   }

--- a/packages/nx-release-version/index.js
+++ b/packages/nx-release-version/index.js
@@ -3,7 +3,6 @@
 const { releaseVersionGenerator } = require('@nx/js/src/generators/release-version/release-version');
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 const { REPO_ROOT } = require('../../scripts/consts');
 
 /**
@@ -17,8 +16,6 @@ async function runSetVersion() {
   const { version } = JSON.parse(manifest);
 
   await updateReactNativeArtifacts(version);
-
-  spawnSync('yarn', ['install', '--mode', 'update-lockfile']);
 
   return [
     path.join(
@@ -65,10 +62,6 @@ async function runSetVersion() {
       'Libraries',
       'Core',
       'ReactNativeVersion.js',
-    ),
-    path.join(
-      REPO_ROOT,
-      'yarn.lock',
     ),
   ];
 }


### PR DESCRIPTION
## Summary:

This reverts commit 791012b8f08270baa940a4f0e9125162d27a0f7b.

We had some custom logic to update the lock file after the "version" step of release happened. Turns out you can just do that directly through `nx`... so let's remove the logic and do it that was instead. 

## Test Plan:

Ran `nx release --skip-publish` locally (and cmd+c'ed it before it committed anything...) to see if the lock would update with the new versions and it did. 