### PR TITLE
ci: pin cmake to 3.31.6

### DIFF
--- a/.github/actions/microsoft-setup-toolchain/action.yml
+++ b/.github/actions/microsoft-setup-toolchain/action.yml
@@ -22,6 +22,31 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Pin cmake version
+      if: ${{ inputs.platform == 'macos' || inputs.platform == 'ios' || inputs.platform == 'visionos' }}
+      run: |
+        brew uninstall cmake
+        # Copied from https://github.com/actions/runner-images/pull/12791
+        # Pin cmake to 3.31.6 due to a backward compatibility issue
+        # https://github.com/actions/runner-images/issues/11926
+        cmake_commit="b4e46db74e74a8c1650b38b1da222284ce1ec5ce"
+        tap_name="local/pinned"
+        
+        echo "Creating local tap (no git)..."
+        brew tap-new --no-git "$tap_name" >/dev/null
+        
+        cmake_formula_dir="$(brew --repo "$tap_name")/Formula"
+        mkdir -p "$cmake_formula_dir"
+        
+        cmake_rb_link="https://raw.githubusercontent.com/Homebrew/homebrew-core/$cmake_commit/Formula/c/cmake.rb"
+        cmake_rb_path="$cmake_formula_dir/cmake.rb"
+        
+        echo "Downloading cmake.rb from $cmake_rb_link"
+        curl -fsSL "$cmake_rb_link" -o "$cmake_rb_path"
+        
+        echo "Installing cmake 3.31.6 from custom tap..."
+        brew install "$tap_name/cmake"
+      shell: bash
     - name: Set up Ccache
       id: setup-ccache
       if: ${{ inputs.platform == 'ios' || inputs.platform == 'macos' || inputs.platform == 'visionos' }}


### PR DESCRIPTION
## Summary:

Currently all Hermes slices in PR are failing to build (but build locally).

```
2025-09-17T00:55:31.8097360Z CMake Error at CMakeLists.txt:42 (cmake_policy):
2025-09-17T00:55:31.8097720Z   Policy CMP0026 may not be set to OLD behavior because this version of CMake
2025-09-17T00:55:31.8098290Z   no longer supports it.  The policy was introduced in CMake version 3.0.0,
2025-09-17T00:55:31.8098600Z   and use of NEW behavior is now required.
2025-09-17T00:55:31.8098750Z 
2025-09-17T00:55:31.8098940Z   Please either update your CMakeLists.txt files to conform to the new
2025-09-17T00:55:31.8099330Z   behavior or use an older version of CMake that still supports the old
2025-09-17T00:55:31.8099700Z   behavior.  Run cmake --help-policy CMP0026 for more information.
2025-09-17T00:55:31.8099900Z 
2025-09-17T00:55:31.8099900Z 
2025-09-17T00:55:31.8101310Z CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
2025-09-17T00:55:31.8101980Z CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
2025-09-17T00:55:31.8102350Z CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
```

This is because GitHub Actions recently updated the macOS images to cmake 4 (https://github.com/actions/runner-images/issues/12934). Per their comment, use their example script to pin to a lower version

## Test Plan:

CI should pass
