### PR TITLE
ci: update to macos-26

### DIFF
--- a/.github/workflows/microsoft-build-rntester.yml
+++ b/.github/workflows/microsoft-build-rntester.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-rntester:
     name: "${{ matrix.platform }}, ${{ matrix.arch }}, ${{ matrix.engine }}"
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 90
     strategy:
       fail-fast: false

--- a/.github/workflows/microsoft-react-native-test-app-integration.yml
+++ b/.github/workflows/microsoft-react-native-test-app-integration.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   react-native-test-app-integration:
     name: "Test react-native-test-app integration"
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/microsoft-test-react-native-macos-init.yml
+++ b/.github/workflows/microsoft-test-react-native-macos-init.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test-react-native-macos-init:
     name: "Test react-native-macos init"
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary:

The image `macOS-26` is marked as a beta, let's try bumping to it.

## Test Plan:

CI should pass
