### PR TITLE
fix: null shadow color crash

### DIFF
--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -764,7 +764,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 -(void)didUpdateShadow
 {
     NSShadow *shadow = [NSShadow new];
-    NSColor *baseShadowColor = [NSColor colorWithCGColor:_shadowColor];
+    NSColor *baseShadowColor = nil;
+    if (_shadowColor != NULL) {
+      baseShadowColor = [NSColor colorWithCGColor:_shadowColor];
+    }
     shadow.shadowColor = [baseShadowColor colorWithAlphaComponent:[self shadowOpacity]];
     shadow.shadowOffset = [self shadowOffset];
     shadow.shadowBlurRadius = [self shadowRadius];


### PR DESCRIPTION
## Summary:

When updating RCTView in https://github.com/microsoft/react-native-macos/pull/2642, we end up slightly changing the behavior when `didUpdateShadow` is called, causing transparent shadows to crash the app. This breakage occurs because `NSColor colorWithCGColor:` doesn’t accept a `NULL` `CGColorRef`; instead, it raises an exception rather than gracefully returning `nil`.

<img  height="698" alt="image" src="https://github.com/user-attachments/assets/67413d6e-47e8-47b3-8b29-b9b553cfd19f" />

## Test Plan:

Run RNTester
