### PR TITLE
ci(0.75): Add docs and CI checks for RN peer dependency

### DIFF
--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -34,4 +34,22 @@ stages:
     jobs:
       - template: /.ado/jobs/test-react-native-macos-init.yml@self
 
+  - stage: Validate_Peer_Dependency
+    displayName: 'Validate Peer Dependency'
+    dependsOn: []
+    condition: and(succeeded(), contains(variables['System.PullRequest.TargetBranch'], '-stable'))
+    jobs:
+      - job: CheckRNPeerDependency
+        displayName: 'react-native'
+        pool:
+          vmImage: $(vmImageApple)
+        steps:
+          - script: |
+              set -eox pipefail
+              if ! jq -e '.peerDependencies["react-native"]' packages/react-native/package.json > /dev/null; then
+                echo "##vso[task.logissue type=error]react-native is not listed as a peerDependency in packages/react-native/package.json"
+                exit 1
+              fi
+            displayName: 'Validate peerDependency in package.json'
+
       # - template: /.ado/jobs/react-native-test-app-integration.yml@self

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -83,3 +83,13 @@ We do this so that our first release will have a proper patch version of 0, as s
 > semver.inc('0.72.0-ready', 'patch')
 '0.72.0' // Better!
 ```
+
+## Hermes Compatibility (0.74 and above)
+
+*Note: This is only applicable if Hermes is enabled via the `USE_HERMES=1` environment variable when running `pod install`.*
+
+React Native macOS updates the patch version automatically for every change that comes through, so our patch number can differ wildly from that of vanilla React Native.
+
+To ensure the best possible Hermes compatibility, we specify a peer dependency in React Native macOS's `package.json` indicating which version of upstream React Native best corresponds with our own version. For example, our 0.74.34 corresponds to upstream's 0.74.7, and we reflect this connection in [this particular version of `package.json`](https://github.com/microsoft/react-native-macos/blob/2db3abeb5d4318fee3abdff4a4d1a68967223135/packages/react-native/package.json#L103).
+
+For stable branches, the existence of this peer dependency is enforced as part of our CIs.


### PR DESCRIPTION
## Summary:

This enforces and explains the existence of a peer dependency on RNCore for Hermes builds.

## Test Plan:

The added CI should pass.
