### PR TITLE
Turn on Hermes builds in our test matrix

### DIFF
--- a/.ado/jobs/build-test-rntester.yml
+++ b/.ado/jobs/build-test-rntester.yml
@@ -50,6 +50,54 @@ parameters:
         packager_platform: 'ios'
         new_arch_enabled: '1'
         use_hermes: '0'
+      - name: macos_debug_oldarch_hermes
+        friendly_name: 'macOS, Old Arch, Hermes'
+        sdk: macosx
+        configuration: Debug
+        scheme: RNTester-macOS
+        packager_platform: 'macos'
+        new_arch_enabled: '0'
+        use_hermes: '1'
+      - name: macos_debug_newarch_hermes
+        friendly_name: 'macOS, New Arch, Hermes'
+        sdk: macosx
+        configuration: Debug
+        scheme: RNTester-macOS
+        packager_platform: 'macos'
+        new_arch_enabled: '1'
+        use_hermes: '1'
+      - name: ios_debug_oldarch_hermes
+        friendly_name: 'iOS, Old Arch, Hermes'
+        sdk: iphonesimulator
+        configuration: Debug
+        scheme: RNTester
+        packager_platform: 'ios'
+        new_arch_enabled: '0'
+        use_hermes: '1'
+      - name: ios_debug_newarch_hermes
+        friendly_name: 'iOS, New Arch, Hermes'
+        sdk: iphonesimulator
+        configuration: Debug
+        scheme: RNTester
+        packager_platform: 'ios'
+        new_arch_enabled: '1'
+        use_hermes: '1'
+      - name: xros_debug_oldarch_hermes
+        friendly_name: 'xrOS, Old Arch, Hermes'
+        sdk: xrsimulator
+        configuration: Debug
+        scheme: RNTester-visionOS
+        packager_platform: 'ios'
+        new_arch_enabled: '0'
+        use_hermes: '1'
+      - name: xros_debug_newarch_hermes
+        friendly_name: 'xrOS, New Arch, Hermes'
+        sdk: xrsimulator
+        configuration: Debug
+        scheme: RNTester-visionOS
+        packager_platform: 'ios'
+        new_arch_enabled: '1'
+        use_hermes: '1'
 
 jobs:
   - ${{ each slice in parameters.appleBuildMatrix }}:

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -196,7 +196,7 @@ class ReactNativePodsUtils
 
     def self.add_build_settings_to_pod(installer, settings_name, settings_value, target_pod_name, configuration_type)
         installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
-            if pod_name.to_s == target_pod_name
+            if pod_name.to_s == target_pod_name || %w[macOS iOS visionOS].any? { |platform| pod_name.to_s == "#{target_pod_name}-#{platform}" } # [macOS]
                 target_installation_result.native_target.build_configurations.each do |config|
                         if configuration_type == nil || (configuration_type != nil && config.type == configuration_type)
                             config.build_settings[settings_name] ||= '$(inherited) '


### PR DESCRIPTION
## Summary:

I found that RNTester works with Hermes, so let's enable it in our CIs!

This requires a bit of extra finagling to get the correct version. The implementation of `podspec_source_build_from_github_merge_base` shows how to do this.

## Test Plan:

If CIs pass, we're good!