### PR TITLE
Host platform touch

### DIFF
--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -221,13 +221,10 @@ export interface NativePointerEvent extends NativeMouseEvent {
 export type PointerEvent = NativeSyntheticEvent<NativePointerEvent>;
 
 export type NativeTouchEvent = $ReadOnly<{
-  altKey?: ?boolean, // [macOS]
-  button?: ?number, // [macOS]
   /**
    * Array of all touch events that have changed since the last event
    */
   changedTouches: $ReadOnlyArray<NativeTouchEvent>,
-  ctrlKey?: ?boolean, // [macOS]
   /**
    * 3D Touch reported force
    * @platform ios
@@ -245,7 +242,6 @@ export type NativeTouchEvent = $ReadOnly<{
    * The Y position of the touch, relative to the element
    */
   locationY: number,
-  metaKey?: ?boolean, // [macOS]
   /**
    * The X position of the touch, relative to the screen
    */
@@ -254,7 +250,7 @@ export type NativeTouchEvent = $ReadOnly<{
    * The Y position of the touch, relative to the screen
    */
   pageY: number,
-  shiftKey?: ?boolean, // [macOS]
+
   /**
    * The node id of the element receiving the touch event
    */
@@ -267,6 +263,11 @@ export type NativeTouchEvent = $ReadOnly<{
    * Array of all current touches on the screen
    */
   touches: $ReadOnlyArray<NativeTouchEvent>,
+  button?: ?number, // [macOS]
+  altKey?: ?boolean, // [macOS]
+  ctrlKey?: ?boolean, // [macOS]
+  shiftKey?: ?boolean, // [macOS]
+  metaKey?: ?boolean, // [macOS]
 }>;
 
 export type GestureResponderEvent = ResponderSyntheticEvent<NativeTouchEvent>;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.cpp
@@ -23,13 +23,6 @@ void setTouchPayloadOnObject(
   object.setProperty(runtime, "target", touch.target);
   object.setProperty(runtime, "timestamp", touch.timestamp * 1000);
   object.setProperty(runtime, "force", touch.force);
-#if TARGET_OS_OSX // [macOS
-  object.setProperty(runtime, "button", touch.button);
-  object.setProperty(runtime, "altKey", touch.altKey);
-  object.setProperty(runtime, "ctrlKey", touch.ctrlKey);
-  object.setProperty(runtime, "shiftKey", touch.shiftKey);
-  object.setProperty(runtime, "metaKey", touch.metaKey);
-#endif // macOS]
 }
 
 #if RN_DEBUG_STRING_CONVERTIBLE
@@ -49,13 +42,6 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
       {"target", getDebugDescription(touch.target, options)},
       {"force", getDebugDescription(touch.force, options)},
       {"timestamp", getDebugDescription(touch.timestamp, options)},
-#if TARGET_OS_SX // [macOS
-	  {"button", getDebugDescription(touch.button, options)},
-	  {"altKey", getDebugDescription(touch.altKey, options)},
-	  {"ctrlKey", getDebugDescription(touch.ctrlKey, options)},
-	  {"shiftKey", getDebugDescription(touch.shiftKey, options)},
-	  {"metaKey", getDebugDescription(touch.metaKey, options)},
-#endif // macOS]
   };
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
@@ -55,32 +55,6 @@ struct BaseTouch {
    * The time in seconds when the touch occurred or when it was last mutated.
    */
   Float timestamp;
-#if TARGET_OS_OSX // [macOS
-  /*
-   * The button indicating which pointer is used.
-   */
-  int button;
-
-  /*
-   * A flag indicating if the alt key is pressed.
-   */
-  bool altKey;
-
-  /*
-   * A flag indicating if the control key is pressed.
-   */
-  bool ctrlKey;
-
-  /*
-   * A flag indicating if the shift key is pressed.
-   */
-  bool shiftKey;
-
-  /*
-   * A flag indicating if the meta key is pressed.
-   */
-  bool metaKey;
-#endif // macOS]
 
   /*
    * The particular implementation of `Hasher` and (especially) `Comparator`

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostPlatformTouch.h"
+#include "Touch.h"
+
+namespace facebook::react {
+
+void setTouchPayloadOnObject(
+    jsi::Object& object,
+    jsi::Runtime& runtime,
+    const HostPlatformTouch& touch) {
+  setTouchPayloadOnObject(object, runtime, static_cast<const BaseTouch&>(touch));
+#if TARGET_OS_OSX // [macOS
+  object.setProperty(runtime, "button", touch.button);
+  object.setProperty(runtime, "altKey", touch.altKey);
+  object.setProperty(runtime, "ctrlKey", touch.ctrlKey);
+  object.setProperty(runtime, "shiftKey", touch.shiftKey);
+  object.setProperty(runtime, "metaKey", touch.metaKey);
+#endif // macOS]
+}
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+
+std::string getDebugName(const HostPlatformTouch& /*touch*/) {
+  return "Touch";
+}
+
+std::vector<DebugStringConvertibleObject> getDebugProps(
+    const HostPlatformTouch& touch,
+    DebugStringConvertibleOptions options) {
+  auto debugProps = getDebugProps(static_cast<const BaseTouch&>(touch), options);
+  debugProps.insert(
+      debugProps.end(),
+      {
+          {"button", getDebugDescription(touch.button, options)},
+          {"altKey", getDebugDescription(touch.altKey, options)},
+          {"ctrlKey", getDebugDescription(touch.ctrlKey, options)},
+          {"shiftKey", getDebugDescription(touch.shiftKey, options)},
+          {"metaKey", getDebugDescription(touch.metaKey, options)},
+      });
+  return debugProps;
+};
+
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/macos/react/renderer/components/view/HostPlatformTouch.h
@@ -12,5 +12,32 @@
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {
-using HostPlatformTouch = BaseTouch;
+
+struct HostPlatformTouch : public BaseTouch {
+  /*
+   * The button indicating which pointer is used.
+   */
+  int button;
+
+  /*
+   * A flag indicating if the alt key is pressed.
+   */
+  bool altKey;
+
+  /*
+   * A flag indicating if the control key is pressed.
+   */
+  bool ctrlKey;
+
+  /*
+   * A flag indicating if the shift key is pressed.
+   */
+  bool shiftKey;
+
+  /*
+   * A flag indicating if the meta key is pressed.
+   */
+  bool metaKey;
+};
+
 } // namespace facebook::react


### PR DESCRIPTION
Note: as it stands this doesn't work, as the c++ infrastructure is still using BaseTouch for some reason 🤷

## Summary:

Move our diffs from `BaseTouch` to `HostPlatformTouch`

## Test Plan:

Added this code to RNTesterPlayground to see if the desktop specific keys were passed:
```jsx
<Pressable
  style={styles.pressable}
  onTouchStart={event => {

    console.log('Playground onPress event:', event.nativeEvent.metaKey);
  }}>
    <RNTesterText>Press here to log the press event</RNTesterText>
</Pressable>
```
