### PR TITLE
ci(0.76): fix typo in yml

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -71,4 +71,4 @@ extends:
                fetchFilter: blob:none # partial clone for faster clones while maintaining history
                persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-             - template: /.ado/templates/npm-publish-steps.yml@self
+             - template: /.ado/jobs/npm-publish.yml@self


### PR DESCRIPTION
## Summary:

Fix a typo in YML

## Test Plan:

This matches the other branches above like 0.78-stable