### PR TITLE
chore(0.76): Merge the rest of the React Native 0.76 stable branch

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -131,26 +131,6 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
-  build_android:
-    runs-on: 8-core-ubuntu
-    needs: [set_release_type]
-    container:
-      image: reactnativecommunity/react-native-android:latest
-      env:
-        TERM: "dumb"
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
-        ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
-        ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build Android
-        uses: ./.github/actions/build-android
-        with:
-          release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-
   build_npm_package:
     runs-on: 8-core-ubuntu
     needs:
@@ -160,7 +140,6 @@ jobs:
         build_hermes_macos,
         build_hermesc_linux,
         build_hermesc_windows,
-        build_android,
       ]
     container:
       image: reactnativecommunity/react-native-android:latest

--- a/.nx/version-plans/version-plan-1754531007010.md
+++ b/.nx/version-plans/version-plan-1754531007010.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Sync to upstream React Native 0.76 branch

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,8 @@ nexusPublishing {
     sonatype {
       username.set(sonatypeUsername)
       password.set(sonatypePassword)
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
     }
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -34,7 +34,7 @@ internal object DependencyUtils {
           }
         }
         // We add the snapshot for users on nightlies.
-        mavenRepoFromUrl("https://oss.sonatype.org/content/repositories/snapshots/") { repo ->
+        mavenRepoFromUrl("https://central.sonatype.com/repository/maven-snapshots/") { repo ->
           repo.content { it.excludeGroup("org.webkit") }
         }
         repositories.mavenCentral { repo ->

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -44,7 +44,7 @@ class DependencyUtilsTest {
 
   @Test
   fun configureRepositories_containsSnapshotRepo() {
-    val repositoryURI = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+    val repositoryURI = URI.create("https://central.sonatype.com/repository/maven-snapshots/")
     val project = createProject()
 
     configureRepositories(project, tempFolder.root)
@@ -138,7 +138,7 @@ class DependencyUtilsTest {
 
   @Test
   fun configureRepositories_snapshotRepoHasHigherPriorityThanMavenCentral() {
-    val repositoryURI = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+    val repositoryURI = URI.create("https://central.sonatype.com/repository/maven-snapshots/")
     val mavenCentralURI = URI.create("https://repo.maven.apache.org/maven2/")
     val project = createProject()
 

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -76,7 +76,7 @@ function publishAndroidArtifactsToMaven(
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
       exec(
-        './gradlew findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository',
+        './gradlew publishAndroidToSonatype closeAndReleaseSonatypeStagingRepository',
       ).code
     ) {
       echo(


### PR DESCRIPTION
## Summary:

There doesn't seem to be a release to sync to, but we still want to sync and make a new release. Let's do so. 
