### PR TITLE
chore(ci): disable integration tests

### DIFF
--- a/.github/workflows/microsoft-pr.yml
+++ b/.github/workflows/microsoft-pr.yml
@@ -127,21 +127,21 @@ jobs:
     permissions: {}
     uses: ./.github/workflows/microsoft-build-rntester.yml
 
-  test-react-native-macos-init:
-    name: "Test react-native-macos init"
-    permissions: {}
-    # https://github.com/microsoft/react-native-macos/issues/2344
-    # Run only for stable branches. Once nightlies are available, enable on main as well.
-    if: ${{ endsWith(github.base_ref, '-stable') }}
-    uses: ./.github/workflows/microsoft-test-react-native-macos-init.yml
+  # https://github.com/microsoft/react-native-macos/issues/2344
+  # Disable these tests because verdaccio hangs
+  # test-react-native-macos-init:
+  #   name: "Test react-native-macos init"
+  #   permissions: {}
+  #   if: ${{ endsWith(github.base_ref, '-stable') }}
+  #   uses: ./.github/workflows/microsoft-test-react-native-macos-init.yml
 
-  react-native-test-app-integration:
-    name: "Test react-native-test-app integration"
-    permissions: {}
-    # https://github.com/microsoft/react-native-macos/issues/2344
-    # Run only for stable branches. Once nightlies are available, enable on main as well.
-    if: ${{ endsWith(github.base_ref, '-stable') }}
-    uses: ./.github/workflows/microsoft-react-native-test-app-integration.yml
+  # https://github.com/microsoft/react-native-macos/issues/2344
+  # Disable these tests because verdaccio hangs
+  # react-native-test-app-integration:
+  #   name: "Test react-native-test-app integration"
+  #   permissions: {}
+  #   if: ${{ endsWith(github.base_ref, '-stable') }}
+  #   uses: ./.github/workflows/microsoft-react-native-test-app-integration.yml
 
   all:
     name: "All"

--- a/.github/workflows/microsoft-pr.yml
+++ b/.github/workflows/microsoft-pr.yml
@@ -154,8 +154,8 @@ jobs:
       - yarn-constraints
       - javascript-tests
       - build-rntester
-      - test-react-native-macos-init
-      - react-native-test-app-integration
+      # - test-react-native-macos-init
+      # - react-native-test-app-integration
     if: always()
     steps:
       - name: All required jobs passed


### PR DESCRIPTION
## Summary:

Verdaccio still hangs on 0.79-stable, so let's disable this altogether for now. 
