### PR TITLE
ci: only create .rnm-publish sentinel file if versioning happened

### DIFF
--- a/packages/nx-release-version/index.js
+++ b/packages/nx-release-version/index.js
@@ -79,22 +79,25 @@ const afterAllProjectsVersioned = async (cwd, opts) => {
   const changedFiles = [...baseResult.changedFiles];
   const deletedFiles = [...baseResult.deletedFiles];
 
-  try {
-    // Create the .rnm-publish file to indicate versioning has occurred
-    fs.writeFileSync(path.join(REPO_ROOT, '.rnm-publish'), '');
+  // Only update React Native artifacts if versioning actually happened
+  if (changedFiles.length > 0) {
+    try {
+      // Create the .rnm-publish file to indicate versioning has occurred
+      fs.writeFileSync(path.join(REPO_ROOT, '.rnm-publish'), '');
 
-    // Update React Native artifacts
-    const versionedFiles = await runSetVersion();
+      // Update React Native artifacts
+      const versionedFiles = await runSetVersion();
 
-    // Add the versioned files to changed files
-    changedFiles.push(...versionedFiles);
+      // Add the versioned files to changed files
+      changedFiles.push(...versionedFiles);
 
-    console.log('✅ Updated React Native artifacts');
-    console.table(versionedFiles.map(file => path.relative(REPO_ROOT, file)));
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error(`❌ Failed to update React Native artifacts: ${errorMessage}`);
-    throw error;
+      console.log('✅ Updated React Native artifacts');
+      console.table(versionedFiles.map(file => path.relative(REPO_ROOT, file)));
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`❌ Failed to update React Native artifacts: ${errorMessage}`);
+      throw error;
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary:

We run `npm publish` if a `.rnm-publish` sentinel file exists, which is created as part of nx release. We were unconditionally creating it, which meant that we would attempt to publish every run, leading to failed publish runs that try to publish over an existing package. This change adds a check to only create the sentinel file if publish detects a change.

## Test Plan:

CI should pass