### PR TITLE
ci(0.78): Add some logging to the pubish phase

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -21,6 +21,8 @@ steps:
   - script: |
       echo Target branch: $(System.PullRequest.TargetBranch)
       yarn nx release --dry-run --verbose
+    env:
+      GITHUB_TOKEN: $(githubAuthToken)
     displayName: Version and publish packages (dry run)
     condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 
@@ -35,12 +37,12 @@ steps:
   - script: |
       echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
       yarn nx release publish --excludeTaskDependencies
+    env:
+      NODE_AUTH_TOKEN: $(npmAuthToken)
     displayName: Publish packages
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
   - script: |
       rm -f ~/.npmrc
-    env:
-      NODE_AUTH_TOKEN: $(npmAuthToken)
     displayName: Remove npmrc if it exists
     condition: always()

--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -21,8 +21,6 @@ steps:
   - script: |
       echo Target branch: $(System.PullRequest.TargetBranch)
       yarn nx release --dry-run --verbose
-    env:
-      GITHUB_TOKEN: $(githubAuthToken)
     displayName: Version and publish packages (dry run)
     condition: and(succeeded(), ne(variables['publish_react_native_macos'], '1'))
 
@@ -37,8 +35,6 @@ steps:
   - script: |
       echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
       yarn nx release publish --excludeTaskDependencies
-    env:
-      NODE_AUTH_TOKEN: $(npmAuthToken)
     displayName: Publish packages
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 

--- a/.nx/version-plans/version-plan-1744766603658.md
+++ b/.nx/version-plans/version-plan-1744766603658.md
@@ -1,0 +1,5 @@
+---
+react-native-macos: patch
+---
+
+Publish a new 0.78 patch release

--- a/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch
+++ b/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch
@@ -1,0 +1,22 @@
+diff --git a/src/executors/release-publish/release-publish.impl.js b/src/executors/release-publish/release-publish.impl.js
+index 08cd58274d308bcb2ca644e8af5bd99a153c9e91..5ce12c3cb563345ffd19159fd108ff763626b930 100644
+--- a/src/executors/release-publish/release-publish.impl.js
++++ b/src/executors/release-publish/release-publish.impl.js
+@@ -246,6 +246,8 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
+         };
+     }
+     catch (err) {
++        console.log('Caught Error 1: ') // [macOS]
++        console.log(err) // [macOS]
+         try {
+             const stdoutData = JSON.parse(err.stdout?.toString() || '{}');
+             console.error(`${pm} publish error:`);
+@@ -267,6 +269,8 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
+             };
+         }
+         catch (err) {
++            console.log('Caught Error 2: ') // [macOS]
++            console.log(err) // [macOS]
+             console.error(`Something unexpected went wrong when processing the ${pm} publish output\n`, err);
+             return {
+                 success: false,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-flow": "^7.24.7",
     "@definitelytyped/dtslint": "^0.0.127",
     "@jest/create-cache-key-function": "^29.6.3",
-    "@nx/js": "~20.0.0",
+    "@nx/js": "patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch",
     "@react-native/metro-babel-transformer": "0.78.2",
     "@react-native/metro-config": "0.78.2",
     "@tsconfig/node18": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,7 +2350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nx/js@npm:~20.0.0":
+"@nx/js@npm:20.0.7, @nx/js@npm:~20.0.0":
   version: 20.0.7
   resolution: "@nx/js@npm:20.0.7"
   dependencies:
@@ -2390,6 +2390,49 @@ __metadata:
     verdaccio:
       optional: true
   checksum: 10c0/eae4688886a73c2fc0354dbfc1b626c897337b4a77a264f851cc166ae48ae9e7437fd052d94325c1270724e95e9cebb2e45b872adbe742fc3784d3a454815b93
+  languageName: node
+  linkType: hard
+
+"@nx/js@patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch":
+  version: 20.0.7
+  resolution: "@nx/js@patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch::version=20.0.7&hash=6556dd"
+  dependencies:
+    "@babel/core": "npm:^7.23.2"
+    "@babel/plugin-proposal-decorators": "npm:^7.22.7"
+    "@babel/plugin-transform-class-properties": "npm:^7.22.5"
+    "@babel/plugin-transform-runtime": "npm:^7.23.2"
+    "@babel/preset-env": "npm:^7.23.2"
+    "@babel/preset-typescript": "npm:^7.22.5"
+    "@babel/runtime": "npm:^7.22.6"
+    "@nx/devkit": "npm:20.0.7"
+    "@nx/workspace": "npm:20.0.7"
+    "@zkochan/js-yaml": "npm:0.0.7"
+    babel-plugin-const-enum: "npm:^1.0.1"
+    babel-plugin-macros: "npm:^2.8.0"
+    babel-plugin-transform-typescript-metadata: "npm:^0.3.1"
+    chalk: "npm:^4.1.0"
+    columnify: "npm:^1.6.0"
+    detect-port: "npm:^1.5.1"
+    enquirer: "npm:~2.3.6"
+    fast-glob: "npm:3.2.7"
+    ignore: "npm:^5.0.4"
+    js-tokens: "npm:^4.0.0"
+    jsonc-parser: "npm:3.2.0"
+    minimatch: "npm:9.0.3"
+    npm-package-arg: "npm:11.0.1"
+    npm-run-path: "npm:^4.0.1"
+    ora: "npm:5.3.0"
+    semver: "npm:^7.5.3"
+    source-map-support: "npm:0.5.19"
+    ts-node: "npm:10.9.1"
+    tsconfig-paths: "npm:^4.1.2"
+    tslib: "npm:^2.3.0"
+  peerDependencies:
+    verdaccio: ^5.0.4
+  peerDependenciesMeta:
+    verdaccio:
+      optional: true
+  checksum: 10c0/4ea6d88fd623baad2627dcb0a8aa68d2f5eb799b8ded1abc2984eedb508295e640244c7a5a4a57b7b060b0cd2df735142b7d8c00ea6ad33ea4c9608b078f8a14
   languageName: node
   linkType: hard
 
@@ -2685,7 +2728,7 @@ __metadata:
     "@babel/preset-flow": "npm:^7.24.7"
     "@definitelytyped/dtslint": "npm:^0.0.127"
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@nx/js": "npm:~20.0.0"
+    "@nx/js": "patch:@nx/js@npm%3A20.0.7#~/.yarn/patches/@nx-js-npm-20.0.7-30719000fd.patch"
     "@react-native/metro-babel-transformer": "npm:0.78.2"
     "@react-native/metro-config": "npm:0.78.2"
     "@tsconfig/node18": "npm:1.0.1"


### PR DESCRIPTION
## Summary:

Patch nx to add some logging to help figure out why `yarn nx run react-native-macos:nx-release-publish --excludeTaskDependencies` fails

## Test Plan:

I expect CI to fail after merge :D 