### PR TITLE
feat(fabric): Add more macOS props to host platform

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.h
@@ -12,5 +12,65 @@
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {
-using HostPlatformTouch = BaseTouch;
+
+class HostPlatformTouch : public BaseTouch {
+ public:
+  /*
+   * The button indicating which pointer is used.
+   */
+  int button;
+
+  /*
+   * The pointer type indicating the device type (e.g., mouse, pen, touch)
+   */
+  std::string pointerType;
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  bool altKey;
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  bool ctrlKey;
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool shiftKey;
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool metaKey;
+
+  /*
+   * Windows-specific timestamp field. We can't use the shared BaseTouch
+   * timestamp field beacuse it's a float and lacks sufficient resolution.
+   */
+  double pointerTimestamp;
+};
+
+inline static void setTouchPayloadOnObject(
+    jsi::Object& object,
+    jsi::Runtime& runtime,
+    const HostPlatformTouch& touch) {
+  object.setProperty(runtime, "locationX", touch.offsetPoint.x);
+  object.setProperty(runtime, "locationY", touch.offsetPoint.y);
+  object.setProperty(runtime, "pageX", touch.pagePoint.x);
+  object.setProperty(runtime, "pageY", touch.pagePoint.y);
+  object.setProperty(runtime, "screenX", touch.screenPoint.x);
+  object.setProperty(runtime, "screenY", touch.screenPoint.y);
+  object.setProperty(runtime, "identifier", touch.identifier);
+  object.setProperty(runtime, "target", touch.target);
+  object.setProperty(runtime, "timestamp", touch.pointerTimestamp);
+  object.setProperty(runtime, "force", touch.force);
+  object.setProperty(runtime, "button", touch.button);
+  object.setProperty(runtime, "altKey", touch.altKey);
+  object.setProperty(runtime, "ctrlKey", touch.ctrlKey);
+  object.setProperty(runtime, "shiftKey", touch.shiftKey);
+  object.setProperty(runtime, "metaKey", touch.metaKey);
+};
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
@@ -7,7 +7,8 @@
 
  // [macOS]
 
-#include <react/renderer/components/view/HostPlatformViewEventEmitter.h>
+
+#include "HostPlatformViewEventEmitter.h"
 
 namespace facebook::react {
 
@@ -19,6 +20,147 @@ void HostPlatformViewEventEmitter::onFocus() const {
 
 void HostPlatformViewEventEmitter::onBlur() const {
   dispatchEvent("blur");
+}
+
+#pragma mark - Keyboard Events
+
+static jsi::Value keyEventPayload(
+    jsi::Runtime& runtime,
+    const KeyEvent& event) {
+  auto payload = jsi::Object(runtime);
+  payload.setProperty(
+      runtime, "key", jsi::String::createFromUtf8(runtime, event.key));
+  payload.setProperty(runtime, "ctrlKey", event.ctrlKey);
+  payload.setProperty(runtime, "shiftKey", event.shiftKey);
+  payload.setProperty(runtime, "altKey", event.altKey);
+  payload.setProperty(runtime, "metaKey", event.metaKey);
+  payload.setProperty(runtime, "capsLockKey", event.capsLockKey);
+  payload.setProperty(runtime, "numericPadKey", event.numericPadKey);
+  payload.setProperty(runtime, "helpKey", event.helpKey);
+  payload.setProperty(runtime, "functionKey", event.functionKey);
+  return payload;
+};
+
+void HostPlatformViewEventEmitter::onKeyDown(const KeyEvent& keyEvent) const {
+  dispatchEvent("keyDown", [keyEvent](jsi::Runtime& runtime) {
+    return keyEventPayload(runtime, keyEvent);
+  });
+}
+
+void HostPlatformViewEventEmitter::onKeyUp(const KeyEvent& keyEvent) const {
+  dispatchEvent("keyUp", [keyEvent](jsi::Runtime& runtime) {
+    return keyEventPayload(runtime, keyEvent);
+  });
+}
+
+#pragma mark - Mouse Events
+
+static jsi::Object mouseEventPayload(
+    jsi::Runtime& runtime,
+    const MouseEvent& event) {
+  auto payload = jsi::Object(runtime);
+  payload.setProperty(runtime, "clientX", event.clientX);
+  payload.setProperty(runtime, "clientY", event.clientY);
+  payload.setProperty(runtime, "screenX", event.screenX);
+  payload.setProperty(runtime, "screenY", event.screenY);
+  payload.setProperty(runtime, "altKey", event.altKey);
+  payload.setProperty(runtime, "ctrlKey", event.ctrlKey);
+  payload.setProperty(runtime, "shiftKey", event.shiftKey);
+  payload.setProperty(runtime, "metaKey", event.metaKey);
+  return payload;
+};
+
+void HostPlatformViewEventEmitter::onMouseEnter(
+    const MouseEvent& mouseEvent) const {
+  dispatchEvent("mouseEnter", [mouseEvent](jsi::Runtime& runtime) {
+    return mouseEventPayload(runtime, mouseEvent);
+  });
+}
+
+void HostPlatformViewEventEmitter::onMouseLeave(
+    const MouseEvent& mouseEvent) const {
+  dispatchEvent("mouseLeave", [mouseEvent](jsi::Runtime& runtime) {
+    return mouseEventPayload(runtime, mouseEvent);
+  });
+}
+
+void HostPlatformViewEventEmitter::onDoubleClick(
+    const MouseEvent& mouseEvent) const {
+  dispatchEvent("doubleClick", [mouseEvent](jsi::Runtime& runtime) {
+    return mouseEventPayload(runtime, mouseEvent);
+  });
+}
+
+#pragma mark - Drag and Drop Events
+
+static jsi::Value dataTransferPayload(
+    jsi::Runtime& runtime,
+    const std::vector<DataTransferItem>& dataTransferItems) {
+  auto filesArray = jsi::Array(runtime, dataTransferItems.size());
+  auto itemsArray = jsi::Array(runtime, dataTransferItems.size());
+  auto typesArray = jsi::Array(runtime, dataTransferItems.size());
+  int i = 0;
+  for (const auto& transferItem : dataTransferItems) {
+    auto fileObject = jsi::Object(runtime);
+    fileObject.setProperty(runtime, "name", transferItem.name);
+    fileObject.setProperty(runtime, "type", transferItem.type);
+    fileObject.setProperty(runtime, "uri", transferItem.uri);
+    if (transferItem.size.has_value()) {
+      fileObject.setProperty(runtime, "size", *transferItem.size);
+    }
+    if (transferItem.width.has_value()) {
+      fileObject.setProperty(runtime, "width", *transferItem.width);
+    }
+    if (transferItem.height.has_value()) {
+      fileObject.setProperty(runtime, "height", *transferItem.height);
+    }
+    filesArray.setValueAtIndex(runtime, i, fileObject);
+
+    auto itemObject = jsi::Object(runtime);
+    itemObject.setProperty(runtime, "kind", transferItem.kind);
+    itemObject.setProperty(runtime, "type", transferItem.type);
+    itemsArray.setValueAtIndex(runtime, i, itemObject);
+
+    typesArray.setValueAtIndex(runtime, i, transferItem.type);
+    i++;
+  }
+
+  auto dataTransferObject = jsi::Object(runtime);
+  dataTransferObject.setProperty(runtime, "files", filesArray);
+  dataTransferObject.setProperty(runtime, "items", itemsArray);
+  dataTransferObject.setProperty(runtime, "types", typesArray);
+
+  return dataTransferObject;
+}
+
+static jsi::Value dragEventPayload(
+    jsi::Runtime& runtime,
+    const DragEvent& event) {
+  auto payload = mouseEventPayload(runtime, event);
+  auto dataTransferObject =
+      dataTransferPayload(runtime, event.dataTransferItems);
+  payload.setProperty(runtime, "dataTransfer", dataTransferObject);
+  return payload;
+}
+
+void HostPlatformViewEventEmitter::onDragEnter(
+    const DragEvent& dragEvent) const {
+  dispatchEvent("dragEnter", [dragEvent](jsi::Runtime& runtime) {
+    return dragEventPayload(runtime, dragEvent);
+  });
+}
+
+void HostPlatformViewEventEmitter::onDragLeave(
+    const DragEvent& dragEvent) const {
+  dispatchEvent("dragLeave", [dragEvent](jsi::Runtime& runtime) {
+    return dragEventPayload(runtime, dragEvent);
+  });
+}
+
+void HostPlatformViewEventEmitter::onDrop(const DragEvent& dragEvent) const {
+  dispatchEvent("drop", [dragEvent](jsi::Runtime& runtime) {
+    return dragEventPayload(runtime, dragEvent);
+  });
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -10,6 +10,8 @@
 #pragma once
 
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
+#include "KeyEvent.h"
+#include "MouseEvent.h"
 
 namespace facebook::react {
 
@@ -21,6 +23,23 @@ class HostPlatformViewEventEmitter : public BaseViewEventEmitter {
 
   void onFocus() const;
   void onBlur() const;
+
+#pragma mark - Keyboard Events
+
+  void onKeyDown(const KeyEvent& keyEvent) const;
+  void onKeyUp(const KeyEvent& keyEvent) const;
+
+#pragma mark - Mouse Events
+
+  void onMouseEnter(const MouseEvent& mouseEvent) const;
+  void onMouseLeave(const MouseEvent& mouseEvent) const;
+  void onDoubleClick(const MouseEvent& mouseEvent) const;
+
+#pragma mark - Drag and Drop Events
+
+  void onDragEnter(const DragEvent& dragEvent) const;
+  void onDragLeave(const DragEvent& dragEvent) const;
+  void onDrop(const DragEvent& dragEvent) const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEvents.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewEvents.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
+#include <array>
+#include <bitset>
+#include <cmath>
+#include <optional>
+
+namespace facebook::react {
+
+struct HostPlatformViewEvents {
+  std::bitset<64> bits{};
+
+  enum class Offset : std::size_t {
+    // Focus Events
+    Focus = 0,
+    Blur = 1,
+
+    // Keyboard Events
+    KeyDown = 1,
+    KeyUp = 2,
+
+    // Mouse Events
+    MouseEnter = 3,
+    MouseLeave = 4,
+    DoubleClick = 5,
+  };
+
+  constexpr bool operator[](const Offset offset) const {
+    return bits[static_cast<std::size_t>(offset)];
+  }
+
+  std::bitset<64>::reference operator[](const Offset offset) {
+    return bits[static_cast<std::size_t>(offset)];
+  }
+};
+
+inline static bool operator==(
+    const HostPlatformViewEvents& lhs,
+    const HostPlatformViewEvents& rhs) {
+  return lhs.bits == rhs.bits;
+}
+
+inline static bool operator!=(
+    const HostPlatformViewEvents& lhs,
+    const HostPlatformViewEvents& rhs) {
+  return lhs.bits != rhs.bits;
+}
+
+static inline HostPlatformViewEvents convertRawProp(
+    const PropsParserContext& context,
+    const RawProps& rawProps,
+    const HostPlatformViewEvents& sourceValue,
+    const HostPlatformViewEvents& defaultValue) {
+  HostPlatformViewEvents result{};
+  using Offset = HostPlatformViewEvents::Offset;
+
+  // Focus Events
+  result[Offset::Focus] = convertRawProp(
+    context, 
+    rawProps, 
+    "onFocus", 
+    sourceValue[Offset::Focus], 
+    defaultValue[Offset::Focus]);
+  result[Offset::Blur] = convertRawProp(
+    context, 
+    rawProps, 
+    "onBlur", 
+    sourceValue[Offset::Blur], 
+    defaultValue[Offset::Blur]);
+
+  // Keyboard Events
+  result[Offset::KeyDown] = convertRawProp(
+      context,
+      rawProps,
+      "onKeyDown",
+      sourceValue[Offset::KeyDown],
+      defaultValue[Offset::KeyDown]);
+  result[Offset::KeyUp] = convertRawProp(
+      context,
+      rawProps,
+      "onKeyUp",
+      sourceValue[Offset::KeyUp],
+      defaultValue[Offset::KeyUp]);
+
+  // Mouse Events
+  result[Offset::MouseEnter] = convertRawProp(
+      context,
+      rawProps,
+      "onMouseEnter",
+      sourceValue[Offset::MouseEnter],
+      defaultValue[Offset::MouseEnter]);
+  result[Offset::MouseLeave] = convertRawProp(
+      context,
+      rawProps,
+      "onMouseLeave",
+      sourceValue[Offset::MouseLeave],
+      defaultValue[Offset::MouseLeave]);
+
+  result[Offset::DoubleClick] = convertRawProp(
+      context,
+      rawProps,
+      "onDoubleClick",
+      sourceValue[Offset::DoubleClick],
+      defaultValue[Offset::DoubleClick]);
+
+  return result;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -65,23 +65,23 @@ HostPlatformViewProps::HostPlatformViewProps(
                     "tooltip",
                     sourceProps.tooltip,
                     {})),
-      validKeysDown(
+      keyDownEvents(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.validKeysDown
+              ? sourceProps.keyDownEvents
               : convertRawProp(
                     context,
                     rawProps,
-                    "validKeysDown",
-                    sourceProps.validKeysDown,
+                    "keyDownEvents",
+                    sourceProps.keyDownEvents,
                     {})),
-      validKeysUp(
+      keyUpEvents(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.validKeysUp
+              ? sourceProps.keyUpEvents
               : convertRawProp(
                     context,
                     rawProps,
-                    "validKeysUp",
-                    sourceProps.validKeysUp,
+                    "keyUpEvents",
+                    sourceProps.keyUpEvents,
                     {})){};
 
 #define VIEW_EVENT_CASE_MACOS(eventType)                           \
@@ -120,8 +120,8 @@ void HostPlatformViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(draggedTypes);
     RAW_SET_PROP_SWITCH_CASE_BASIC(tooltip);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(validKeysDown);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(validKeysUp);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(keyDownEvents);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(keyUpEvents);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -1,17 +1,16 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Microsoft Corporation.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "HostPlatformViewProps.h"
+ // [macOS]
 
-#include <algorithm>
+#include "HostPlatformViewProps.h"
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/conversions.h>
-#include <react/renderer/components/view/propsConversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 
@@ -22,22 +21,13 @@ HostPlatformViewProps::HostPlatformViewProps(
     const HostPlatformViewProps& sourceProps,
     const RawProps& rawProps)
     : BaseViewProps(context, sourceProps, rawProps),
-      macOSViewEvents(
+      hostPlatformEvents(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.macOSViewEvents
-              : convertRawProp(
-                    context, 
-                    rawProps,
-                    sourceProps.macOSViewEvents,
-                    {})),
-      focusable(
-          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.focusable
+              ? sourceProps.hostPlatformEvents
               : convertRawProp(
                     context,
                     rawProps,
-                    "focusable",
-                    sourceProps.focusable,
+                    sourceProps.hostPlatformEvents,
                     {})),
       enableFocusRing(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -47,19 +37,64 @@ HostPlatformViewProps::HostPlatformViewProps(
                     rawProps,
                     "enableFocusRing",
                     sourceProps.enableFocusRing,
-                    {})) {}
+                    true)),
+      focusable(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.focusable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "focusable",
+                    sourceProps.focusable,
+                    {})),
+      draggedTypes(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.draggedTypes
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "draggedTypes",
+                    sourceProps.draggedTypes,
+                    {})),
+      tooltip(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.tooltip
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "tooltip",
+                    sourceProps.tooltip,
+                    {})),
+      validKeysDown(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.validKeysDown
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "validKeysDown",
+                    sourceProps.validKeysDown,
+                    {})),
+      validKeysUp(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.validKeysUp
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "validKeysUp",
+                    sourceProps.validKeysUp,
+                    {})){};
 
-#define MACOS_VIEW_EVENT_CASE(eventType)                    \
-case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): {       \
-  const auto offset = MacOSViewEvents::Offset::eventType;   \
-  MacOSViewEvents defaultViewEvents{};                      \
-  bool res = defaultViewEvents[offset];                     \
-  if (value.hasValue()) {                                   \
-    fromRawValue(context, value, res);                      \
-  }                                                         \
-  macOSViewEvents[offset] = res;                              \
-  return;                                                   \
-}
+#define VIEW_EVENT_CASE_MACOS(eventType)                           \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): {            \
+    const auto offset = HostPlatformViewEvents::Offset::eventType; \
+    HostPlatformViewEvents defaultViewEvents{};                    \
+    bool res = defaultViewEvents[offset];                          \
+    if (value.hasValue()) {                                        \
+      fromRawValue(context, value, res);                           \
+    }                                                              \
+    hostPlatformEvents[offset] = res;                              \
+    return;                                                        \
+  }
 
 void HostPlatformViewProps::setProp(
     const PropsParserContext& context,
@@ -70,17 +105,24 @@ void HostPlatformViewProps::setProp(
   // call all super::setProp methods, since multiple structs may
   // reuse the same values.
   BaseViewProps::setProp(context, hash, propName, value);
-  
+
   static auto defaults = HostPlatformViewProps{};
-  
+
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
+    VIEW_EVENT_CASE_MACOS(Focus);
+    VIEW_EVENT_CASE_MACOS(Blur);
+    VIEW_EVENT_CASE_MACOS(KeyDown);
+    VIEW_EVENT_CASE_MACOS(KeyUp);
+    VIEW_EVENT_CASE_MACOS(MouseEnter);
+    VIEW_EVENT_CASE_MACOS(MouseLeave);
+    VIEW_EVENT_CASE_MACOS(DoubleClick);
     RAW_SET_PROP_SWITCH_CASE_BASIC(enableFocusRing);
-    MACOS_VIEW_EVENT_CASE(Focus);
-    MACOS_VIEW_EVENT_CASE(Blur);
-      
+    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(draggedTypes);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(tooltip);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(validKeysDown);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(validKeysUp);
   }
 }
-
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
@@ -10,14 +10,11 @@
 #pragma once
 
 #include <react/renderer/components/view/BaseViewProps.h>
-#include <react/renderer/components/view/primitives.h>
-#include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
-
-#include "MacOSViewEvents.h"
+#include "HostPlatformViewEvents.h"
+#include "KeyEvent.h"
 
 namespace facebook::react {
-
 class HostPlatformViewProps : public BaseViewProps {
  public:
   HostPlatformViewProps() = default;
@@ -32,12 +29,14 @@ class HostPlatformViewProps : public BaseViewProps {
       const char* propName,
       const RawValue& value);
 
-  MacOSViewEvents macOSViewEvents{};
+  HostPlatformViewEvents hostPlatformEvents{};
 
-#pragma mark - Props
-
-  bool focusable{false};
   bool enableFocusRing{true};
+  bool focusable{false};
 
+  std::vector<std::string> draggedTypes{};
+  std::optional<std::string> tooltip{};
+  std::optional<std::vector<HandledKey>> validKeysDown{};
+  std::optional<std::vector<HandledKey>> validKeysUp{};
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewProps.h
@@ -36,7 +36,7 @@ class HostPlatformViewProps : public BaseViewProps {
 
   std::vector<std::string> draggedTypes{};
   std::optional<std::string> tooltip{};
-  std::optional<std::vector<HandledKey>> validKeysDown{};
-  std::optional<std::vector<HandledKey>> validKeysUp{};
+  std::vector<HandledKeyEvent> keyDownEvents{};
+  std::vector<HandledKeyEvent> keyUpEvents{};
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Microsoft Corporation.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+ // [macOS]
 
 #pragma once
 
@@ -13,7 +15,12 @@
 namespace facebook::react::HostPlatformViewTraitsInitializer {
 
 inline bool formsStackingContext(const ViewProps& props) {
-  return false;
+  constexpr decltype(HostPlatformViewEvents::bits) mouseEventMask = {
+      (1 << (int)HostPlatformViewEvents::Offset::MouseEnter) |
+      (1 << (int)HostPlatformViewEvents::Offset::MouseLeave) |
+      (1 << (int)HostPlatformViewEvents::Offset::DoubleClick)};
+  return (props.hostPlatformEvents.bits & mouseEventMask).any() ||
+      props.tooltip;
 }
 
 inline bool formsView(const ViewProps& props) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/KeyEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/KeyEvent.h
@@ -1,63 +1,29 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Microsoft Corporation.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+ // [macOS]
+
 #pragma once
 
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
-#include <optional>
+#include <react/renderer/graphics/Float.h>
 #include <string>
 
 namespace facebook::react {
 
 /*
- * Describes a request to handle a key input.
+ * Describes an individual key event.
  */
-struct HandledKey {
+struct BaseKeyEvent {
   /**
-   * The key for the event aligned to https://www.w3.org/TR/uievents-key/.
+   * The code for the event aligned to https://www.w3.org/TR/uievents-code/.
    */
-  std::string key{};
-
-  /*
-   * A flag indicating if the alt key is pressed.
-   */
-  std::optional<bool> altKey{};
-
-  /*
-   * A flag indicating if the control key is pressed.
-   */
-  std::optional<bool> ctrlKey{};
-
-  /*
-   * A flag indicating if the shift key is pressed.
-   */
-  std::optional<bool> shiftKey{};
-
-  /*
-   * A flag indicating if the meta key is pressed.
-   */
-  std::optional<bool> metaKey{};
-};
-
-inline static bool operator==(const HandledKey& lhs, const HandledKey& rhs) {
-  return lhs.key == rhs.key && lhs.altKey == rhs.altKey &&
-      lhs.ctrlKey == rhs.ctrlKey && lhs.shiftKey == rhs.shiftKey &&
-      lhs.metaKey == rhs.metaKey;
-}
-
-/**
- * Key event emitted by handled key events.
- */
-struct KeyEvent {
-  /**
-   * The key for the event aligned to https://www.w3.org/TR/uievents-key/.
-   */
-  std::string key{};
+  std::string code{};
 
   /*
    * A flag indicating if the alt key is pressed.
@@ -78,58 +44,76 @@ struct KeyEvent {
    * A flag indicating if the meta key is pressed.
    */
   bool metaKey{false};
-
-  /*
-   * A flag indicating if the caps lock key is pressed.
-   */
-  bool capsLockKey{false};
-
-  /*
-   * A flag indicating if the key on the numeric pad is pressed.
-   */
-  bool numericPadKey{false};
-
-  /*
-   * A flag indicating if the help key is pressed.
-   */
-  bool helpKey{false};
-
-  /*
-   * A flag indicating if a function key is pressed.
-   */
-  bool functionKey{false};
 };
 
-inline static bool operator==(const KeyEvent& lhs, const HandledKey& rhs) {
-  return lhs.key == rhs.key &&
-      (!rhs.altKey.has_value() || lhs.altKey == *rhs.altKey) &&
-      (!rhs.ctrlKey.has_value() || lhs.ctrlKey == *rhs.ctrlKey) &&
-      (!rhs.shiftKey.has_value() || lhs.shiftKey == *rhs.shiftKey) &&
-      (!rhs.metaKey.has_value() || lhs.metaKey == *rhs.metaKey);
+inline static bool operator==(const BaseKeyEvent &lhs, const BaseKeyEvent &rhs) {
+  return lhs.code == rhs.code && lhs.altKey == rhs.altKey && lhs.ctrlKey == rhs.ctrlKey &&
+      lhs.shiftKey == rhs.shiftKey && lhs.metaKey == rhs.metaKey;
 }
 
-inline void fromRawValue(
-    const PropsParserContext& context,
-    const RawValue& value,
-    HandledKey& result) {
-  if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
-    auto map = static_cast<std::unordered_map<std::string, RawValue>>(value);
-    for (const auto& pair : map) {
-      if (pair.first == "key") {
-        result.key = static_cast<std::string>(pair.second);
-      } else if (pair.first == "altKey") {
-        result.altKey = static_cast<bool>(pair.second);
-      } else if (pair.first == "ctrlKey") {
-        result.ctrlKey = static_cast<bool>(pair.second);
-      } else if (pair.first == "shiftKey") {
-        result.shiftKey = static_cast<bool>(pair.second);
-      } else if (pair.first == "metaKey") {
-        result.metaKey = static_cast<bool>(pair.second);
-      }
-    }
-  } else if (value.hasType<std::string>()) {
-    result.key = (std::string)value;
+/**
+ * Event phase indicator matching the EventPhase in React.
+ * EventPhase includes None, Capturing, AtTarget, Bubbling.
+ */
+enum class HandledEventPhase { Capturing = 1, Bubbling = 3 };
+
+inline void fromRawValue(const PropsParserContext &context, const RawValue &value, HandledEventPhase &result) {
+  if (value.hasType<int>()) {
+    result = static_cast<HandledEventPhase>((int)value);
+    return;
   }
+
+  LOG(ERROR) << "Unsupported HandledKeyEvent::EventPhase type";
 }
+
+/**
+ * Describes a handled key event declaration.
+ */
+struct HandledKeyEvent : BaseKeyEvent {
+  /**
+   * The phase at which the event should be marked as handled.
+   */
+  HandledEventPhase handledEventPhase{HandledEventPhase::Bubbling};
+};
+
+inline void fromRawValue(const PropsParserContext &context, const RawValue &value, HandledKeyEvent &result) {
+  if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    auto map = (std::unordered_map<std::string, RawValue>)value;
+
+    auto attrIterator = map.find("handledEventPhase");
+    if (attrIterator != map.end())
+      fromRawValue(context, attrIterator->second, result.handledEventPhase);
+    attrIterator = map.find("altKey");
+    if (attrIterator != map.end())
+      fromRawValue(context, attrIterator->second, result.altKey);
+    attrIterator = map.find("ctrlKey");
+    if (attrIterator != map.end())
+      fromRawValue(context, attrIterator->second, result.ctrlKey);
+    attrIterator = map.find("metaKey");
+    if (attrIterator != map.end())
+      fromRawValue(context, attrIterator->second, result.metaKey);
+    attrIterator = map.find("shiftKey");
+    if (attrIterator != map.end())
+      fromRawValue(context, attrIterator->second, result.shiftKey);
+    attrIterator = map.find("code");
+    if (attrIterator != map.end())
+      fromRawValue(context, attrIterator->second, result.code);
+    return;
+  }
+
+  LOG(ERROR) << "Unsupported HandledKeyEvent type";
+}
+
+inline static bool operator==(const HandledKeyEvent &lhs, const HandledKeyEvent &rhs) {
+  return lhs.handledEventPhase == rhs.handledEventPhase &&
+      static_cast<BaseKeyEvent>(lhs) == static_cast<BaseKeyEvent>(rhs);
+}
+
+struct KeyEvent : BaseKeyEvent {
+  /**
+   * The key for the event aligned to https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values.
+   */
+  std::string key{};
+};
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/KeyEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/KeyEvent.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
+#include <optional>
+#include <string>
+
+namespace facebook::react {
+
+/*
+ * Describes a request to handle a key input.
+ */
+struct HandledKey {
+  /**
+   * The key for the event aligned to https://www.w3.org/TR/uievents-key/.
+   */
+  std::string key{};
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  std::optional<bool> altKey{};
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  std::optional<bool> ctrlKey{};
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  std::optional<bool> shiftKey{};
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  std::optional<bool> metaKey{};
+};
+
+inline static bool operator==(const HandledKey& lhs, const HandledKey& rhs) {
+  return lhs.key == rhs.key && lhs.altKey == rhs.altKey &&
+      lhs.ctrlKey == rhs.ctrlKey && lhs.shiftKey == rhs.shiftKey &&
+      lhs.metaKey == rhs.metaKey;
+}
+
+/**
+ * Key event emitted by handled key events.
+ */
+struct KeyEvent {
+  /**
+   * The key for the event aligned to https://www.w3.org/TR/uievents-key/.
+   */
+  std::string key{};
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  bool altKey{false};
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  bool ctrlKey{false};
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool shiftKey{false};
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  bool metaKey{false};
+
+  /*
+   * A flag indicating if the caps lock key is pressed.
+   */
+  bool capsLockKey{false};
+
+  /*
+   * A flag indicating if the key on the numeric pad is pressed.
+   */
+  bool numericPadKey{false};
+
+  /*
+   * A flag indicating if the help key is pressed.
+   */
+  bool helpKey{false};
+
+  /*
+   * A flag indicating if a function key is pressed.
+   */
+  bool functionKey{false};
+};
+
+inline static bool operator==(const KeyEvent& lhs, const HandledKey& rhs) {
+  return lhs.key == rhs.key &&
+      (!rhs.altKey.has_value() || lhs.altKey == *rhs.altKey) &&
+      (!rhs.ctrlKey.has_value() || lhs.ctrlKey == *rhs.ctrlKey) &&
+      (!rhs.shiftKey.has_value() || lhs.shiftKey == *rhs.shiftKey) &&
+      (!rhs.metaKey.has_value() || lhs.metaKey == *rhs.metaKey);
+}
+
+inline void fromRawValue(
+    const PropsParserContext& context,
+    const RawValue& value,
+    HandledKey& result) {
+  if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    auto map = static_cast<std::unordered_map<std::string, RawValue>>(value);
+    for (const auto& pair : map) {
+      if (pair.first == "key") {
+        result.key = static_cast<std::string>(pair.second);
+      } else if (pair.first == "altKey") {
+        result.altKey = static_cast<bool>(pair.second);
+      } else if (pair.first == "ctrlKey") {
+        result.ctrlKey = static_cast<bool>(pair.second);
+      } else if (pair.first == "shiftKey") {
+        result.shiftKey = static_cast<bool>(pair.second);
+      } else if (pair.first == "metaKey") {
+        result.metaKey = static_cast<bool>(pair.second);
+      }
+    }
+  } else if (value.hasType<std::string>()) {
+    result.key = (std::string)value;
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MouseEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/MouseEvent.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/Float.h>
+
+namespace facebook::react {
+
+/*
+ * Describes a mouse enter/leave event.
+ */
+struct MouseEvent {
+  /**
+   * Pointer horizontal location in target view.
+   */
+  Float clientX{0};
+
+  /**
+   * Pointer vertical location in target view.
+   */
+  Float clientY{0};
+
+  /**
+   * Pointer horizontal location in window.
+   */
+  Float screenX{0};
+
+  /**
+   * Pointer vertical location in window.
+   */
+  Float screenY{0};
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  bool altKey{false};
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  bool ctrlKey{false};
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool shiftKey{false};
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  bool metaKey{false};
+};
+
+struct DataTransferItem {
+  std::string name{};
+  std::string kind{};
+  std::string type{};
+  std::string uri{};
+  std::optional<int> size{};
+  std::optional<int> width{};
+  std::optional<int> height{};
+};
+
+struct DragEvent : MouseEvent {
+  std::vector<DataTransferItem> dataTransferItems;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
## Summary:

This builds on top of #2690 and adds more macOS only props (but not all the ones we have in paper) to our host platform. This was originally done in #2364 on a different branch. 

## Test Plan:

CI should pass
