### PR TITLE
ci: set the npm dist-tag in `nx release publish`

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -42,7 +42,7 @@ steps:
 
     - script: |
         if [[ -f .rnm-publish ]]; then
-          yarn nx release publish --excludeTaskDependencies
+          yarn nx release publish --tag ${{ parameters['publishTag'] }} --excludeTaskDependencies 
         fi
       displayName: Publish packages
       condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))


### PR DESCRIPTION
## Summary:

We separate our CI to run `nx release` as two steps: `nx release --skip-publish` and `nx release publish`. The latter seems to not pick up the NPM dist-tag we want to set packages to release with, so it defaults to `latest`. This seems solvable by simply passing in `--tag`., since that gets picked up [in this line of code](https://github.com/nrwl/nx/blob/745abdaecfffbf09278dd576ef32afb8a7da9735/packages/js/src/executors/release-publish/release-publish.impl.ts#L123).

## Test Plan:

Locally ran `nx release-publish` with extra console.logs to make sure the tag was passed in. 
