### PR TITLE
fix: Support Function Key Handling in macOS Views

### DIFF
--- a/packages/react-native/React/Views/RCTViewKeyboardEvent.m
+++ b/packages/react-native/React/Views/RCTViewKeyboardEvent.m
@@ -63,6 +63,32 @@
     return @"PageUp";
   } else if (code == NSPageDownFunctionKey) {
     return @"PageDown";
+  } else if (code == NSPageDownFunctionKey) {
+    return @"PageDown";
+  } else if (code == NSF1FunctionKey) {
+    return @"F1";
+  } else if (code == NSF2FunctionKey) {
+    return @"F2";
+  } else if (code == NSF3FunctionKey) {
+    return @"F3";
+  } else if (code == NSF4FunctionKey) {
+    return @"F4";
+  } else if (code == NSF5FunctionKey) {
+    return @"F5";
+  } else if (code == NSF6FunctionKey) {
+    return @"F6";
+  } else if (code == NSF7FunctionKey) {
+    return @"F7";
+  } else if (code == NSF8FunctionKey) {
+    return @"F8";
+  } else if (code == NSF9FunctionKey) {
+    return @"F9";
+  } else if (code == NSF10FunctionKey) {
+    return @"F10";
+  } else if (code == NSF11FunctionKey) {
+    return @"F11";
+  } else if (code == NSF12FunctionKey) {
+    return @"F12";
   }
 
   return key;

--- a/packages/react-native/React/Views/RCTViewKeyboardEvent.m
+++ b/packages/react-native/React/Views/RCTViewKeyboardEvent.m
@@ -63,8 +63,6 @@
     return @"PageUp";
   } else if (code == NSPageDownFunctionKey) {
     return @"PageDown";
-  } else if (code == NSPageDownFunctionKey) {
-    return @"PageDown";
   } else if (code == NSF1FunctionKey) {
     return @"F1";
   } else if (code == NSF2FunctionKey) {


### PR DESCRIPTION
## Summary:

Function keys on macOS currently get dispatched with the value from the underlying NS*FunctionKey code point. For instance, a `F12` event gets dispatched as `\uf70f` for [NS12FunctionKey](https://developer.apple.com/documentation/appkit/nsf12functionkey?language=objc). To clean this up, we should dispatch the same strings we use on other platforms (i.e. `'F12'` for the F12 key).

## Test Plan:
I used a pressable component with a `onKeyDown` handler in `RNTester-macOS` to test keyboard events. With this change, the function keys come in as `F12`, `F11` etc... instead of the underlying NS*FunctionKey code points.
