### PR TITLE
fix: Fix a typo in Hermes-utils.rb

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -305,7 +305,7 @@ def findMatchingHermesVersion(package)
         return nil
     end
 
-    if packages['peerDependencies']
+    if package['peerDependencies']
         return package['peerDependencies']['react-native']
     end
 


### PR DESCRIPTION
## Summary:

Discovered when cherry-picking #2531 into #2530. I didn't catch it before because we don't actually run through this part on the main branch.

## Test Plan:

No effects on main branch, but #2530 CIs should succeed now.