### PR TITLE
fix(0.74, UBSAN): ensure `[RCTUITextField validAttributesForMarkedText]` is nonnull

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -153,7 +153,7 @@
 
 - (NSArray<NSAttributedStringKey> *)validAttributesForMarkedText
 {
-	return ((NSTextView *)self.currentEditor).validAttributesForMarkedText;
+	return ((NSTextView *)self.currentEditor).validAttributesForMarkedText ?: @[];
 }
 
 #endif // macOS]


### PR DESCRIPTION
Backport of #2515 to 0.74-stable