### PR TITLE
[DRAFT] fix(fabric, view): support a bunch of macOS only view props

### DIFF
--- a/ReactCommon/react/renderer/components/view/macOS/KeyEvent.h
+++ b/ReactCommon/react/renderer/components/view/macOS/KeyEvent.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::react {
+
+/*
+ * Describes a request to handle a key input.
+ */
+struct HandledKey {
+  /**
+   * The key for the event aligned to https://www.w3.org/TR/uievents-key/.
+   */
+  std::string key{};
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  std::optional<bool> altKey{};
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  std::optional<bool> ctrlKey{};
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  std::optional<bool> shiftKey{};
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  std::optional<bool> metaKey{};
+};
+
+inline static bool operator==(const HandledKey &lhs, const HandledKey &rhs) {
+  return lhs.key == rhs.key && lhs.altKey == rhs.altKey && lhs.ctrlKey == rhs.ctrlKey &&
+      lhs.shiftKey == rhs.shiftKey && lhs.metaKey == rhs.metaKey;
+}
+
+/**
+ * Key event emitted by handled key events.
+ */
+struct KeyEvent {
+  /**
+   * The key for the event aligned to https://www.w3.org/TR/uievents-key/.
+   */
+  std::string key{};
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  bool altKey{false};
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  bool ctrlKey{false};
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool shiftKey{false};
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  bool metaKey{false};
+  
+  /*
+   * A flag indicating if the caps lock key is pressed.
+   */
+  bool capsLockKey{false};
+
+  /*
+   * A flag indicating if the key on the numeric pad is pressed.
+   */
+  bool numericPadKey{false};
+
+  /*
+   * A flag indicating if the help key is pressed.
+   */
+  bool helpKey{false};
+
+  /*
+   * A flag indicating if a function key is pressed.
+   */
+  bool functionKey{false};
+};
+
+inline static bool operator==(const KeyEvent &lhs, const HandledKey &rhs) {
+  return lhs.key == rhs.key && 
+      (!rhs.altKey.has_value() || lhs.altKey == *rhs.altKey) && 
+      (!rhs.ctrlKey.has_value() || lhs.ctrlKey == *rhs.ctrlKey) && 
+      (!rhs.shiftKey.has_value() || lhs.shiftKey == *rhs.shiftKey) && 
+      (!rhs.metaKey.has_value() || lhs.metaKey == *rhs.metaKey);
+}
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/components/view/macOS/MacOSViewEventEmitter.cpp
+++ b/ReactCommon/react/renderer/components/view/macOS/MacOSViewEventEmitter.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MacOSViewEventEmitter.h"
+
+namespace facebook::react {
+
+#pragma mark - Keyboard Events
+
+static jsi::Value keyEventPayload(jsi::Runtime &runtime, KeyEvent const &event) {
+  auto payload = jsi::Object(runtime);
+  payload.setProperty(runtime, "key", jsi::String::createFromUtf8(runtime, event.key));
+  payload.setProperty(runtime, "ctrlKey", event.ctrlKey);
+  payload.setProperty(runtime, "shiftKey", event.shiftKey);
+  payload.setProperty(runtime, "altKey", event.altKey);
+  payload.setProperty(runtime, "metaKey", event.metaKey);
+  payload.setProperty(runtime, "capsLockKey", event.capsLockKey);
+  payload.setProperty(runtime, "numericPadKey", event.numericPadKey);
+  payload.setProperty(runtime, "helpKey", event.helpKey);
+  payload.setProperty(runtime, "functionKey", event.functionKey);
+  return payload;
+};
+
+void MacOSViewEventEmitter::onKeyDown(KeyEvent const &keyEvent) const {
+  dispatchEvent(
+      "keyDown",
+      [keyEvent](jsi::Runtime &runtime) { return keyEventPayload(runtime, keyEvent); },
+      EventPriority::AsynchronousBatched);
+}
+
+void MacOSViewEventEmitter::onKeyUp(KeyEvent const &keyEvent) const {
+  dispatchEvent(
+      "keyUp",
+      [keyEvent](jsi::Runtime &runtime) { return keyEventPayload(runtime, keyEvent); },
+      EventPriority::AsynchronousBatched);
+}
+
+static jsi::Value mouseEventPayload(jsi::Runtime &runtime, MouseEvent const &event) {
+  auto payload = jsi::Object(runtime);
+  payload.setProperty(runtime, "clientX", event.clientX);
+  payload.setProperty(runtime, "clientY", event.clientY);
+  payload.setProperty(runtime, "screenX", event.screenX);
+  payload.setProperty(runtime, "screenY", event.screenY);
+  payload.setProperty(runtime, "altKey", event.altKey);
+  payload.setProperty(runtime, "ctrlKey", event.ctrlKey);
+  payload.setProperty(runtime, "shiftKey", event.shiftKey);
+  payload.setProperty(runtime, "metaKey", event.metaKey);
+  return payload;
+};
+
+void MacOSViewEventEmitter::onMouseEnter(MouseEvent const &mouseEvent) const {
+  dispatchEvent(
+      "mouseEnter",
+      [mouseEvent](jsi::Runtime &runtime) { return mouseEventPayload(runtime, mouseEvent); },
+      EventPriority::AsynchronousBatched);
+}
+
+void MacOSViewEventEmitter::onMouseLeave(MouseEvent const &mouseEvent) const {
+  dispatchEvent(
+      "mouseLeave",
+      [mouseEvent](jsi::Runtime &runtime) { return mouseEventPayload(runtime, mouseEvent); },
+      EventPriority::AsynchronousBatched);
+}
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/components/view/macOS/MacOSViewEventEmitter.h
+++ b/ReactCommon/react/renderer/components/view/macOS/MacOSViewEventEmitter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/TouchEventEmitter.h>
+#include <react/renderer/components/view/macOS/KeyEvent.h>
+#include <react/renderer/components/view/macOS/MouseEvent.h>
+
+namespace facebook::react {
+
+class MacOSViewEventEmitter : public TouchEventEmitter {
+ public:
+  using TouchEventEmitter::TouchEventEmitter;
+
+#pragma mark - Keyboard Events
+
+  void onKeyDown(KeyEvent const &keyEvent) const;
+  void onKeyUp(KeyEvent const &keyEvent) const;
+  
+#pragma mark - Mouse Events
+
+  void onMouseEnter(MouseEvent const &mouseEvent) const;
+  void onMouseLeave(MouseEvent const &mouseEvent) const;
+};
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/components/view/macOS/MacOSViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/macOS/MacOSViewProps.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MacOSViewProps.h"
+
+#include <react/renderer/components/view/macOS/conversions.h>
+#include <react/renderer/core/CoreFeatures.h>
+#include <react/renderer/core/propsConversions.h>
+
+namespace facebook::react {
+
+MacOSViewProps::MacOSViewProps(
+    const PropsParserContext &context,
+    const MacOSViewProps &sourceProps,
+    const RawProps &rawProps,
+    bool shouldSetRawProps)
+    : macOSViewEvents(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.macOSViewEvents
+                                                 : convertRawProp(context, rawProps, sourceProps.macOSViewEvents, {})),
+      focusable(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.focusable
+              : convertRawProp(context, rawProps, "focusable", sourceProps.focusable, {})),
+      enableFocusRing(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.enableFocusRing
+              : convertRawProp(context, rawProps, "enableFocusRing", sourceProps.enableFocusRing, true)),
+      validKeysDown(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.validKeysDown
+              : convertRawProp(context, rawProps, "validKeysDown", sourceProps.validKeysDown, {})),
+      validKeysUp(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.validKeysUp
+              : convertRawProp(context, rawProps, "validKeysUp", sourceProps.validKeysUp, {})){};
+
+#define VIEW_EVENT_CASE_MACOS(eventType, eventString) \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH(eventString): {   \
+    MacOSViewEvents defaultViewEvents{};              \
+    bool res = defaultViewEvents[eventType];          \
+    if (value.hasValue()) {                           \
+      fromRawValue(context, value, res);              \
+    }                                                 \
+    macOSViewEvents[eventType] = res;                 \
+    return;                                           \
+  }
+
+void MacOSViewProps::setProp(
+    const PropsParserContext &context,
+    RawPropsPropNameHash hash,
+    const char *propName,
+    RawValue const &value) {
+  switch (hash) {
+    VIEW_EVENT_CASE_MACOS(MacOSViewEvents::Offset::KeyDown, "onKeyDown");
+    VIEW_EVENT_CASE_MACOS(MacOSViewEvents::Offset::KeyUp, "onKeyUp");
+    VIEW_EVENT_CASE_MACOS(MacOSViewEvents::Offset::MouseEnter, "onMouseEnter");
+    VIEW_EVENT_CASE_MACOS(MacOSViewEvents::Offset::MouseLeave, "onMouseLeave");
+    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable, false);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(enableFocusRing, true);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(validKeysDown, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(validKeysUp, {});
+  }
+}
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/components/view/macOS/MacOSViewProps.h
+++ b/ReactCommon/react/renderer/components/view/macOS/MacOSViewProps.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/macOS/KeyEvent.h>
+#include <react/renderer/components/view/macOS/primitives.h>
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
+
+namespace facebook::react {
+
+class MacOSViewProps {
+  public:
+    MacOSViewProps() = default;
+    MacOSViewProps(
+        const PropsParserContext &context,
+        const MacOSViewProps &sourceProps,
+        const RawProps &rawProps,
+        bool shouldSetRawProps = true);
+
+  void
+  setProp(
+      const PropsParserContext &context,
+      RawPropsPropNameHash hash,
+      const char *propName,
+      RawValue const &value);
+
+  MacOSViewEvents macOSViewEvents{};
+
+  bool focusable{false};
+  bool enableFocusRing{true};
+
+  std::optional<std::vector<HandledKey>> validKeysDown{};
+  std::optional<std::vector<HandledKey>> validKeysUp{};
+};
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/components/view/macOS/MouseEvent.h
+++ b/ReactCommon/react/renderer/components/view/macOS/MouseEvent.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/Geometry.h>
+
+namespace facebook::react {
+
+/*
+ * Describes a mouse enter/leave event.
+ */
+struct MouseEvent {
+  /**
+   * Pointer horizontal location in target view.
+   */
+  Float clientX{0};
+  
+  /**
+   * Pointer vertical location in target view.
+   */
+  Float clientY{0};
+
+  /**
+   * Pointer horizontal location in window.
+   */
+  Float screenX{0};
+  
+  /**
+   * Pointer vertical location in window.
+   */
+  Float screenY{0};
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  bool altKey{false};
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  bool ctrlKey{false};
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool shiftKey{false};
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  bool metaKey{false};
+};
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/components/view/macOS/conversions.h
+++ b/ReactCommon/react/renderer/components/view/macOS/conversions.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Conv.h>
+#include <react/renderer/components/view/macOS/KeyEvent.h>
+#include <react/renderer/components/view/macOS/primitives.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
+
+#include <unordered_map>
+#include <string>
+
+namespace facebook::react {
+
+static inline MacOSViewEvents convertRawProp(
+    const PropsParserContext &context,
+    const RawProps &rawProps,
+    const MacOSViewEvents &sourceValue,
+    const MacOSViewEvents &defaultValue) {
+  MacOSViewEvents result{};
+  using Offset = MacOSViewEvents::Offset;
+
+  result[Offset::KeyDown] =
+      convertRawProp(context, rawProps, "onKeyDown", sourceValue[Offset::KeyDown], defaultValue[Offset::KeyDown]);
+  result[Offset::KeyUp] =
+      convertRawProp(context, rawProps, "onKeyUp", sourceValue[Offset::KeyUp], defaultValue[Offset::KeyUp]);
+
+  result[Offset::MouseEnter] =
+      convertRawProp(context, rawProps, "onMouseEnter", sourceValue[Offset::MouseEnter], defaultValue[Offset::MouseEnter]);
+  result[Offset::MouseLeave] =
+      convertRawProp(context, rawProps, "onMouseLeave", sourceValue[Offset::MouseLeave], defaultValue[Offset::MouseLeave]);
+
+  return result;
+}
+
+inline void fromRawValue(const PropsParserContext &context, const RawValue &value, HandledKey &result) {
+  if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    auto map = static_cast<std::unordered_map<std::string, RawValue>>(value);
+    for (const auto &pair : map) {
+      if (pair.first == "key") {
+        result.key = static_cast<std::string>(pair.second);
+      } else if (pair.first == "altKey") {
+        result.altKey = static_cast<bool>(pair.second);
+      } else if (pair.first == "ctrlKey") {
+        result.ctrlKey = static_cast<bool>(pair.second);
+      } else if (pair.first == "shiftKey") {
+        result.shiftKey = static_cast<bool>(pair.second);
+      } else if (pair.first == "metaKey") {
+        result.metaKey = static_cast<bool>(pair.second);
+      }
+    }
+  } else if (value.hasType<std::string>()) {
+    result.key = (std::string)value;
+  }
+}
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/components/view/macOS/primitives.h
+++ b/ReactCommon/react/renderer/components/view/macOS/primitives.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <bitset>
+
+namespace facebook::react {
+
+struct MacOSViewEvents {
+  std::bitset<8> bits{};
+
+  enum class Offset : uint8_t {
+    KeyDown = 1,
+    KeyUp = 2,
+
+    MouseEnter = 3,
+    MouseLeave = 4,
+  };
+
+  constexpr bool operator[](const Offset offset) const {
+    return bits[static_cast<uint8_t>(offset)];
+  }
+
+  std::bitset<8>::reference operator[](const Offset offset) {
+    return bits[static_cast<uint8_t>(offset)];
+  }
+};
+
+inline static bool operator==(MacOSViewEvents const &lhs, MacOSViewEvents const &rhs) {
+  return lhs.bits == rhs.bits;
+}
+
+inline static bool operator!=(MacOSViewEvents const &lhs, MacOSViewEvents const &rhs) {
+  return lhs.bits != rhs.bits;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
@@ -13,13 +13,14 @@
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/ReactPrimitives.h>
 
-#include "TouchEventEmitter.h"
+#include "HostPlatformViewEventEmitter.h"
 
 namespace facebook::react {
 
-class BaseViewEventEmitter : public TouchEventEmitter {
+class BaseViewEventEmitter : public HostPlatformViewEventEmitter {
  public:
-  using TouchEventEmitter::TouchEventEmitter;
+  using HostPlatformViewEventEmitter::HostPlatformViewEventEmitter;
+
 
 #pragma mark - Accessibility
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -59,6 +59,7 @@ BaseViewProps::BaseViewProps(
     const std::function<bool(const std::string&)>& filterObjectKeys)
     : YogaStylableProps(context, sourceProps, rawProps, filterObjectKeys),
       AccessibilityProps(context, sourceProps, rawProps),
+      HostPlatformViewProps(context, sourceProps, rawProps, shouldSetRawProps),
       opacity(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.opacity
@@ -369,6 +370,7 @@ void BaseViewProps::setProp(
   // reuse the same values.
   YogaStylableProps::setProp(context, hash, propName, value);
   AccessibilityProps::setProp(context, hash, propName, value);
+  HostPlatformViewProps::setProp(context, hash, propName, value);
 
   static auto defaults = BaseViewProps{};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -9,6 +9,7 @@
 
 #include <react/renderer/components/view/AccessibilityProps.h>
 #include <react/renderer/components/view/YogaStylableProps.h>
+#include <react/renderer/components/view/HostPlatformViewProps.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/Props.h>
@@ -25,8 +26,9 @@
 
 namespace facebook::react {
 
-class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
+class BaseViewProps : public YogaStylableProps, public AccessibilityProps, public HostPlatformViewProps {
  public:
+  using SharedViewProps = std::shared_ptr<BaseViewProps const>;
   BaseViewProps() = default;
   BaseViewProps(
       const PropsParserContext& context,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if TARGET_OS_OSX
+
+#include <react/renderer/components/view/macOS/MacOSViewEventEmitter.h>
+
+namespace facebook::react {
+using HostPlatformViewEventEmitter = MacOSViewEventEmitter;
+} // namespace facebook::react
+
+#else
+
+#include <react/renderer/components/view/TouchEventEmitter.h>
+
+namespace facebook::react {
+  using HostPlatformViewEventEmitter = TouchEventEmitter;
+} // namespace facebook::react
+
+#endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/HostPlatformViewProps.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if !TARGET_OS_OSX // [macOS
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
+#else // [macOS
+#include <react/renderer/components/view/macOS/MacOSViewProps.h>
+#endif // macOS]
+
+namespace facebook::react {
+#if !TARGET_OS_OSX // [macOS]
+class HostPlatformViewProps {
+ public:
+  HostPlatformViewProps() = default;
+  HostPlatformViewProps(
+      const PropsParserContext &context,
+      const HostPlatformViewProps &sourceProps,
+      const RawProps &rawProps,
+      bool shouldSetRawProps = true) {}
+
+  void
+  setProp(
+      const PropsParserContext &context,
+      RawPropsPropNameHash hash,
+      const char *propName,
+      RawValue const &value) {}
+};
+#else // [macOS
+  using HostPlatformViewProps = MacOSViewProps;
+#endif // macOS]
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -62,6 +62,12 @@ void ViewShadowNode::initialize() noexcept {
       !viewProps.filter.empty() ||
       viewProps.mixBlendMode != BlendMode::Normal ||
       viewProps.isolation == Isolation::Isolate ||
+#if TARGET_OS_OSX // [macOS
+      viewProps.focusable ||
+      viewProps.enableFocusRing ||
+      viewProps.macOSViewEvents[MacOSViewEvents::Offset::MouseEnter] ||
+      viewProps.macOSViewEvents[MacOSViewEvents::Offset::MouseLeave] ||
+#endif // macOS]
       HostPlatformViewTraitsInitializer::formsStackingContext(viewProps);
 
   bool formsView = formsStackingContext ||


### PR DESCRIPTION
## Summary:

Cherry pick a bunch of the commits in #2117 around adding support for macOS only view props like `focusable`

## Test Plan:

todo