### PR TITLE
ci(0.77): set the npm dist-tag in `nx release publish`

### DIFF
--- a/.ado/templates/npm-publish-steps.yml
+++ b/.ado/templates/npm-publish-steps.yml
@@ -29,7 +29,7 @@ steps:
 
   - script: |
       echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
-      yarn nx release publish --excludeTaskDependencies
+      yarn nx release publish --tag ${{ parameters['publishTag'] }} --excludeTaskDependencies 
     displayName: Publish packages
     condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 


### PR DESCRIPTION
Backport of #2484 to `0.77-stable`