### PR TITLE
fix(UBSAN): ensure `[RCTUITextField validAttributesForMarkedText]` Is non null

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -161,7 +161,7 @@
 
 - (NSArray<NSAttributedStringKey> *)validAttributesForMarkedText
 {
-	return ((NSTextView *)self.currentEditor).validAttributesForMarkedText;
+	return ((NSTextView *)self.currentEditor).validAttributesForMarkedText ?: @[];
 }
 
 #endif // macOS]


### PR DESCRIPTION
## Summary:

Internally, we build with [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), which caught an instance of a method returning nil while marked as non null. Apple documentation says that method should return an empty array as a fallback, so let's do that. 

## Test Plan:

Tested internally. 
