### PR TITLE
fix(0.75, Xcode 26): Add explicit cast for enum type to suppress a warning

### DIFF
--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -44,7 +44,7 @@ void UIGraphicsBeginImageContextWithOptions(CGSize size, __unused BOOL opaque, C
 	size_t height = ceilf(size.height * scale);
 
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-	CGContextRef ctx = CGBitmapContextCreate(NULL, width, height, 8/*bitsPerComponent*/, width * 4/*bytesPerRow*/, colorSpace, kCGImageAlphaPremultipliedFirst);
+	CGContextRef ctx = CGBitmapContextCreate(NULL, width, height, 8/*bitsPerComponent*/, width * 4/*bytesPerRow*/, colorSpace, (CGBitmapInfo)kCGImageAlphaPremultipliedFirst);
 	CGColorSpaceRelease(colorSpace);
 
 	if (ctx != NULL)


### PR DESCRIPTION
## Summary:

Suppress a warning caught in our internal build system.

## Test Plan:

CI should pass
