### PR TITLE
fix(constraints): `enforcePrivateReactNativeScopedPackages` checks workspaces instead of dependencies

### DIFF
--- a/packages/react-native-compatibility-check/package.json
+++ b/packages/react-native-compatibility-check/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/compatibility-check",
   "version": "0.79.0-main",
+  "private": true,
   "description": "Check a React Native app's boundary between JS and Native for incompatibilities",
   "license": "MIT",
   "repository": {

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -60,11 +60,11 @@ const isMainBranch = ({Yarn}) => {
  * @param {Context} context
  */
 function enforcePrivateReactNativeScopedPackages({Yarn}) {
-    for (const dependency of Yarn.dependencies()) {
-        if (dependency.ident.startsWith('@react-native/')) {
-            Yarn.workspace({ident: dependency.ident})?.set('private', true);
+    for (const workspace of Yarn.workspaces()) {
+        if (workspace.ident?.startsWith('@react-native/') && !PACKAGES_TO_IGNORE.includes(workspace.ident)) {
+            workspace.set('private', true);
         }
-    }  
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary:

Followup to #2651 , make sure our constraint `enforcePrivateReactNativeScopedPackages` (makes sure the unforked `@react-native/*` packages in this repo are marked private) uses _workspaces_ instead of _dependencies_. The former seems to map to packages, while the latter maps to things in our Yarn lock file. 

## Test Plan:

Tested on the 0.79-stable branch with #2650 
