### PR TITLE
chore: remember RCTAppDelegate main window position

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -32,6 +32,10 @@
 
 using namespace facebook::react;
 
+#if TARGET_OS_OSX // [macOS
+static NSString *sRCTAppDelegateMainWindowFrameAutoSaveName = @"RCTAppDelegateMainWindow";
+#endif // macOS]
+
 @implementation RCTAppDelegate
 
 - (instancetype)init
@@ -92,7 +96,10 @@ using namespace facebook::react;
   rootView.frame = frame;
   self.window.contentViewController = rootViewController;
   [self.window makeKeyAndOrderFront:self];
-  [self.window center];
+  if (![self.window setFrameUsingName:sRCTAppDelegateMainWindowFrameAutoSaveName]) {
+    [self.window center];
+  }
+  [self.window setFrameAutosaveName:sRCTAppDelegateMainWindowFrameAutoSaveName];
 #endif // macOS]
 }
 


### PR DESCRIPTION
## Summary:

Previously, we always centered the window, which got a bit annoying during debugging when I'd like to have it remember the last position as I relaunch it. This is probably a good thing to do in general, so let's do it in `RCTAppDelegate`.

## Test Plan:

Removed any saved frame by running `defaults delete Microsoft.RNTester-macOS`: window is centered
Resize window and move it and close and relaunch: old position is remembered. 
