### PR TITLE
ci(0.76): fix typo in `nx.json`

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -29,7 +29,7 @@
         "currentVersionResolverMetadata": {
           "tag": "v0.76-stable"
         },
-        "fallbackCurrentVersionResolver": "disk",
+        "fallbackCurrentVersionResolver": "disk"
       }
     }
   }


### PR DESCRIPTION
## Summary:

Guess the config doesn't like trailing commas.

## Test Plan:

CI should pass
