### PR TITLE
Use peerDependencies to get Hermes version on stable branches

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -22,8 +22,7 @@ end
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
 # [macOS
-rn_version = package['version']
-version = findLatestVersionWithArtifact(rn_version) || rn_version
+version = findLatestVersionWithArtifact(package) || package['version']
 # macOS]
 
 source_type = hermes_source_type(version, react_native_path)

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -298,18 +298,14 @@ end
 
 # [macOS react-native-macos does not publish macos specific hermes artifacts
 # so we attempt to find the latest patch version of the iOS artifacts and use that
-def findLatestVersionWithArtifact(version)
-    if version == "1000.0.0"
+def findLatestVersionWithArtifact(package)
+    if package['version'] == "1000.0.0"
         # The main branch builds from source, so skip the artifact check
         return nil
     end
 
-    # See https://central.sonatype.org/search/rest-api-guide/ for details on query params
-    versionWithoutPatch = "#{version.match(/^(\d+\.\d+)/)}"
-    res, = Open3.capture3("curl -s https://search.maven.org/solrsearch/select?q=g:com.facebook.react+AND+a:react-native-artifacts+AND+v:#{versionWithoutPatch}.*&core=gav&rows=1&wt=json")
-    wt = JSON.parse(res)
-    response = wt['response']
-    return response['docs'][0]['v'] unless response['numFound'] == 0
+    # This assumes that whatever peer dependency we specify has an artifact
+    return package['peerDependencies']['react-native']
 end
 # macOS]
 


### PR DESCRIPTION
## Summary:

This is a follow-up to #2524 where we expect the RNCore version to be explicitly specified as a peer dependency in our stable branches.

#2530 brings this in for 0.74-stable; this brings it into the main branch for cherry-picking into other branches.

## Test Plan:

If CIs pass, we're good.

This shouldn't do anything on the main branch anyway, since we don't run through any of the peer dependency logic. Either way, a quick run of RNTester validates that we're still getting our Hermes version via the same `git merge-base` approach.