### PR TITLE
ci: rename GHA job to match Azure Pipelines to satisfy checks

### DIFF
--- a/.github/workflows/microsoft-pr.yml
+++ b/.github/workflows/microsoft-pr.yml
@@ -143,8 +143,8 @@ jobs:
   #   if: ${{ endsWith(github.base_ref, '-stable') }}
   #   uses: ./.github/workflows/microsoft-react-native-test-app-integration.yml
 
-  pr:
-    name: "All Checks"
+  PR:
+    name: "PR"
     permissions: {}
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/microsoft-pr.yml
+++ b/.github/workflows/microsoft-pr.yml
@@ -143,20 +143,18 @@ jobs:
   #   if: ${{ endsWith(github.base_ref, '-stable') }}
   #   uses: ./.github/workflows/microsoft-react-native-test-app-integration.yml
 
-  all:
-    name: "All"
+  pr:
+    name: "All Checks"
     permissions: {}
     runs-on: ubuntu-latest
     needs:
       - lint-title
-      - build-website
       - npm-publish-dry-run
       - yarn-constraints
       - javascript-tests
       - build-rntester
       # - test-react-native-macos-init
       # - react-native-test-app-integration
-    if: always()
     steps:
       - name: All required jobs passed
         run: echo "All required jobs completed."


### PR DESCRIPTION
## Summary:

On older stable branches, our Github repo ruleset looked for a job named "PR", which we have now named "all" in Github Actions. Let's rename the GHA job so that Azure Pipelines and GHA both report success on the same job and we don't need to fork our ruleset.

## Test Plan:

Testing in #2650 
