### PR TITLE
ci: "update to nx 21" followup fixes

### DIFF
--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -24,7 +24,11 @@ jobs:
     - template: /.ado/templates/configure-git.yml@self
 
     - script: |
-        PUBLISH_TAG=$(jq -r '.release.version.generatorOptions.currentVersionResolverMetadata.tag' nx.json)
+        PUBLISH_TAG=$(jq -r '.release.version.versionActionsOptions.currentVersionResolverMetadata.tag' nx.json)
+        if [ -z "$PUBLISH_TAG" ] || [ "$PUBLISH_TAG" = "null" ]; then
+          echo "Error: Failed to read publish tag from nx.json"
+          exit 1
+        fi
         echo "##vso[task.setvariable variable=publishTag]$PUBLISH_TAG"
         echo "Using publish tag from nx.json: $PUBLISH_TAG"
       displayName: Read publish tag from nx.json

--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -65,7 +65,12 @@ jobs:
 
       - script: |
           if [[ -f .rnm-publish ]]; then
-            yarn nx release publish --tag ${{ parameters['publishTag'] }} --excludeTaskDependencies 
+            # https://github.com/microsoft/react-native-macos/issues/2580
+            # `nx release publish` gets confused by the output of RNM's prepack script.
+            # Let's call `yarn npm publish` directly instead on the packages we want to publish.
+            # yarn nx release publish --tag ${{ parameters['publishTag'] }} --excludeTaskDependencies
+            yarn ./packages/virtualized-lists npm publish --tag ${{ parameters['publishTag'] }}
+            yarn ./packages/react-native npm publish --tag ${{ parameters['publishTag'] }}
           fi
         displayName: Publish packages
         condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))

--- a/packages/nx-release-version/index.js
+++ b/packages/nx-release-version/index.js
@@ -87,10 +87,8 @@ const afterAllProjectsVersioned = async (_cwd, _opts) => {
     changedFiles.push(...versionedFiles);
 
     console.log('✅ Updated React Native artifacts');
-    console.log('🏷️  Created .rnm-publish marker file');
-
+    console.table(versionedFiles.map(file => path.relative(REPO_ROOT, file)));
   } catch (error) {
-    console.error('Failed to update React Native artifacts:', error);
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`❌ Failed to update React Native artifacts: ${errorMessage}`);
     throw error;


### PR DESCRIPTION
## Summary:

Two fixes:
1. After #2560 , I forgot to update the CI step that reads the `nx.json` tag. Let's do that, and have it properly fail if it can't find the tag. 
2, Fix #2580 by calling `yarn npm publish` directly.
3. Use `console.table()` to print the react native artifacts updated in a release. Why? Because it looks cool.

## Test Plan:

CI should pass.
Seriously, this looks cool!
```shell
 NX   No files would be changed as a result of running versioning

✅ Updated React Native artifacts
┌─────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ (index) │ Values                                                                                                           │
├─────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ 0       │ 'packages/react-native/ReactAndroid/gradle.properties'                                                           │
│ 1       │ 'packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java' │
│ 2       │ 'packages/react-native/React/Base/RCTVersion.m'                                                                  │
│ 3       │ 'packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h'                                                │
│ 4       │ 'packages/react-native/Libraries/Core/ReactNativeVersion.js'                                                     │
└─────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```
