### PR TITLE
feat(fabric): Add macOS host platform to ReactCommon

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -76,7 +76,7 @@ using namespace facebook::react;
 {
   // Prop updates are ignored by _refreshControl until after the initial layout, so just store them in _props until then
   if (_isBeforeInitialLayout) {
-    _props = std::static_pointer_cast<const BaseViewProps>(props);
+    _props = std::static_pointer_cast<const PullToRefreshViewProps>(props); // [macOS]
     return;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ // [macOS]
+
+#pragma once
+
+#include <react/renderer/components/view/BaseTouch.h>
+
+namespace facebook::react {
+using HostPlatformTouch = BaseTouch;
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ // [macOS]
+
+#include <react/renderer/components/view/HostPlatformViewEventEmitter.h>
+
+namespace facebook::react {
+
+#pragma mark - Focus Events
+
+void HostPlatformViewEventEmitter::onFocus() const {
+  dispatchEvent("focus");
+}
+
+void HostPlatformViewEventEmitter::onBlur() const {
+  dispatchEvent("blur");
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ // [macOS]
+
+#pragma once
+
+#include <react/renderer/components/view/BaseViewEventEmitter.h>
+
+namespace facebook::react {
+using HostPlatformViewEventEmitter = BaseViewEventEmitter;
+} // namespace facebook::react
+
+#pragma mark - Focus Events
+
+void HostPlatformViewEventEmitter::onFocus() const {
+  dispatchEvent("focus");
+}
+
+void HostPlatformViewEventEmitter::onBlur() const {
+  dispatchEvent("blur");
+}

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -12,15 +12,15 @@
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 
 namespace facebook::react {
-using HostPlatformViewEventEmitter = BaseViewEventEmitter;
-} // namespace facebook::react
+
+class HostPlatformViewEventEmitter : public BaseViewEventEmitter {
+ public:
+  using BaseViewEventEmitter::BaseViewEventEmitter;
 
 #pragma mark - Focus Events
 
-void HostPlatformViewEventEmitter::onFocus() const {
-  dispatchEvent("focus");
-}
+  void onFocus() const;
+  void onBlur() const;
+};
 
-void HostPlatformViewEventEmitter::onBlur() const {
-  dispatchEvent("blur");
-}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostPlatformViewProps.h"
+
+#include <algorithm>
+
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/components/view/conversions.h>
+#include <react/renderer/components/view/propsConversions.h>
+#include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/core/propsConversions.h>
+
+namespace facebook::react {
+
+HostPlatformViewProps::HostPlatformViewProps(
+    const PropsParserContext& context,
+    const HostPlatformViewProps& sourceProps,
+    const RawProps& rawProps)
+    : BaseViewProps(context, sourceProps, rawProps),
+      macOSViewEvents(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.macOSViewEvents
+              : convertRawProp(
+                    context, 
+                    rawProps,
+                    sourceProps.macOSViewEvents,
+                    {})),
+      focusable(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.focusable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "focusable",
+                    sourceProps.focusable,
+                    {})),
+      enableFocusRing(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.enableFocusRing
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "enableFocusRing",
+                    sourceProps.enableFocusRing,
+                    {})) {}
+
+#define MACOS_VIEW_EVENT_CASE(eventType)                    \
+case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): {       \
+  const auto offset = MacOSViewEvents::Offset::eventType;   \
+  MacOSViewEvents defaultViewEvents{};                      \
+  bool res = defaultViewEvents[offset];                     \
+  if (value.hasValue()) {                                   \
+    fromRawValue(context, value, res);                      \
+  }                                                         \
+  macOSViewEvents[offset] = res;                              \
+  return;                                                   \
+}
+
+void HostPlatformViewProps::setProp(
+    const PropsParserContext& context,
+    RawPropsPropNameHash hash,
+    const char* propName,
+    const RawValue& value) {
+  // All Props structs setProp methods must always, unconditionally,
+  // call all super::setProp methods, since multiple structs may
+  // reuse the same values.
+  BaseViewProps::setProp(context, hash, propName, value);
+  
+  static auto defaults = HostPlatformViewProps{};
+  
+  switch (hash) {
+    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(enableFocusRing);
+    MACOS_VIEW_EVENT_CASE(Focus);
+    MACOS_VIEW_EVENT_CASE(Blur);
+      
+  }
+}
+
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
@@ -14,6 +14,8 @@
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 
+#include "MacOSViewEvents.h"
+
 namespace facebook::react {
 
 class HostPlatformViewProps : public BaseViewProps {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ // [macOS]
+ 
+#pragma once
+
+#include <react/renderer/components/view/BaseViewProps.h>
+
+namespace facebook::react {
+using HostPlatformViewProps = BaseViewProps;
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
@@ -6,11 +6,36 @@
  */
 
  // [macOS]
- 
+
 #pragma once
 
 #include <react/renderer/components/view/BaseViewProps.h>
+#include <react/renderer/components/view/primitives.h>
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook::react {
-using HostPlatformViewProps = BaseViewProps;
+
+class HostPlatformViewProps : public BaseViewProps {
+ public:
+  HostPlatformViewProps() = default;
+  HostPlatformViewProps(
+      const PropsParserContext& context,
+      const HostPlatformViewProps& sourceProps,
+      const RawProps& rawProps);
+
+  void setProp(
+      const PropsParserContext& context,
+      RawPropsPropNameHash hash,
+      const char* propName,
+      const RawValue& value);
+
+  MacOSViewEvents macOSViewEvents{};
+
+#pragma mark - Props
+
+  bool focusable{false};
+  bool enableFocusRing{true};
+
+};
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/ShadowNodeTraits.h>
+
+namespace facebook::react::HostPlatformViewTraitsInitializer {
+
+inline bool formsStackingContext(const ViewProps& props) {
+  return false;
+}
+
+inline bool formsView(const ViewProps& props) {
+  return false;
+}
+
+} // namespace facebook::react::HostPlatformViewTraitsInitializer

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -17,7 +17,7 @@ inline bool formsStackingContext(const ViewProps& props) {
 }
 
 inline bool formsView(const ViewProps& props) {
-  return false;
+  return props.focusable || props.enableFocusRing;
 }
 
 } // namespace facebook::react::HostPlatformViewTraitsInitializer

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -17,7 +17,7 @@ inline bool formsStackingContext(const ViewProps& props) {
 }
 
 inline bool formsView(const ViewProps& props) {
-  return props.focusable || props.enableFocusRing;
+  return props.focusable;
 }
 
 } // namespace facebook::react::HostPlatformViewTraitsInitializer

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
@@ -16,20 +16,20 @@ namespace facebook::react {
 
 // TODO: Windows names this "WindowsEvents" and drops "View". Should we?
 struct MacOSViewEvents {
-  std::bitset<8> bits{}; // TODO: Windows sets this to 32.. should we be higher?
+  std::bitset<64> bits{};
 
-  enum class Offset : uint8_t { // TODO: Windows sets this and others to std::size_t instead of uint8_t.. should we?
+  enum class Offset : std::size_t {
     // Focus Events
     Focus = 0,
     Blur = 1,
   };
 
   constexpr bool operator[](const Offset offset) const {
-    return bits[static_cast<uint8_t>(offset)];
+    return bits[static_cast<std::size_t >(offset)];
   }
 
-  std::bitset<8>::reference operator[](const Offset offset) {
-    return bits[static_cast<uint8_t>(offset)];
+  std::bitset<64>::reference operator[](const Offset offset) {
+    return bits[static_cast<std::size_t >(offset)];
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
+
+#include <bitset>
+
+namespace facebook::react {
+
+struct MacOSViewEvents {
+  std::bitset<8> bits{}; // TODO: Windows sets this to 32.. should we be higher?
+
+  enum class Offset : uint8_t { // TODO: Windows sets this and others to std::size_t instead of uint8_t.. should we?
+    // Focus Events
+    Focus = 0,
+    Blur = 1,
+  };
+
+  constexpr bool operator[](const Offset offset) const {
+    return bits[static_cast<uint8_t>(offset)];
+  }
+
+  std::bitset<8>::reference operator[](const Offset offset) {
+    return bits[static_cast<uint8_t>(offset)];
+  }
+};
+
+inline static bool operator==(MacOSViewEvents const &lhs, MacOSViewEvents const &rhs) {
+  return lhs.bits == rhs.bits;
+}
+
+inline static bool operator!=(MacOSViewEvents const &lhs, MacOSViewEvents const &rhs) {
+  return lhs.bits != rhs.bits;
+}
+
+static inline MacOSViewEvents convertRawProp(
+    const PropsParserContext &context,
+    const RawProps &rawProps,
+    const MacOSViewEvents &sourceValue,
+    const MacOSViewEvents &defaultValue) {
+  MacOSViewEvents result{};
+  using Offset = MacOSViewEvents::Offset;
+
+  // Focus Events
+  result[Offset::Focus] =
+      convertRawProp(context, rawProps, "onFocus", sourceValue[Offset::Focus], defaultValue[Offset::Focus]);
+  result[Offset::Blur] =
+      convertRawProp(context, rawProps, "onBlur", sourceValue[Offset::Blur], defaultValue[Offset::Blur]);
+
+  return result;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
@@ -14,6 +14,7 @@
 
 namespace facebook::react {
 
+// TODO: Windows names this "WindowsEvents" and drops "View". Should we?
 struct MacOSViewEvents {
   std::bitset<8> bits{}; // TODO: Windows sets this to 32.. should we be higher?
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MacOSViewEvents.h
@@ -14,7 +14,6 @@
 
 namespace facebook::react {
 
-// TODO: Windows names this "WindowsEvents" and drops "View". Should we?
 struct MacOSViewEvents {
   std::bitset<64> bits{};
 


### PR DESCRIPTION
## Summary:

Add a new macOS host platform folder, with overrides for some of the HostPlatform* files to implement some macOS only props. This follows the pattern in React Native Core that Android uses, and what React Native Windows does. 

Some notes:

- I also needed to fix a casting issue in `RCTPullToRefreshViewComponentView.mm`. This is later fixed upstream so we can remove the diff then. 
- These new props are not implemented on the component (`RCTViewComponentView` yet, that will be in a future PR)

## Test Plan:

CI should pass. 
