### PR TITLE
fix: ensure PausedInDebuggerOverlay has message set before presenting

### DIFF
--- a/packages/react-native/React/DevSupport/RCTPausedInDebuggerOverlayController.mm
+++ b/packages/react-native/React/DevSupport/RCTPausedInDebuggerOverlayController.mm
@@ -179,10 +179,10 @@
   [self.alertWindow makeKeyAndVisible];
   [self.alertWindow.rootViewController presentViewController:view animated:NO completion:nil];
 #else // [macOS]
-  self.alertWindow.contentViewController = view;
   view.message = message;
   view.onResume = onResume;
-  
+
+  self.alertWindow.contentViewController = view;
   NSWindow *parentWindow = RCTKeyWindow();
   if (![[parentWindow sheets] doesContain:self->_alertWindow]) {
     [parentWindow beginSheet:self.alertWindow completionHandler:^(NSModalResponse returnCode) {


### PR DESCRIPTION
## Summary:

RCTUILabel doesn't like it if we set message to nil, which we accidentally did by loading our viewController into a window (which calls viewDidLoad, which creates our label and sets message) before we have set our property. Simple fix to call code in the right order. 

## Test Plan:

<img width="1392" height="860" alt="image" src="https://github.com/user-attachments/assets/c6158b2c-4f8f-4348-9eb0-e863ec72a9e1" />
