### PR TITLE
fix(fabric): Add focus and blur to View commands

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -21,12 +21,14 @@ const ViewNativeComponent: HostComponent<Props> =
   }));
 
 interface NativeCommands {
+  +focus: () => void; // [macOS]
+  +blur: () => void; // [macOS]
   +hotspotUpdate: (viewRef: HostInstance, x: number, y: number) => void;
   +setPressed: (viewRef: HostInstance, pressed: boolean) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['hotspotUpdate', 'setPressed'],
+  supportedCommands: ['focus', 'blur', 'hotspotUpdate', 'setPressed'], // [macOS]
 });
 
 export default ViewNativeComponent;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1512,6 +1512,19 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
 
 #if TARGET_OS_OSX // [macOS
 
+- (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args
+{
+  if ([commandName isEqualToString:@"focus"]) {
+    [self focus];
+    return;
+  }
+
+  if ([commandName isEqualToString:@"blur"]) {
+    [self blur];
+    return;
+  }
+}
+
 # pragma mark - Focus Ring
 
 - (CGRect)focusRingMaskBounds
@@ -1537,6 +1550,16 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
 
 
 #pragma mark - Focus Events
+  
+- (void)focus
+{
+  [[self window] makeFirstResponder:self];
+}
+
+- (void)blur
+{
+  [[self window] resignFirstResponder];
+}
 
 - (BOOL)needsPanelToBecomeKey 
 {


### PR DESCRIPTION
## Summary:

Followup to #2692 , we need to add `focus` and `blur` to the View native components' commands, and implement them so they can be called by JS. This matches what is later implemented upstream in https://github.com/facebook/react-native/commit/3e5838086f1f630c130c6af9e6f5712618816aa6

## Test Plan:

`ref.current?.focus()` actually works.