### PR TITLE
chore(0.78): update dependency in @react-native/oss-library-example

### DIFF
--- a/packages/react-native-test-library/package.json
+++ b/packages/react-native-test-library/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@react-native/babel-preset": "workspace:*",
-    "react-native-macos": "0.78.3"
+    "react-native-macos": "workspace:*"
   },
   "peerDependencies": {
     "react": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,7 +2802,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-macos/virtualized-lists@npm:0.78.2, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-macos/virtualized-lists@npm:0.78.4, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-macos/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -3113,7 +3113,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@react-native/babel-preset": "workspace:*"
-    react-native-macos: "npm:0.78.3"
+    react-native-macos: "workspace:*"
   peerDependencies:
     react: "*"
     react-native-macos: "*"
@@ -10889,12 +10889,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@npm:0.78.3, react-native-macos@workspace:packages/react-native":
+"react-native-macos@workspace:*, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.6.3"
-    "@react-native-macos/virtualized-lists": "npm:0.78.2"
+    "@react-native-macos/virtualized-lists": "npm:0.78.4"
     "@react-native/assets-registry": "npm:0.78.2"
     "@react-native/codegen": "npm:0.78.2"
     "@react-native/community-cli-plugin": "npm:0.78.2"


### PR DESCRIPTION
## Summary:

This got out of sync with the local workspace version, let's use the
workspace protocol here.