### PR TITLE
ci: mark unforked monorepo packages as private

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/assets-registry",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Asset support code for React Native.",
   "license": "MIT",
   "repository": {

--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/babel-plugin-codegen",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Babel plugin to generate native module and view manager code for React Native.",
   "license": "MIT",
   "repository": {

--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/community-cli-plugin",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Core CLI commands for React Native",
   "keywords": [
     "react-native",

--- a/packages/core-cli-utils/package.json
+++ b/packages/core-cli-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/core-cli-utils",
   "version": "0.77.0-main",
+  "private": true,
   "description": "React Native CLI library for Frameworks to build on",
   "license": "MIT",
   "main": "./src/index.flow.js",

--- a/packages/debugger-frontend/package.json
+++ b/packages/debugger-frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/debugger-frontend",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Debugger frontend for React Native based on Chrome DevTools",
   "keywords": [
     "react-native",

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/dev-middleware",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Dev server middleware for React Native",
   "keywords": [
     "react-native",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/eslint-config",
   "version": "0.77.0-main",
+  "private": true,
   "description": "ESLint config for React Native",
   "license": "MIT",
   "repository": {

--- a/packages/eslint-plugin-react-native/package.json
+++ b/packages/eslint-plugin-react-native/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/eslint-plugin",
   "version": "0.77.0-main",
+  "private": true,
   "description": "ESLint rules for @react-native/eslint-config",
   "license": "MIT",
   "repository": {

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/eslint-plugin-specs",
   "version": "0.77.0-main",
+  "private": true,
   "description": "ESLint rules to validate NativeModule and Component Specs",
   "license": "MIT",
   "repository": {

--- a/packages/gradle-plugin/package.json
+++ b/packages/gradle-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/gradle-plugin",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Gradle Plugin for React Native",
   "license": "MIT",
   "repository": {

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/metro-config",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Metro configuration for React Native.",
   "license": "MIT",
   "repository": {

--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/normalize-colors",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Color normalization for React Native.",
   "license": "MIT",
   "repository": {

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/js-polyfills",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Polyfills for React Native.",
   "license": "MIT",
   "repository": {

--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/babel-preset",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Babel preset for React Native applications",
   "main": "src/index.js",
   "repository": {

--- a/packages/react-native-babel-transformer/package.json
+++ b/packages/react-native-babel-transformer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/metro-babel-transformer",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Babel transformer for React Native applications.",
   "main": "src/index.js",
   "repository": {

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/codegen",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Code generation tools for React Native",
   "license": "MIT",
   "repository": {

--- a/packages/react-native-popup-menu-android/package.json
+++ b/packages/react-native-popup-menu-android/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/popup-menu-android",
   "version": "0.77.0-main",
+  "private": true,
   "description": "PopupMenu for the Android platform",
   "main": "index.js",
   "files": [

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/typescript-config",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Default TypeScript configuration for React Native apps",
   "license": "MIT",
   "repository": {

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native-mac/virtualized-lists",
   "version": "0.77.0-main",
+  "private": true,
   "description": "Virtualized lists for React Native macOS.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary:

It's not clear (both to humans and to build tools like `nx`) that the only packages we fork from the React Native monorepo upstream are ` 'react-native' --> 'react-native-macos'` and `'@react-native/virtualized-lists' --> '@react-native-mac/virtualized-lists'`. The rest of the packages should essentially only ever be used in local development, while the published package `react-native-macos` uses the upstream versions of these packages. We can solve this by marking the packages as private. 

## Test Plan:

IIRC, this caused some build failure last time I tried this.. let's see how CI reacts to this change. Further testing with `nx release` should be done locally to make sure the nx build graph stops marking the unforked monoreppo packages as dependencies.