### PR TITLE
fix: keyDownEvents stops propogation, default events for Pressable

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -353,12 +353,11 @@ function Pressable(
 
   const accessibilityLabel = ariaLabel ?? props.accessibilityLabel;
 
+  const keyDownEvents = keyDownEvents ?? [{key: 'Space'}, {key: 'Enter'}];
+
   const restPropsWithDefaults: React.ElementConfig<typeof View> = {
     ...restProps,
     ...android_rippleConfig?.viewProps,
-    acceptsFirstMouse: acceptsFirstMouse !== false && !disabled, // [macOS]
-    mouseDownCanMoveWindow: false, // [macOS]
-    enableFocusRing: enableFocusRing !== false && !disabled,
     accessible: accessible !== false,
     accessibilityViewIsModal:
       restProps['aria-modal'] ?? restProps.accessibilityViewIsModal,
@@ -368,6 +367,12 @@ function Pressable(
     focusable: focusable !== false && !disabled, // macOS]
     accessibilityValue,
     hitSlop,
+    // [macOS
+    acceptsFirstMouse: acceptsFirstMouse !== false && !disabled,
+    enableFocusRing: enableFocusRing !== false && !disabled,
+    keyDownEvents,
+    mouseDownCanMoveWindow: false,
+    // macOS]
   };
 
   const config = useMemo(

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -353,7 +353,7 @@ function Pressable(
 
   const accessibilityLabel = ariaLabel ?? props.accessibilityLabel;
 
-  const keyDownEvents = keyDownEvents ?? [{key: 'Space'}, {key: 'Enter'}];
+  const _keyDownEvents = keyDownEvents ?? [{key: ' '}, {key: 'Enter'}];
 
   const restPropsWithDefaults: React.ElementConfig<typeof View> = {
     ...restProps,
@@ -370,7 +370,7 @@ function Pressable(
     // [macOS
     acceptsFirstMouse: acceptsFirstMouse !== false && !disabled,
     enableFocusRing: enableFocusRing !== false && !disabled,
-    keyDownEvents,
+    keyDownEvents: _keyDownEvents,
     mouseDownCanMoveWindow: false,
     // macOS]
   };

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -12,8 +12,8 @@ import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {____TextStyle_Internal as TextStyleInternal} from '../../StyleSheet/StyleSheetTypes';
 import type {
   GestureResponderEvent,
-  KeyEvent,
-  HandledKeyEvent,
+  KeyEvent, // [macOS]
+  HandledKeyEvent, // [macOS]
   NativeSyntheticEvent,
   ScrollEvent,
 } from '../../Types/CoreEventTypes';
@@ -1670,7 +1670,8 @@ function InternalTextInput(props: TextInputProps): React.Node {
     props.onScroll && props.onScroll(event);
   };
 
-  const _keyDown = (event: KeyEvent) => {
+  // [macOS
+  const _onKeyDown = (event: KeyEvent) => {
     if (props.keyDownEvents && event.isPropagationStopped() !== true) {
       const isHandled = props.keyDownEvents.some(({key, metaKey, ctrlKey, altKey, shiftKey}: HandledKeyEvent) => {
         return (
@@ -1688,7 +1689,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
     props.onKeyDown && props.onKeyDown(event);
   };
 
-  const _keyUp = (event: KeyEvent) => {
+  const _onKeyUp = (event: KeyEvent) => {
     if (props.keyUpEvents && event.isPropagationStopped() !== true) {
       const isHandled = props.keyUpEvents.some(({key, metaKey, ctrlKey, altKey, shiftKey}: HandledKeyEvent) => {
         return (
@@ -1705,6 +1706,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
     }
     props.onKeyUp && props.onKeyUp(event);
   };
+  // macOS]
 
   let textInput = null;
 
@@ -1861,8 +1863,8 @@ function InternalTextInput(props: TextInputProps): React.Node {
         onChange={_onChange}
         onContentSizeChange={props.onContentSizeChange}
         onFocus={_onFocus}
-        onKeyDown={_keyDown} // [macOS]
-        onKeyUp={_keyUp} // [macOS]
+        onKeyDown={_onKeyDown} // [macOS]
+        onKeyUp={_onKeyUp} // [macOS]
         onScroll={_onScroll}
         onSelectionChange={_onSelectionChange}
         onSelectionChangeShouldSetResponder={emptyFunctionThatReturnsTrue}

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -13,6 +13,7 @@ import type {ViewProps} from './ViewPropTypes';
 import TextAncestor from '../../Text/TextAncestor';
 import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
+import type { KeyEvent, HandledKeyEvent } from '../../Types/CoreEventTypes';
 
 export type Props = ViewProps;
 
@@ -94,6 +95,42 @@ const View: component(
       };
     }
 
+    const _keyDown = (event: KeyEvent) => {
+      if (otherProps.keyDownEvents && event.isPropagationStopped() !== true) {
+        const isHandled = otherProps.keyDownEvents.some(({key, metaKey, ctrlKey, altKey, shiftKey}: HandledKeyEvent) => {
+          return (
+            event.nativeEvent.key === key &&
+            (metaKey ?? event.nativeEvent.metaKey) === event.nativeEvent.metaKey &&
+            (ctrlKey ?? event.nativeEvent.ctrlKey) === event.nativeEvent.ctrlKey &&
+            (altKey ?? event.nativeEvent.altKey) === event.nativeEvent.altKey &&
+            (shiftKey ?? event.nativeEvent.shiftKey) === event.nativeEvent.shiftKey
+          );
+        });
+        if (isHandled) {
+          event.stopPropagation();
+        }
+      }
+      otherProps.onKeyDown && otherProps.onKeyDown(event);
+    };
+
+    const _keyUp = (event: KeyEvent) => {
+      if (otherProps.keyUpEvents && event.isPropagationStopped() !== true) {
+        const isHandled = otherProps.keyUpEvents.some(({key, metaKey, ctrlKey, altKey, shiftKey}: HandledKeyEvent) => {
+          return (
+            event.nativeEvent.key === key &&
+            (metaKey ?? event.nativeEvent.metaKey) === event.nativeEvent.metaKey &&
+            (ctrlKey ?? event.nativeEvent.ctrlKey) === event.nativeEvent.ctrlKey &&
+            (altKey ?? event.nativeEvent.altKey) === event.nativeEvent.altKey &&
+            (shiftKey ?? event.nativeEvent.shiftKey) === event.nativeEvent.shiftKey
+          );
+        });
+        if (isHandled) {
+          event.stopPropagation();
+        }
+      }
+      otherProps.onKeyUp && otherProps.onKeyUp(event);
+    };
+
     const actualView = (
       <ViewNativeComponent
         {...otherProps}
@@ -112,6 +149,8 @@ const View: component(
             : importantForAccessibility
         }
         nativeID={id ?? nativeID}
+        onKeyDown={_keyDown}
+        onKeyUp={_keyUp}
         ref={forwardedRef}
       />
     );

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -13,7 +13,7 @@ import type {ViewProps} from './ViewPropTypes';
 import TextAncestor from '../../Text/TextAncestor';
 import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
-import type { KeyEvent, HandledKeyEvent } from '../../Types/CoreEventTypes';
+import type { KeyEvent, HandledKeyEvent } from '../../Types/CoreEventTypes'; // [macOS]
 
 export type Props = ViewProps;
 
@@ -95,7 +95,8 @@ const View: component(
       };
     }
 
-    const _keyDown = (event: KeyEvent) => {
+    // [macOS
+    const _onKeyDown = (event: KeyEvent) => {
       if (otherProps.keyDownEvents && event.isPropagationStopped() !== true) {
         const isHandled = otherProps.keyDownEvents.some(({key, metaKey, ctrlKey, altKey, shiftKey}: HandledKeyEvent) => {
           return (
@@ -113,7 +114,7 @@ const View: component(
       otherProps.onKeyDown && otherProps.onKeyDown(event);
     };
 
-    const _keyUp = (event: KeyEvent) => {
+    const _onKeyUp = (event: KeyEvent) => {
       if (otherProps.keyUpEvents && event.isPropagationStopped() !== true) {
         const isHandled = otherProps.keyUpEvents.some(({key, metaKey, ctrlKey, altKey, shiftKey}: HandledKeyEvent) => {
           return (
@@ -130,6 +131,7 @@ const View: component(
       }
       otherProps.onKeyUp && otherProps.onKeyUp(event);
     };
+    // macOS]
 
     const actualView = (
       <ViewNativeComponent
@@ -149,8 +151,8 @@ const View: component(
             : importantForAccessibility
         }
         nativeID={id ?? nativeID}
-        onKeyDown={_keyDown}
-        onKeyUp={_keyUp}
+        onKeyDown={_onKeyDown} // [macOS]
+        onKeyUp={_onKeyUp} // [macOS]
         ref={forwardedRef}
       />
     );


### PR DESCRIPTION
## Summary:

Two changes:

- Similar to https://github.com/microsoft/react-native-windows/pull/8077 , we would like to have JS event propagation (as well as native) stop if `keyDownEvents` or `keyUpEvents` is specified. 
- Add `Space` and `Enter` as default keyDown events for Pressable, to more closely match a button. 

## Test Plan:

Updated the test page:
![Screenshot 2025-10-07 at 5 29 00 PM](https://github.com/user-attachments/assets/9b2b5360-3b44-4221-b3ef-6856feb551f1)


