### PR TITLE
ci(0.77): use ADO variable syntax for publish tag

### DIFF
--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -68,9 +68,9 @@ jobs:
             # https://github.com/microsoft/react-native-macos/issues/2580
             # `nx release publish` gets confused by the output of RNM's prepack script.
             # Let's call `yarn npm publish` directly instead on the packages we want to publish.
-            # yarn nx release publish --tag ${{ parameters['publishTag'] }} --excludeTaskDependencies
-            yarn ./packages/virtualized-lists npm publish --tag ${{ parameters['publishTag'] }}
-            yarn ./packages/react-native npm publish --tag ${{ parameters['publishTag'] }}
+            # yarn nx release publish --tag $(publishTag) --excludeTaskDependencies
+            yarn ./packages/virtualized-lists npm publish --tag $(publishTag)
+            yarn ./packages/react-native npm publish --tag $(publishTag)
           fi
         displayName: Publish packages
         condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # the global will be requested for
 # review when someone opens a pull request.
-* @microsoft/apple-rn-team
+* @microsoft/react-native-macos-write

--- a/.nx/version-plans/version-plan-1753834798331.md
+++ b/.nx/version-plans/version-plan-1753834798331.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Implement paused in Debugger overlay

--- a/packages/react-native/Libraries/Core/ReactNativeVersion.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersion.js
@@ -16,7 +16,7 @@ const version: $ReadOnly<{
 }> = {
   major: 0,
   minor: 77,
-  patch: 6,
+  patch: 5,
   prerelease: null,
 };
 

--- a/packages/react-native/React/Base/RCTVersion.m
+++ b/packages/react-native/React/Base/RCTVersion.m
@@ -23,7 +23,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(77),
-                  RCTVersionPatch: @(6),
+                  RCTVersionPatch: @(5),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.77.6
+VERSION_NAME=0.77.5
 react.internal.publishingGroup=com.facebook.react
 
 android.useAndroidX=true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -17,6 +17,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 77,
-      "patch", 6,
+      "patch", 5,
       "prerelease", null);
 }

--- a/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -17,7 +17,7 @@ namespace facebook::react {
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 77;
-  int32_t Patch = 6;
+  int32_t Patch = 5;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.77.6",
+  "version": "0.77.5",
   "description": "React Native for macOS",
   "license": "MIT",
   "repository": {
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-macos/virtualized-lists": "0.77.6",
+    "@react-native-macos/virtualized-lists": "0.77.5",
     "@react-native/assets-registry": "0.77.2",
     "@react-native/codegen": "0.77.2",
     "@react-native/community-cli-plugin": "0.77.2",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-macos/virtualized-lists",
-  "version": "0.77.6",
+  "version": "0.77.5",
   "description": "Virtualized lists for React Native macOS.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Backport https://github.com/microsoft/react-native-macos/pull/2595
