### PR TITLE
ci: promote 0.79 to next

### DIFF
--- a/.nx/version-plans/version-plan-1756507729173.md
+++ b/.nx/version-plans/version-plan-1756507729173.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Release React Native macOS 0.79.0

--- a/packages/helloworld/package.json
+++ b/packages/helloworld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helloworld",
-  "version": "0.79.6",
+  "version": "0.79.0-rc.0",
   "private": true,
   "scripts": {
     "bootstrap": "node ./cli.js bootstrap",
@@ -13,16 +13,16 @@
   },
   "dependencies": {
     "react": "19.0.0",
-    "react-native-macos": "workspace:*"
+    "react-native-macos": "0.79.0-rc.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@react-native/babel-preset": "0.79.6",
-    "@react-native/core-cli-utils": "0.79.6",
-    "@react-native/eslint-config": "0.79.6",
-    "@react-native/metro-config": "0.79.6",
+    "@react-native/babel-preset": "0.79.0-rc.0",
+    "@react-native/core-cli-utils": "0.79.0-rc.0",
+    "@react-native/eslint-config": "0.79.0-rc.0",
+    "@react-native/metro-config": "0.79.0-rc.0",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "eslint": "^8.19.0",

--- a/packages/nx-release-version/package.json
+++ b/packages/nx-release-version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-macos/nx-release-version",
-  "version": "0.0.1-dev",
+  "version": "0.79.0-rc.0",
   "private": true,
   "description": "Nx Release Version Actions for React Native macOS",
   "homepage": "https://github.com/microsoft/react-native-macos/tree/HEAD/packages/nx-release-version#readme",

--- a/packages/react-native-bots/package.json
+++ b/packages/react-native-bots/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-native/bots",
   "description": "React Native Bots",
-  "version": "0.79.6",
+  "version": "0.79.0-rc.0",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/packages/react-native/Libraries/Core/ReactNativeVersion.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersion.js
@@ -17,5 +17,5 @@ export const version: $ReadOnly<{
   major: 0,
   minor: 79,
   patch: 0,
-  prerelease: null,
+  prerelease: 'rc.0',
 };

--- a/packages/react-native/React/Base/RCTVersion.m
+++ b/packages/react-native/React/Base/RCTVersion.m
@@ -24,7 +24,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(79),
                   RCTVersionPatch: @(0),
-                  RCTVersionPrerelease: [NSNull null],
+                  RCTVersionPrerelease: @"rc.0",
                   };
   });
   return __rnVersion;

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.79.0
+VERSION_NAME=0.79.0-rc.0
 react.internal.publishingGroup=com.facebook.react
 
 android.useAndroidX=true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -18,5 +18,5 @@ public class ReactNativeVersion {
       "major", 0,
       "minor", 79,
       "patch", 0,
-      "prerelease", null);
+      "prerelease", "rc.0");
 }

--- a/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -22,7 +22,7 @@ constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 79;
   int32_t Patch = 0;
-  std::string_view Prerelease = "";
+  std::string_view Prerelease = "rc.0";
 } ReactNativeVersion;
 
 } // namespace facebook::react

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.79.0",
+  "version": "0.79.0-rc.0",
   "description": "React Native for macOS",
   "license": "MIT",
   "repository": {
@@ -113,7 +113,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.7.0",
-    "@react-native-macos/virtualized-lists": "0.79.0",
+    "@react-native-macos/virtualized-lists": "0.79.0-rc.0",
     "@react-native/assets-registry": "0.79.6",
     "@react-native/codegen": "0.79.6",
     "@react-native/community-cli-plugin": "0.79.6",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -55,7 +55,7 @@
     "@react-native-community/cli-platform-ios": "15.0.0-alpha.2",
     "commander": "^12.0.0",
     "listr2": "^6.4.1",
-    "react-native-macos": "workspace:*",
+    "react-native-macos": "0.79.0-rc.0",
     "rxjs": "npm:@react-native-community/rxjs@6.5.4-custom"
   }
 }

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-macos/virtualized-lists",
-  "version": "0.79.0",
+  "version": "0.79.0-rc.0",
   "description": "Virtualized lists for React Native macOS.",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,7 +2573,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-macos/virtualized-lists@npm:0.79.0, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-macos/virtualized-lists@npm:0.79.0-rc.0, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-macos/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -2927,7 +2927,7 @@ __metadata:
     invariant: "npm:^2.2.4"
     listr2: "npm:^6.4.1"
     nullthrows: "npm:^1.1.1"
-    react-native-macos: "workspace:*"
+    react-native-macos: "npm:0.79.0-rc.0"
     rxjs: "npm:@react-native-community/rxjs@6.5.4-custom"
   peerDependencies:
     react: 19.0.0
@@ -10030,12 +10030,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-macos@workspace:*, react-native-macos@workspace:packages/react-native":
+"react-native-macos@npm:0.79.0-rc.0, react-native-macos@workspace:packages/react-native":
   version: 0.0.0-use.local
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.7.0"
-    "@react-native-macos/virtualized-lists": "npm:0.79.0"
+    "@react-native-macos/virtualized-lists": "npm:0.79.0-rc.0"
     "@react-native/assets-registry": "npm:0.79.6"
     "@react-native/codegen": "npm:0.79.6"
     "@react-native/community-cli-plugin": "npm:0.79.6"


### PR DESCRIPTION
## Summary:

Before we can publish React Native macOS 0.79.0, our tooling wants us to publish an rc.. so let's publish an rc first.

Promote and release 0.79.0-rc.0 

