### PR TITLE
fix: add RCTAppDependencyProvider to template

### DIFF
--- a/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld-macOS/AppDelegate.mm
+++ b/packages/react-native/local-cli/generator-macos/templates/macos/HelloWorld-macOS/AppDelegate.mm
@@ -1,6 +1,7 @@
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
+#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
 
 @implementation AppDelegate
 
@@ -10,7 +11,8 @@
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
-
+  self.dependencyProvider = [RCTAppDependencyProvider new];
+  
   return [super applicationDidFinishLaunching:notification];
 }
 


### PR DESCRIPTION
## Summary:

Fixes #2558 

This was missing from our template, which meant 3rd party fabric components would not get registered

## Test Plan:

Working on it...
