### PR TITLE
Fix issue #2706: Add proper constraints for macOS dev loading view

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -175,6 +175,22 @@ RCT_EXPORT_MODULE()
       [self->_label.bottomAnchor constraintEqualToAnchor:self->_container.bottomAnchor constant:-5],
     ]];
 #else // [macOS
+    self->_window.contentView = [[NSView alloc] init];
+    [self->_window.contentView addSubview:self->_container];
+    // Container constraints
+    [NSLayoutConstraint activateConstraints:@[
+      [self->_container.topAnchor constraintEqualToAnchor:self->_window.contentView.topAnchor],
+      [self->_container.leadingAnchor constraintEqualToAnchor:self->_window.contentView.leadingAnchor],
+      [self->_container.trailingAnchor constraintEqualToAnchor:self->_window.contentView.trailingAnchor],
+      [self->_container.bottomAnchor constraintEqualToAnchor:self->_window.contentView.bottomAnchor],
+      
+      // Label constraints
+      [self->_label.centerXAnchor constraintEqualToAnchor:self->_container.centerXAnchor],
+      [self->_label.centerYAnchor constraintEqualToAnchor:self->_container.centerYAnchor],
+      [self->_label.leadingAnchor constraintGreaterThanOrEqualToAnchor:self->_container.leadingAnchor constant:10],
+      [self->_label.trailingAnchor constraintLessThanOrEqualToAnchor:self->_container.trailingAnchor constant:-10],
+    ]];
+    
     if (![[RCTKeyWindow() sheets] doesContain:self->_window]) {
       [RCTKeyWindow() beginSheet:self->_window completionHandler:^(NSModalResponse returnCode) {
         [self->_window orderOut:self];


### PR DESCRIPTION
- Add contentView initialization and container constraints for macOS
- Fix layout issues with the dev loading view on macOS platform
- Ensure proper positioning and sizing of the loading message window

Fixes #2706

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
