### PR TITLE
fix(0.77, UBSAN): ensure `[RCTUITextField validAttributesForMarkedText]` is nonnull

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -153,7 +153,7 @@
 
 - (NSArray<NSAttributedStringKey> *)validAttributesForMarkedText
 {
-	return ((NSTextView *)self.currentEditor).validAttributesForMarkedText;
+	return ((NSTextView *)self.currentEditor).validAttributesForMarkedText ?: @[];
 }
 
 #endif // macOS]


### PR DESCRIPTION
Backport of https://github.com/microsoft/react-native-macos/pull/2515 to 0.77-stable