### PR TITLE
chore(0.76): update dependency in @react-native/oss-library-example

### DIFF
--- a/packages/react-native-test-library/package.json
+++ b/packages/react-native-test-library/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@react-native/babel-preset": "0.76.9",
-    "react-native-macos": "0.76.9"
+    "react-native-macos": "workspace:*"
   },
   "peerDependencies": {
     "react": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,7 +3425,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-macos/virtualized-lists@npm:0.76.9, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-macos/virtualized-lists@npm:0.76.10, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-macos/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -3756,7 +3756,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "npm:0.76.9"
-    react-native-macos: "npm:0.76.9"
+    react-native-macos: "workspace:*"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -12323,12 +12323,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@npm:0.76.9, react-native-macos@workspace:packages/react-native":
+"react-native-macos@workspace:*, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-macos/virtualized-lists": "npm:0.76.9"
+    "@react-native-macos/virtualized-lists": "npm:0.76.10"
     "@react-native/assets-registry": "npm:0.76.9"
     "@react-native/codegen": "npm:0.76.9"
     "@react-native/community-cli-plugin": "npm:0.76.9"


### PR DESCRIPTION
## Summary:

This got out of sync with the local workspace version, let's use the workspace protocol here. 

