### PR TITLE
chore: remove diff for `[RCTDevSettings overridenKeys]`

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.h
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.h
@@ -30,13 +30,6 @@
  */
 - (id)settingForKey:(NSString *)key;
 
-// [macOS
-/**
- * Returns all keys that are overridden
- */
-- (NSArray<NSString *> *)overridenKeys;
-// macOS]
-
 @end
 
 @protocol RCTDevSettingsInspectable <NSObject>

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -104,13 +104,6 @@ void RCTDevSettingsSetEnabled(BOOL enabled)
   return _settings[key];
 }
 
-// [macOS
-- (NSArray<NSString *> *)overridenKeys
-{
-  return [_settings allKeys];
-}
-// macOS]
-
 - (void)_reloadWithDefaults:(NSDictionary *)defaultValues
 {
   NSDictionary *existingSettings = [_userDefaults objectForKey:kRCTDevSettingsUserDefaultsKey];


### PR DESCRIPTION
## Summary:

This was added for an old internal use case that is no longer valid. Let's remove it. 

