### PR TITLE
chore: Move one instance of `RCTUIView` --> `RCTPlatformView` 

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -244,7 +244,7 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
     NSNumber *index = mountInstruction[kRCTLegacyInteropChildIndexKey];
     RCTUIView *childView = mountInstruction[kRCTLegacyInteropChildComponentKey]; // [macOS]
     if ([childView isKindOfClass:[RCTLegacyViewManagerInteropComponentView class]]) {
-      RCTUIView *target = ((RCTLegacyViewManagerInteropComponentView *)childView).contentView; // [macOS]
+      RCTPlatformView *target = ((RCTLegacyViewManagerInteropComponentView *)childView).contentView; // [macOS]
       [_adapter.paperView insertReactSubview:target atIndex:index.integerValue];
     } else {
       [_adapter.paperView insertReactSubview:childView atIndex:index.integerValue];


### PR DESCRIPTION
## Summary:

In general, we prefer to use `RCTPlatformView` (`#define NSView`) over `RCTUIView` (subclass of NSView for iOS interop) as it tends to have less "Expected NSView, but got subclass of NSView" style errors. This changes fixes one of those errors