### PR TITLE
ci: set npmAuthToken in yarnrc, not npmrc

### DIFF
--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -77,13 +77,7 @@ jobs:
         condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
     - script: |
-        # Check and unset npmAuthToken if it exists
-        if [ "$(yarn config npmAuthToken --json | jq -r '.effective')" != "null" ]; then
-          yarn config unset npmAuthToken
-        fi
-        # Check and unset npmPublishRegistry if it exists
-        if [ "$(yarn config npmPublishRegistry --json | jq -r '.effective')" != "null" ]; then
-          yarn config unset npmPublishRegistry
-        fi
+        yarn config unset npmAuthToken
+        yarn config unset npmPublishRegistry
       displayName: Unset npm configuration
       condition: always()

--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -50,7 +50,8 @@ jobs:
     # Disable Nightly publishing on the main branch
     - ${{ if endsWith(variables['Build.SourceBranchName'], '-stable') }}:
       - script: |
-          echo "//registry.npmjs.org/:_authToken=$(npmAuthToken)" > ~/.npmrc
+          yarn config set npmPublishRegistry "https://registry.npmjs.org"
+          yarn config set npmAuthToken $(npmAuthToken)
           node .ado/scripts/prepublish-check.mjs --verbose --tag $(publishTag)
         displayName: Set and validate npm auth
         condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
@@ -76,6 +77,13 @@ jobs:
         condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
     - script: |
-        rm -f ~/.npmrc
-      displayName: Remove npmrc if it exists
+        # Check and unset npmAuthToken if it exists
+        if [ "$(yarn config npmAuthToken --json | jq -r '.effective')" != "null" ]; then
+          yarn config unset npmAuthToken
+        fi
+        # Check and unset npmPublishRegistry if it exists
+        if [ "$(yarn config npmPublishRegistry --json | jq -r '.effective')" != "null" ]; then
+          yarn config unset npmPublishRegistry
+        fi
+      displayName: Unset npm configuration
       condition: always()


### PR DESCRIPTION
## Summary:

With #2560 and followup changes, we call `yarn npm publish` directly instead of `nx release publish` (Which indirectly used npm publish). Yarn's NPM publish command grabs its auth token from `.yarnrc.yml`, not `.npmrc`. Let's update our CI steps that set this. 


## Test Plan:

Tested that I can call `yarn config set / unset` to set and unset these values. 
