### PR TITLE
fix: dismiss redbox only if presented

### DIFF
--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -418,8 +418,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
 #if !TARGET_OS_OSX // [macOS]
   [self dismissViewControllerAnimated:YES completion:nil];
-#else // [macOS
-  [[RCTKeyWindow() contentViewController] dismissViewController:self];
+#else // [macOS]
+  if (self.presentingViewController) {
+    [[RCTKeyWindow() contentViewController] dismissViewController:self];
+  }
 #endif // macOS]
 }
 


### PR DESCRIPTION
## Summary:

We had a bug where if you tried to Reload RNTester (via the dev menu) after a Redbox, the following error was thrown:

```
Thread 1: "dismissViewController:: Error: maybe this view controller was not presented?"
```

This fixes it by checking if there's a presentingViewController first

## Test Plan:

Reloads work now after a Redbox. 
